### PR TITLE
feat: Add `adena.MakeTx` method

### DIFF
--- a/packages/adena-extension/src/common/utils/encoding-util.ts
+++ b/packages/adena-extension/src/common/utils/encoding-util.ts
@@ -1,0 +1,3 @@
+export function bytesToBase64(bytes: number[]) {
+  return Buffer.from(bytes).toString('base64');
+}

--- a/packages/adena-extension/src/containers/make-transaction-container/make-transaction-container.tsx
+++ b/packages/adena-extension/src/containers/make-transaction-container/make-transaction-container.tsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import ApproveTransaction from '@components/approve/approve-transaction/approve-transaction';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useCurrentAccount } from '@hooks/use-current-account';
+import { InjectionMessage, InjectionMessageInstance } from '@inject/message';
+import { createFaviconByHostname, decodeParameter, parseParmeters } from '@common/utils/client-utils';
+import { useAdenaContext, useWalletContext } from '@hooks/use-context';
+import { StdSignDoc, Account, isLedgerAccount } from 'adena-module';
+import { RoutePath } from '@router/path';
+import { validateInjectionData } from '@inject/message/methods';
+import BigNumber from 'bignumber.js';
+import { useNetwork } from '@hooks/use-network';
+import { bytesToBase64 } from '@common/utils/encoding-util';
+
+function mappedTransactionData(document: StdSignDoc) {
+  return {
+    messages: document.msgs,
+    contracts: document.msgs.map((message) => {
+      return {
+        type: message?.type || '',
+        function: message?.type === '/bank.MsgSend' ? 'Transfer' : message?.value?.func || '',
+        value: message?.value || '',
+      };
+    }),
+    gasWanted: document.fee.gas,
+    gasFee: `${document.fee.amount[0].amount}${document.fee.amount[0].denom}`,
+    document,
+  }
+}
+
+const DEFAULT_DENOM = 'GNOT';
+
+const MakeTransactionContainer: React.FC = () => {
+  const navigate = useNavigate();
+  const { gnoProvider } = useWalletContext();
+  const { walletService, transactionService } = useAdenaContext();
+  const { currentAccount } = useCurrentAccount();
+  const [transactionData, setTrasactionData] = useState<{ [key in string]: any } | undefined>(
+    undefined,
+  );
+  const { currentNetwork } = useNetwork();
+  const [hostname, setHostname] = useState('');
+  const location = useLocation();
+  const [requestData, setReqeustData] = useState<InjectionMessage>();
+  const [favicon, setFavicon] = useState<any>(null);
+  const [visibleTransactionInfo, setVisibleTransactionInfo] = useState(false);
+  const [document, setDocument] = useState<StdSignDoc>();
+
+  const networkFee = useMemo(() => {
+    if (!document || document.fee.amount.length === 0) {
+      return {
+        amount: '1',
+        denom: DEFAULT_DENOM
+      };
+    }
+    const networkFeeAmount = document.fee.amount[0].amount;
+    const networkFeeAmountOfGnot =
+      BigNumber(networkFeeAmount)
+        .shiftedBy(-6)
+        .toString();
+    return {
+      amount: networkFeeAmountOfGnot,
+      denom: DEFAULT_DENOM
+    };
+  }, [document]);
+
+  useEffect(() => {
+    checkLockWallet();
+  }, [walletService]);
+
+  const checkLockWallet = () => {
+    walletService.isLocked().then(locked => locked && navigate(RoutePath.ApproveLogin + location.search));
+  }
+
+  useEffect(() => {
+    if (location.search) {
+      initRequestData();
+    }
+  }, [location]);
+
+  const initRequestData = () => {
+    const data = parseParmeters(location.search);
+    const parsedData = decodeParameter(data['data']);
+    setReqeustData({ ...parsedData, hostname: data['hostname'] });
+  };
+
+  useEffect(() => {
+    if (currentAccount && requestData && gnoProvider) {
+      if (validate(currentAccount, requestData)) {
+        initFavicon();
+        initTransactionData();
+      }
+    }
+  }, [currentAccount, requestData, gnoProvider]);
+
+  const validate = (currentAccount: Account, requestData: InjectionMessage) => {
+    const validationMessage = validateInjectionData(currentAccount.getAddress('g'), requestData);
+    if (validationMessage) {
+      chrome.runtime.sendMessage(validationMessage);
+      return false;
+    }
+    return true;
+  }
+
+  const initFavicon = async () => {
+    const faviconData = await createFaviconByHostname(requestData?.hostname ?? '');
+    setFavicon(faviconData);
+  };
+
+  const initTransactionData = async () => {
+    if (!currentAccount || !requestData || !currentNetwork) {
+      return false;
+    }
+    try {
+      const document = await transactionService.createDocument(
+        currentAccount,
+        currentNetwork.networkId,
+        requestData?.data?.messages,
+        requestData?.data?.gasWanted,
+        requestData?.data?.gasFee,
+        requestData?.data?.memo,
+      );
+      setDocument(document);
+      setTrasactionData(mappedTransactionData(document));
+      setHostname(requestData?.hostname ?? '');
+      return true;
+    } catch (e) {
+      console.error(e);
+      const error: any = e;
+      if (error?.message === 'Transaction signing request was rejected by the user') {
+        chrome.runtime.sendMessage(
+          InjectionMessageInstance.failure(
+            'SIGN_REJECTED',
+            requestData?.data,
+            requestData?.key,
+          ),
+        );
+      }
+    }
+    return false;
+  };
+
+  const sendTransaction = async () => {
+    if (!document || !currentAccount) {
+      chrome.runtime.sendMessage(
+        InjectionMessageInstance.failure('UNEXPECTED_ERROR', {}, requestData?.key),
+      );
+      return false;
+    }
+
+    try {
+      const signature = await transactionService.createSignature(
+        currentAccount,
+        document
+      );
+      const transactionBytes = await transactionService.createTransaction(document, signature);
+      const encodedTransaction = bytesToBase64(transactionBytes);
+      chrome.runtime.sendMessage(
+        InjectionMessageInstance.success('MAKE_TX', { encodedTransaction }, requestData?.key),
+      );
+    } catch (e) {
+      if (e instanceof Error) {
+        const message = e.message;
+        if (message.includes('Ledger')) {
+          return false;
+        }
+        chrome.runtime.sendMessage(
+          InjectionMessageInstance.failure(
+            'SIGN_FAILED',
+            { error: { message } },
+            requestData?.key,
+          ),
+        );
+      }
+      chrome.runtime.sendMessage(
+        InjectionMessageInstance.failure(
+          'SIGN_FAILED',
+          {},
+          requestData?.key,
+        ),
+      );
+    }
+    return false;
+  };
+
+  const onToggleTransactionData = (visibleTransactionInfo: boolean) => {
+    setVisibleTransactionInfo(visibleTransactionInfo);
+  };
+
+  const onClickConfirm = () => {
+    if (!currentAccount) {
+      return;
+    }
+    if (isLedgerAccount(currentAccount)) {
+      navigate(RoutePath.ApproveSignLoading, {
+        state: {
+          document,
+          requestData
+        }
+      });
+      return;
+    }
+    sendTransaction();
+  };
+
+  const onClickCancel = () => {
+    chrome.runtime.sendMessage(
+      InjectionMessageInstance.failure('SIGN_REJECTED', {}, requestData?.key),
+    );
+  };
+
+  return (
+    <ApproveTransaction
+      title='Make Transaction'
+      domain={hostname}
+      contracts={transactionData?.contracts}
+      loading={transactionData === undefined}
+      logo={favicon}
+      networkFee={networkFee}
+      onClickConfirm={onClickConfirm}
+      onClickCancel={onClickCancel}
+      onToggleTransactionData={onToggleTransactionData}
+      opened={visibleTransactionInfo}
+      transactionData={JSON.stringify(document, null, 2)}
+    />
+  );
+};
+
+export default MakeTransactionContainer;

--- a/packages/adena-extension/src/containers/make-transaction-ledger-loading-container/make-transaction-ledger-loading-container.tsx
+++ b/packages/adena-extension/src/containers/make-transaction-ledger-loading-container/make-transaction-ledger-loading-container.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { StdSignDoc, isLedgerAccount } from 'adena-module';
+import ApproveLedgerLoading from '@components/approve/approve-ledger-loading/approve-ledger-loading';
+import { InjectionMessage, InjectionMessageInstance } from '@inject/message';
+import { useCurrentAccount } from '@hooks/use-current-account';
+import { useAdenaContext } from '@hooks/use-context';
+import { bytesToBase64 } from '@common/utils/encoding-util';
+
+interface MakeTransactionLedgerLoadingState {
+  requestData?: InjectionMessage;
+  document?: StdSignDoc;
+}
+
+const MakeTransactionLedgerLoadingContainer: React.FC = () => {
+  const location = useLocation();
+  const { transactionService } = useAdenaContext();
+  const { document, requestData } = location.state as MakeTransactionLedgerLoadingState;
+  const { currentAccount } = useCurrentAccount();
+  const [completed, setCompleted] = useState(false);
+
+  useEffect(() => {
+    if (currentAccount) {
+      requestTransaction();
+    }
+  }, [currentAccount]);
+
+  const requestTransaction = async () => {
+    if (completed) {
+      return;
+    }
+    const result = await createLedgerTransaction();
+    setCompleted(result);
+    setTimeout(() => !result && requestTransaction(), 1000);
+  };
+
+  const createLedgerTransaction = async () => {
+    if (!currentAccount || !document) {
+      return false;
+    }
+
+    if (!isLedgerAccount(currentAccount)) {
+      return false;
+    }
+
+    const result = await transactionService.createSignatureWithLedger(currentAccount, document).then(async (signature) => {
+      const transactionBytes = await transactionService.createTransaction(document, signature);
+      const encodedTransaction = bytesToBase64(transactionBytes);
+      chrome.runtime.sendMessage(
+        InjectionMessageInstance.success('MAKE_TX', { encodedTransaction }, requestData?.key),
+      );
+      return true;
+    }).catch((error: Error) => {
+      if (error.message === 'Transaction signing request was rejected by the user') {
+        chrome.runtime.sendMessage(
+          InjectionMessageInstance.failure('SIGN_REJECTED', {}, requestData?.key),
+        );
+        return true;
+      }
+      if (error.message.includes('Ledger')) {
+        return false;
+      }
+      return false;
+    });
+    return result;
+  };
+
+  const onClickCancel = () => {
+    if (!requestData) {
+      window.close();
+      return;
+    }
+    chrome.runtime.sendMessage(
+      InjectionMessageInstance.failure('SIGN_REJECTED', requestData.data, requestData.key),
+    );
+  }
+
+  return (
+    <ApproveLedgerLoading
+      onClickCancel={onClickCancel}
+    />
+  );
+};
+
+export default MakeTransactionLedgerLoadingContainer;

--- a/packages/adena-extension/src/inject.ts
+++ b/packages/adena-extension/src/inject.ts
@@ -32,6 +32,11 @@ const init = () => {
       const response = await executor.signAmino(mesasage);
       return response;
     },
+    async MakeTx(mesasage: RequestDocontractMessage) {
+      const executor = new AdenaExecutor();
+      const response = await executor.makeTx(mesasage);
+      return response;
+    },
     async AddNetwork(chain: RequestAddedNetworkMessage) {
       const executor = new AdenaExecutor();
       const response = await executor.addNetwork(chain);

--- a/packages/adena-extension/src/inject/executor/executor.ts
+++ b/packages/adena-extension/src/inject/executor/executor.ts
@@ -85,6 +85,15 @@ export class AdenaExecutor {
     return this.sendEventMessage(eventMessage);
   };
 
+  public makeTx = (params: RequestDocontractMessage) => {
+    const result = this.valdiateContractMessage(params);
+    if (result) {
+      return this.sendEventMessage(result);
+    }
+    const eventMessage = AdenaExecutor.createEventMessage('MAKE_TX', params);
+    return this.sendEventMessage(eventMessage);
+  };
+
   public addNetwork = (chain: RequestAddedNetworkMessage) => {
     const eventMessage = AdenaExecutor.createEventMessage('ADD_NETWORK', { ...chain });
     return this.sendEventMessage(eventMessage);

--- a/packages/adena-extension/src/inject/message/message-handler.ts
+++ b/packages/adena-extension/src/inject/message/message-handler.ts
@@ -112,6 +112,13 @@ export class MessageHandler {
           }
         });
         break;
+      case 'MAKE_TX':
+        HandlerMethod.checkEstablished(message, sendResponse).then((isEstablished) => {
+          if (isEstablished) {
+            HandlerMethod.makeTx(message, sendResponse);
+          }
+        });
+        break;
       default:
         break;
     }

--- a/packages/adena-extension/src/inject/message/message.ts
+++ b/packages/adena-extension/src/inject/message/message.ts
@@ -17,6 +17,10 @@ const MESSAGE_TYPES = {
     code: 0,
     description: 'Sign Amino',
   },
+  MAKE_TX: {
+    code: 0,
+    description: 'Make Transaction',
+  },
   ADD_NETWORK: {
     code: 0,
     description: 'Add Network',

--- a/packages/adena-extension/src/inject/message/methods/transaction.ts
+++ b/packages/adena-extension/src/inject/message/methods/transaction.ts
@@ -26,6 +26,29 @@ export const signAmino = async (
   );
 };
 
+export const makeTx = async (
+  requestData: InjectionMessage,
+  sendResponse: (message: any) => void,
+) => {
+  const core = new InjectCore();
+  const locked = await core.walletService.isLocked();
+  if (!locked) {
+    const address = await core.getCurrentAddress();
+    const validationMessage = validateInjectionData(address, requestData);
+    if (validationMessage) {
+      sendResponse(validationMessage);
+      return;
+    }
+  }
+
+  HandlerMethod.createPopup(
+    RoutePath.MakeTransaction,
+    requestData,
+    InjectionMessageInstance.failure('SIGN_REJECTED', {}, requestData.key),
+    sendResponse,
+  );
+};
+
 export const doContract = async (
   requestData: InjectionMessage,
   sendResponse: (message: any) => void,

--- a/packages/adena-extension/src/router/custom-router.tsx
+++ b/packages/adena-extension/src/router/custom-router.tsx
@@ -72,6 +72,8 @@ import EditCustomNetworkPage from '@pages/wallet/edit-custom-network';
 import ApproveChangingNetworkPage from '@pages/wallet/approve-changing-network/approve-changing-network';
 import ApproveAddingNetworkPage from '@pages/wallet/approve-adding-network/approve-adding-network';
 import AccountDetailsPage from '@pages/wallet/account-details';
+import MakeTransactionContainer from '@containers/make-transaction-container/make-transaction-container';
+import MakeTransactionLedgerLoadingContainer from '@containers/make-transaction-ledger-loading-container/make-transaction-ledger-loading-container';
 
 export const CustomRouter = () => {
   const { wallet } = useWalletContext();
@@ -122,6 +124,8 @@ export const CustomRouter = () => {
           <Route path={RoutePath.ApproveTransactionLoading} element={<ApproveTransactionLedgerLoading />} />
           <Route path={RoutePath.ApproveSign} element={<ApproveSign />} />
           <Route path={RoutePath.ApproveSignLoading} element={<ApproveSignLedgerLoading />} />
+          <Route path={RoutePath.MakeTransaction} element={<MakeTransactionContainer />} />
+          <Route path={RoutePath.MakeTransactionLoading} element={<MakeTransactionLedgerLoadingContainer />} />
           <Route path={RoutePath.ApproveLogin} element={<ApproveLogin />} />
           <Route path={RoutePath.ApproveEstablish} element={<ApproveEstablish />} />
           <Route path={RoutePath.ApproveChangingNetwork} element={<ApproveChangingNetworkPage />} />

--- a/packages/adena-extension/src/router/path.ts
+++ b/packages/adena-extension/src/router/path.ts
@@ -32,6 +32,8 @@ export enum RoutePath {
   ApproveTransactionLoading = '/approve/wallet/transaction/loading',
   ApproveSign = '/approve/wallet/sign',
   ApproveSignLoading = '/approve/wallet/sign/loading',
+  MakeTransaction = '/approve/wallet/make-tx',
+  MakeTransactionLoading = '/approve/wallet/make-tx/loading',
   ApproveEstablish = '/approve/wallet/establish',
   ApproveChangingNetwork = '/approve/wallet/network/change',
   ApproveAddingNetwork = '/approve/wallet/network/add',


### PR DESCRIPTION
Based on #282, We need to review the purpose of this PR. 

`adena.MakeTx` method returns encoded transaction data.
