### PR TITLE
fix: addpkg message validation

### DIFF
--- a/packages/adena-extension/src/inject/message/methods/transaction.ts
+++ b/packages/adena-extension/src/inject/message/methods/transaction.ts
@@ -79,6 +79,13 @@ const validateTransactionMessage = (
         }
         break;
       case '/vm.m_addpkg':
+        if (currentAccountAddress !== message.value.creator) {
+          sendResponse(
+            InjectionMessageInstance.failure('ACCOUNT_MISMATCH', requestData?.data, requestData?.key),
+          );
+          return false;
+        }
+        break;
       default:
         sendResponse(
           InjectionMessageInstance.failure('UNSUPPORTED_TYPE', requestData?.data, requestData?.key),


### PR DESCRIPTION
When trying to sign a message with type `/vm.m_addpkg` it throws the error `UNSUPPORTED_TYPE` because it's missing a `break` in the validation.