### PR TITLE
feat: [ADN-203] Add data migration

### DIFF
--- a/packages/adena-extension/src/common/storage/chrome-local-storage.ts
+++ b/packages/adena-extension/src/common/storage/chrome-local-storage.ts
@@ -1,30 +1,96 @@
 import { Storage } from '.';
+import { StorageMigrator, StorageModelLatest } from '@migrates/storage-migrator';
+
+type StorageKeyTypes =
+  | 'NETWORKS'
+  | 'CURRENT_CHAIN_ID'
+  | 'CURRENT_NETWORK_ID'
+  | 'SERIALIZED'
+  | 'ENCRYPTED_STORED_PASSWORD'
+  | 'CURRENT_ACCOUNT_ID'
+  | 'ACCOUNT_NAMES'
+  | 'ESTABLISH_SITES'
+  | 'ADDRSS_BOOK'
+  | 'ACCOUNT_TOKEN_METAINFOS';
+
+const StorageKeys: StorageKeyTypes[] = [
+  'NETWORKS',
+  'CURRENT_CHAIN_ID',
+  'CURRENT_NETWORK_ID',
+  'SERIALIZED',
+  'ENCRYPTED_STORED_PASSWORD',
+  'CURRENT_ACCOUNT_ID',
+  'ACCOUNT_NAMES',
+  'ESTABLISH_SITES',
+  'ADDRSS_BOOK',
+  'ACCOUNT_TOKEN_METAINFOS',
+];
+
+function isStorageKey(key: string): key is StorageKeyTypes {
+  return StorageKeys.some((storageKey) => storageKey === key);
+}
 
 export class ChromeLocalStorage implements Storage {
+  private static StorageKey = 'ADENA_DATA';
 
   private storage: chrome.storage.LocalStorageArea;
 
+  private migrator: StorageMigrator;
+
+  private current: StorageModelLatest | null = null;
+
   constructor() {
     this.storage = chrome.storage.local;
+    this.migrator = new StorageMigrator(StorageMigrator.migrations(), this.storage);
   }
 
   public get = async (key: string) => {
-    const values = await this.storage.get(key);
-    const value = values[`${key}`] ?? '';
-    return value;
+    if (!isStorageKey(key)) {
+      throw new Error('Unsupported key (' + key + ')');
+    }
+    const data = await this.getStorageData();
+    return data?.data[key];
   };
 
-  public set = async (key: string, value: string) => {
-    await this.storage.set({
-      [key]: value,
-    });
+  public set = async (key: string, value: any) => {
+    await this.setStorageData(key, value);
   };
 
   public remove = async (key: string) => {
-    await this.storage.remove(key);
+    return this.set(key, '');
   };
 
   public clear = async () => {
     await this.storage.clear();
+  };
+
+  public updatePassword = (password: string) => {
+    this.migrator.setPassword(password);
+  };
+
+  private getStorageData = async (): Promise<StorageModelLatest | null> => {
+    if (this.current === null) {
+      const current = await this.migrator.getCurrent();
+      const data = await this.migrator.migrate(current);
+      return data;
+    }
+    return this.current;
+  };
+
+  private setStorageData = async (key: string, value: any) => {
+    const current = await this.getStorageData();
+    if (current === null) {
+      return;
+    }
+    const storageData = {
+      ...current,
+      data: {
+        ...current.data,
+        [key]: value,
+      },
+    };
+    await this.storage.set({
+      [ChromeLocalStorage.StorageKey]: JSON.stringify(storageData),
+    });
   };
 }

--- a/packages/adena-extension/src/common/storage/storage-manager.ts
+++ b/packages/adena-extension/src/common/storage/storage-manager.ts
@@ -1,10 +1,9 @@
-import { Storage } from "./storage";
-import { ChromeLocalStorage } from "./chrome-local-storage";
+import { Storage } from './storage';
+import { ChromeLocalStorage } from './chrome-local-storage';
 
 type objectType = { [key in string]: any };
 
 export class StorageManager<T extends string = string> {
-
   private storage: Storage;
 
   constructor(storage?: Storage) {
@@ -29,48 +28,24 @@ export class StorageManager<T extends string = string> {
   };
 
   getToNumbers = async (valueType: T): Promise<Array<number>> => {
-    const numbers: Array<number> = [];
-    const value = await this.storage.get(valueType);
-
-    if (value === '') {
-      return numbers;
-    }
-
-    const numberStrings = value.split(',');
-    for (const numberString of numberStrings) {
-      try {
-        const number = parseInt(numberString);
-        if (number >= 0) {
-          numbers.push(number);
-        }
-      } catch (e) {
-        console.log(e);
-      }
-    }
-
-    return numbers;
+    return this.storage.get(valueType);
   };
 
   setByNumbers = async (valueType: T, values: Array<number>) => {
-    await this.storage.set(valueType, values.join());
+    await this.storage.set(valueType, values);
   };
 
   getToObject = async <R extends objectType = objectType>(valueType: T): Promise<R> => {
-    let json = {} as R;
-    const value = await this.storage.get(valueType);
-    if (!value) {
-      return json;
-    }
-
-    try {
-      json = JSON.parse(value) as R;
-    } catch (e) {
-      console.log(e);
-    }
-    return json
+    return this.storage.get(valueType);
   };
 
   setByObject = async (valueType: T, value: objectType) => {
-    await this.storage.set(valueType, JSON.stringify(value));
+    await this.storage.set(valueType, value);
+  };
+
+  updatePassword = (password: string) => {
+    if (this.storage instanceof ChromeLocalStorage) {
+      this.storage.updatePassword(password);
+    }
   };
 }

--- a/packages/adena-extension/src/common/storage/storage.ts
+++ b/packages/adena-extension/src/common/storage/storage.ts
@@ -1,16 +1,20 @@
-import { ChromeLocalStorage } from "./chrome-local-storage";
-import { ChromeSessionStorage } from "./chrome-session-storage";
-import { StorageManager } from "./storage-manager";
+import { ChromeLocalStorage } from './chrome-local-storage';
+import { ChromeSessionStorage } from './chrome-session-storage';
+import { StorageManager } from './storage-manager';
+
+export interface StorageModel<T = any> {
+  version: number;
+  data: T;
+}
 
 export interface Storage {
   get: (key: string) => Promise<any>;
-  set: (key: string, value: string) => Promise<void>;
+  set: (key: string, value: any) => Promise<void>;
   remove: (key: string) => Promise<void>;
   clear: () => Promise<void>;
 }
 
 export class AdenaStorage {
-
   private static localStorage: StorageManager<any> | null = null;
 
   private static sessionStorage: StorageManager<any> | null = null;
@@ -28,5 +32,4 @@ export class AdenaStorage {
     }
     return this.sessionStorage as StorageManager<T>;
   };
-
 }

--- a/packages/adena-extension/src/migrates/migrations/v001/storage-model-v001.ts
+++ b/packages/adena-extension/src/migrates/migrations/v001/storage-model-v001.ts
@@ -1,0 +1,111 @@
+export type StorageModelV001 = {
+  version: 1;
+  data: StorageModelDataV001;
+};
+
+export type StorageModelDataV001 = {
+  NETWORKS: NetworksModelV001;
+  CURRENT_CHAIN_ID: CurrentChainIdModelV001;
+  CURRENT_NETWORK_ID: CurrentNetworkIdModelV001;
+  SERIALIZED: SerializedModelV001;
+  ENCRYPTED_STORED_PASSWORD: EncryptedStoredPasswordModelV001;
+  CURRENT_ACCOUNT_ID: CurrentAccountIdModelV001;
+  ACCOUNT_NAMES: AccountNamesModelV001;
+  ESTABLISH_SITES: EstablishSitesModelV001;
+  ADDRSS_BOOK: AddressBookModelV001;
+  ACCOUNT_TOKEN_METAINFOS: AccountTokenMetainfoModelV001;
+};
+
+export type NetworksModelV001 = {
+  main: boolean;
+  chainId: string;
+  chainName: string;
+  networkId: string;
+  networkName: string;
+  addressPrefix: string;
+  rpcUrl: string;
+  gnoUrl: string;
+  apiUrl: string;
+  linkUrl: string;
+  token: {
+    denom: string;
+    unit: number;
+    minimalDenom: string;
+    minimalUnit: number;
+  };
+}[];
+
+export type CurrentChainIdModelV001 = string;
+
+export type CurrentNetworkIdModelV001 = string;
+
+export type SerializedModelV001 = string;
+
+export type WalletModelV001 = {
+  accounts: AccountDataModelV001[];
+  keyrings: KeyringDataModelV001[];
+  currentAccountId?: string;
+};
+
+type AccountDataModelV001 = {
+  id?: string;
+  index: number;
+  type: 'HD_WALLET' | 'PRIVATE_KEY' | 'LEDGER' | 'WEB3_AUTH';
+  name: string;
+  keyringId: string;
+  hdPath?: number;
+  publicKey: number[];
+};
+
+type KeyringDataModelV001 = {
+  id?: string;
+  type: 'HD_WALLET' | 'PRIVATE_KEY' | 'LEDGER' | 'WEB3_AUTH';
+  publicKey?: number[];
+  privateKey?: number[];
+  seed?: number[];
+  mnemonic?: string;
+};
+
+export type EncryptedStoredPasswordModelV001 = string;
+
+export type CurrentAccountIdModelV001 = string;
+
+export type AccountNamesModelV001 = { [key in string]: string };
+
+export type EstablishSitesModelV001 = {
+  [key in string]: {
+    hostname: string;
+    chainId: string;
+    account: string;
+    name: string;
+    favicon: string | null;
+    establishedTime: string;
+  }[];
+};
+
+export type AddressBookModelV001 = {
+  [key in string]: {
+    id: string;
+    name: string;
+    address: string;
+    createdAt: string;
+  }[];
+};
+
+export type AccountTokenMetainfoModelV001 = {
+  [key in string]: {
+    main: boolean;
+    tokenId: string;
+    chainId: string;
+    networkId: string;
+    image?: string;
+    pkgPath: string;
+    symbol: string;
+    type: 'NATIVE' | 'GRC20';
+    name: string;
+    decimals: number;
+    denom: string;
+    minimalDenom: string;
+    display?: boolean;
+  };
+};

--- a/packages/adena-extension/src/migrates/migrations/v002/storage-migration-v002.ts
+++ b/packages/adena-extension/src/migrates/migrations/v002/storage-migration-v002.ts
@@ -1,0 +1,103 @@
+import { Migration } from '@migrates/migrator';
+import { StorageModel } from '@common/storage';
+import {
+  AddressBookModelV001,
+  StorageModelDataV001,
+  WalletModelV001,
+} from '../v001/storage-model-v001';
+import { AddressBookModelV002, StorageModelDataV002, WalletModelV002 } from './storage-model-v002';
+import { decryptAES, encryptAES } from 'adena-module';
+
+export class StorageMigration002 implements Migration<StorageModelDataV002> {
+  public readonly version = 2;
+
+  async up(
+    current: StorageModel<StorageModelDataV001>,
+    password?: string,
+  ): Promise<StorageModel<StorageModelDataV002>> {
+    if (!this.validateModelV001(current.data)) {
+      throw new Error('Stroage Data doesn not match version V001');
+    }
+    const previous: StorageModelDataV001 = current.data;
+    return {
+      version: this.version,
+      data: {
+        ...previous,
+        ADDRSS_BOOK: this.migrateAddressBook(previous.ADDRSS_BOOK),
+        SERIALIZED: await this.migrateWallet(previous.SERIALIZED, password),
+      },
+    };
+  }
+
+  private validateModelV001(currentData: StorageModelDataV001) {
+    const storageDataKeys = [
+      'NETWORKS',
+      'CURRENT_CHAIN_ID',
+      'CURRENT_NETWORK_ID',
+      'SERIALIZED',
+      'ENCRYPTED_STORED_PASSWORD',
+      'CURRENT_ACCOUNT_ID',
+      'ACCOUNT_NAMES',
+      'ESTABLISH_SITES',
+      'ADDRSS_BOOK',
+      'ACCOUNT_TOKEN_METAINFOS',
+    ];
+    const hasKeys = Object.keys(currentData).every((dataKey) => storageDataKeys.includes(dataKey));
+    if (!hasKeys) {
+      return false;
+    }
+    if (!Array.isArray(currentData.NETWORKS)) {
+      return false;
+    }
+    if (typeof currentData.CURRENT_CHAIN_ID !== 'string') {
+      return false;
+    }
+    if (typeof currentData.CURRENT_NETWORK_ID !== 'string') {
+      return false;
+    }
+    if (typeof currentData.SERIALIZED !== 'string') {
+      return false;
+    }
+    if (typeof currentData.ENCRYPTED_STORED_PASSWORD !== 'string') {
+      return false;
+    }
+    if (typeof currentData.CURRENT_ACCOUNT_ID !== 'string') {
+      return false;
+    }
+    if (typeof currentData.ACCOUNT_NAMES !== 'object') {
+      return false;
+    }
+    if (typeof currentData.ESTABLISH_SITES !== 'object') {
+      return false;
+    }
+    if (typeof currentData.ADDRSS_BOOK !== 'object') {
+      return false;
+    }
+    return true;
+  }
+
+  private migrateAddressBook(addressBookDataV001: AddressBookModelV001): AddressBookModelV002 {
+    const addressBooks = Object.keys(addressBookDataV001).flatMap(
+      (key) => addressBookDataV001[key],
+    );
+    const result = addressBooks.filter(
+      (addressBook, index, callback) =>
+        index === callback.findIndex((compare) => compare.address === addressBook.address),
+    );
+    return result;
+  }
+
+  private async migrateWallet(serialized: string, password?: string): Promise<string> {
+    if (password) {
+      const decrypted = await decryptAES(serialized, password);
+      const wallet: WalletModelV001 = JSON.parse(decrypted);
+      const migrated: WalletModelV002 = {
+        ...wallet,
+      };
+      const json = JSON.stringify(migrated);
+      const encrypted = await encryptAES(json, password);
+      return encrypted;
+    }
+    return '';
+  }
+}

--- a/packages/adena-extension/src/migrates/migrations/v002/storage-model-v002.ts
+++ b/packages/adena-extension/src/migrates/migrations/v002/storage-model-v002.ts
@@ -1,0 +1,109 @@
+export type StorageModelV002 = {
+  version: 2;
+  data: StorageModelDataV002;
+};
+
+export type StorageModelDataV002 = {
+  NETWORKS: NetworksModelV002;
+  CURRENT_CHAIN_ID: CurrentChainIdModelV002;
+  CURRENT_NETWORK_ID: CurrentNetworkIdModelV002;
+  SERIALIZED: SerializedModelV002;
+  ENCRYPTED_STORED_PASSWORD: EncryptedStoredPasswordModelV002;
+  CURRENT_ACCOUNT_ID: CurrentAccountIdModelV002;
+  ACCOUNT_NAMES: AccountNamesModelV002;
+  ESTABLISH_SITES: EstablishSitesModelV002;
+  ADDRSS_BOOK: AddressBookModelV002;
+  ACCOUNT_TOKEN_METAINFOS: AccountTokenMetainfoModelV002;
+};
+
+export type NetworksModelV002 = {
+  main: boolean;
+  chainId: string;
+  chainName: string;
+  networkId: string;
+  networkName: string;
+  addressPrefix: string;
+  rpcUrl: string;
+  gnoUrl: string;
+  apiUrl: string;
+  linkUrl: string;
+  token: {
+    denom: string;
+    unit: number;
+    minimalDenom: string;
+    minimalUnit: number;
+  };
+}[];
+
+export type CurrentChainIdModelV002 = string;
+
+export type CurrentNetworkIdModelV002 = string;
+
+export type SerializedModelV002 = string;
+
+export type WalletModelV002 = {
+  accounts: AccountDataModelV002[];
+  keyrings: KeyringDataModelV002[];
+  currentAccountId?: string;
+};
+
+type AccountDataModelV002 = {
+  id?: string;
+  index: number;
+  type: 'HD_WALLET' | 'PRIVATE_KEY' | 'LEDGER' | 'WEB3_AUTH';
+  name: string;
+  keyringId: string;
+  hdPath?: number;
+  publicKey: number[];
+};
+
+type KeyringDataModelV002 = {
+  id?: string;
+  type: 'HD_WALLET' | 'PRIVATE_KEY' | 'LEDGER' | 'WEB3_AUTH';
+  publicKey?: number[];
+  privateKey?: number[];
+  seed?: number[];
+  mnemonic?: string;
+};
+
+export type EncryptedStoredPasswordModelV002 = string;
+
+export type CurrentAccountIdModelV002 = string;
+
+export type AccountNamesModelV002 = { [key in string]: string };
+
+export type EstablishSitesModelV002 = {
+  [key in string]: {
+    hostname: string;
+    chainId: string;
+    account: string;
+    name: string;
+    favicon: string | null;
+    establishedTime: string;
+  }[];
+};
+
+export type AddressBookModelV002 = {
+  id: string;
+  name: string;
+  address: string;
+  createdAt: string;
+}[];
+
+export type AccountTokenMetainfoModelV002 = {
+  [key in string]: {
+    main: boolean;
+    tokenId: string;
+    chainId: string;
+    networkId: string;
+    image?: string;
+    pkgPath: string;
+    symbol: string;
+    type: 'NATIVE' | 'GRC20';
+    name: string;
+    decimals: number;
+    denom: string;
+    minimalDenom: string;
+    display?: boolean;
+  };
+};

--- a/packages/adena-extension/src/migrates/migrator.ts
+++ b/packages/adena-extension/src/migrates/migrator.ts
@@ -1,0 +1,12 @@
+import { StorageModel } from '@common/storage';
+
+export interface Migration<R = any> {
+  version: number;
+  up: (current: StorageModel, password?: string) => Promise<StorageModel<R>>;
+}
+
+export interface Migrator {
+  getCurrent: () => Promise<StorageModel>;
+  migrate: (current: StorageModel) => Promise<StorageModel | null>;
+  save: (result: StorageModel) => Promise<void>;
+}

--- a/packages/adena-extension/src/migrates/storage-migrator.spec.ts
+++ b/packages/adena-extension/src/migrates/storage-migrator.spec.ts
@@ -1,0 +1,95 @@
+import { StorageMigrator } from './storage-migrator';
+import { StorageModelV001 } from './migrations/v001/storage-model-v001';
+
+const mockStorageV001: StorageModelV001 = {
+  version: 1,
+  data: {
+    NETWORKS: [],
+    CURRENT_CHAIN_ID: '',
+    CURRENT_NETWORK_ID: '',
+    SERIALIZED: 'U2FsdGVkX19eI8kOCI/T9o1Ru0b2wdj5rHxmG4QbLQ0yZH4kDa8/gg6Ac2JslvEm',
+    ENCRYPTED_STORED_PASSWORD: '',
+    CURRENT_ACCOUNT_ID: '',
+    ACCOUNT_NAMES: {},
+    ESTABLISH_SITES: {},
+    ADDRSS_BOOK: {
+      'account 1': [
+        {
+          id: 'address_1',
+          address: 'address',
+          createdAt: '0',
+          name: 'addressbook 01',
+        },
+      ],
+    },
+    ACCOUNT_TOKEN_METAINFOS: {},
+  },
+};
+
+const storage = {
+  async set() {
+    return;
+  },
+  async get() {
+    return {};
+  },
+};
+
+describe('StorageMigrator', () => {
+  beforeAll(() => {
+    const mockValue = {
+      ADENA_DATA: JSON.stringify(mockStorageV001),
+    };
+    storage.get = jest.fn().mockResolvedValue(mockValue);
+  });
+
+  it('getCurrent success', async () => {
+    const migrator = new StorageMigrator(StorageMigrator.migrations(), storage);
+    const current = await migrator.getCurrent();
+
+    expect(current).not.toBeNull();
+    expect(current.version).toBe(1);
+    expect(current.data).not.toBeNull();
+    expect(current.data.NETWORKS).toHaveLength(0);
+    expect(current.data.CURRENT_CHAIN_ID).toBe('');
+    expect(current.data.CURRENT_NETWORK_ID).toBe('');
+    expect(current.data.SERIALIZED).not.toBe('');
+    expect(current.data.ENCRYPTED_STORED_PASSWORD).toBe('');
+    expect(current.data.CURRENT_ACCOUNT_ID).toBe('');
+    expect(current.data.ACCOUNT_NAMES).toEqual({});
+    expect(current.data.ESTABLISH_SITES).toEqual({});
+    expect(current.data.ADDRSS_BOOK).toHaveProperty('account 1');
+  });
+
+  it('migrate success', async () => {
+    const migrator = new StorageMigrator(StorageMigrator.migrations(), storage);
+    const current = await migrator.getCurrent();
+    const migrated = await migrator.migrate(current);
+
+    expect(migrated).not.toBeNull();
+    expect(migrated?.version).toBe(2);
+    expect(migrated?.data).not.toBeNull();
+    expect(migrated?.data.NETWORKS).toHaveLength(0);
+    expect(migrated?.data.CURRENT_CHAIN_ID).toBe('');
+    expect(migrated?.data.CURRENT_NETWORK_ID).toBe('');
+    expect(migrated?.data.SERIALIZED).toBe('');
+    expect(migrated?.data.ENCRYPTED_STORED_PASSWORD).toBe('');
+    expect(migrated?.data.CURRENT_ACCOUNT_ID).toBe('');
+    expect(migrated?.data.ACCOUNT_NAMES).toEqual({});
+    expect(migrated?.data.ESTABLISH_SITES).toEqual({});
+    expect(migrated?.data.ADDRSS_BOOK).toHaveLength(1);
+  });
+
+  it('migrate with password success', async () => {
+    const migrator = new StorageMigrator(StorageMigrator.migrations(), storage);
+    migrator.setPassword('123');
+    const current = await migrator.getCurrent();
+    const migrated = await migrator.migrate(current);
+
+    expect(migrated).not.toBeNull();
+    expect(migrated?.version).toBe(2);
+    expect(migrated?.data).not.toBeNull();
+    expect(migrated?.data.SERIALIZED).not.toBe('');
+    expect(migrated?.data.ADDRSS_BOOK).toHaveLength(1);
+  });
+});

--- a/packages/adena-extension/src/migrates/storage-migrator.ts
+++ b/packages/adena-extension/src/migrates/storage-migrator.ts
@@ -1,0 +1,153 @@
+import { StorageModel } from '@common/storage';
+import { Migration, Migrator } from './migrator';
+import { StorageModelV002 } from './migrations/v002/storage-model-v002';
+import { StorageModelDataV001, StorageModelV001 } from './migrations/v001/storage-model-v001';
+import { StorageMigration002 } from './migrations/v002/storage-migration-v002';
+
+const LegacyStorageKeys = [
+  'NETWORKS',
+  'CURRENT_CHAIN_ID',
+  'CURRENT_NETWORK_ID',
+  'SERIALIZED',
+  'ENCRYPTED_STORED_PASSWORD',
+  'CURRENT_ACCOUNT_ID',
+  'ACCOUNT_NAMES',
+  'ESTABLISH_SITES',
+  'ADDRSS_BOOK',
+  'SERIALIZED',
+  'ACCOUNT_TOKEN_METAINFOS',
+];
+
+export type StorageModelLatest = StorageModelV002;
+
+const defaultData: StorageModelDataV001 = {
+  ACCOUNT_NAMES: {},
+  ADDRSS_BOOK: {},
+  CURRENT_ACCOUNT_ID: '',
+  CURRENT_CHAIN_ID: '',
+  CURRENT_NETWORK_ID: '',
+  ESTABLISH_SITES: {},
+  NETWORKS: [],
+  ENCRYPTED_STORED_PASSWORD: '',
+  SERIALIZED: '',
+  ACCOUNT_TOKEN_METAINFOS: {},
+};
+
+interface Storage {
+  set(items: { [key: string]: any }): Promise<void>;
+  get(keys?: string | string[] | { [key: string]: any } | null): Promise<{ [key: string]: any }>;
+}
+
+export class StorageMigrator implements Migrator {
+  private static StorageKey = 'ADENA_DATA';
+  constructor(
+    private migrations: Migration[],
+    private storage: Storage,
+    private password?: string,
+  ) {}
+
+  setPassword(passowrd: string) {
+    this.password = passowrd;
+  }
+
+  async saveable() {
+    const current = await this.getCurrent();
+    const latestVersion = Math.max(...this.migrations.map((m) => m.version));
+    if (current.version === latestVersion) {
+      return true;
+    }
+    return this.password && this.password.length > 0;
+  }
+
+  async serialize(data: StorageModel<unknown>) {
+    return JSON.stringify(data);
+  }
+
+  async deserialize(data: string) {
+    try {
+      return this.mappedJson(JSON.parse(data));
+    } catch (e) {
+      console.error('Migrate', e);
+    }
+    return null;
+  }
+
+  async getCurrent() {
+    const storedValues = await this.storage.get(StorageMigrator.StorageKey);
+    const data = await this.deserialize(storedValues[StorageMigrator.StorageKey]);
+    if (data) {
+      return data;
+    }
+    return {
+      version: 1,
+      data: defaultData,
+    };
+  }
+
+  async migrate(current: StorageModel) {
+    let latest = current;
+    try {
+      const currentVersion = current.version || 1;
+      const migrations = this.migrations
+        .sort((a, b) => a.version - b.version)
+        .filter((migration) => migration.version > currentVersion);
+
+      for (const migration of migrations) {
+        latest = await migration.up(latest, this.password);
+      }
+    } catch (error) {
+      console.error(error);
+      await this.backup(current);
+      return null;
+    }
+    return latest as StorageModelLatest;
+  }
+
+  async save(latest: StorageModel) {
+    if (!(await this.saveable())) {
+      throw new Error('Unable to save');
+    }
+    const savedData = await this.serialize(latest);
+    await this.storage.set({
+      [StorageMigrator.StorageKey]: savedData,
+    });
+  }
+
+  private async backup(current: StorageModel) {
+    const backupStorageKey = `${StorageMigrator.StorageKey}_${Date.now()}`;
+    const savedData = await this.serialize(current);
+    await this.storage.set({ [backupStorageKey]: savedData });
+  }
+
+  private async mappedJson(json: any) {
+    if (json?.version === 2) {
+      return json as StorageModelV002;
+    }
+    if (json?.version === 1) {
+      return json as StorageModelV001;
+    }
+
+    let data = defaultData;
+    const isLegacy = await this.storage.get('SERIALIZED');
+    if (isLegacy) {
+      data = await this.getLegacyData();
+    }
+
+    return {
+      version: 1,
+      data,
+    } as StorageModelV001;
+  }
+
+  private async getLegacyData() {
+    const legacyData: { [key in string]: unknown } = {};
+    for (const key of LegacyStorageKeys) {
+      legacyData[key] = (await this.storage.get(key))[key];
+    }
+    return legacyData as StorageModelDataV001;
+  }
+
+  static migrations(): Migration[] {
+    return [new StorageMigration002()];
+  }
+}

--- a/packages/adena-extension/src/repositories/wallet/wallet.ts
+++ b/packages/adena-extension/src/repositories/wallet/wallet.ts
@@ -34,6 +34,7 @@ export class WalletRepository {
 
   public deleteSerializedWallet = async () => {
     await this.localStorage.remove('SERIALIZED');
+    await this.localStorage.remove('ENCRYPTED_STORED_PASSWORD');
     return true;
   };
 
@@ -59,7 +60,9 @@ export class WalletRepository {
     }
 
     try {
-      return decryptPassword(encryptedKey, encryptedPassword);
+      const password = decryptPassword(encryptedKey, encryptedPassword);
+      this.updateStoragePassword(password);
+      return password;
     } catch (e) {
       throw new WalletError('NOT_FOUND_PASSWORD');
     }
@@ -68,6 +71,7 @@ export class WalletRepository {
   public updateWalletPassword = async (password: string) => {
     const { encryptedKey, encryptedPassword } = encryptPassword(password);
     const storedPassword = encryptSha256Password(password);
+    this.updateStoragePassword(password);
     await this.localStorage.set('ENCRYPTED_STORED_PASSWORD', storedPassword);
     await this.sessionStorage.set('ENCRYPTED_KEY', encryptedKey);
     await this.sessionStorage.set('ENCRYPTED_PASSWORD', encryptedPassword);
@@ -83,5 +87,9 @@ export class WalletRepository {
   public getEncryptedPassword = async () => {
     const encryptedPassword = await this.localStorage.get('ENCRYPTED_STORED_PASSWORD');
     return encryptedPassword;
+  };
+
+  public updateStoragePassword = (password: string) => {
+    this.localStorage.updatePassword(password);
   };
 }

--- a/packages/adena-extension/src/services/wallet/wallet.ts
+++ b/packages/adena-extension/src/services/wallet/wallet.ts
@@ -107,8 +107,8 @@ export class WalletService {
    */
   public saveWallet = async (wallet: Wallet, password: string) => {
     const serializedWallet = await wallet.serialize(password);
-    await this.walletRepository.updateSerializedWallet(serializedWallet);
     await this.walletRepository.updateWalletPassword(password);
+    await this.walletRepository.updateSerializedWallet(serializedWallet);
   };
 
   /**
@@ -119,6 +119,7 @@ export class WalletService {
    */
   public deserializeWallet = async (password: string) => {
     try {
+      await this.walletRepository.updateWalletPassword(password);
       const serializedWallet = await this.walletRepository.getSerializedWallet();
       const walletInstance = await AdenaWallet.deserialize(serializedWallet, password);
       return walletInstance;

--- a/packages/adena-extension/tsconfig.json
+++ b/packages/adena-extension/tsconfig.json
@@ -28,7 +28,8 @@
       "@states/*": ["src/states/*"],
       "@common/*": ["src/common/*"],
       "@inject/*": ["src/inject/*"],
-      "@assets/*": ["src/assets/*"]
+      "@assets/*": ["src/assets/*"],
+      "@migrates/*": ["src/migrates/*"]
     }
   },
   "include": ["./src/**/*"]

--- a/packages/adena-extension/webpack.config.js
+++ b/packages/adena-extension/webpack.config.js
@@ -78,6 +78,7 @@ const config = {
       '@assets': path.resolve(__dirname, 'src/assets'),
       '@repositories': path.resolve(__dirname, 'src/repositories'),
       '@containers': path.resolve(__dirname, 'src/containers'),
+      '@migrates': path.resolve(__dirname, 'src/migrates'),
     },
   },
   plugins: [


### PR DESCRIPTION
Add version to data stored per storage. (Default: 1)

Adds the ability to proceed with migration by version (version 1 → version 2 → version 3, etc.)

Create backup data for data restoration in case of migration failure.