### PR TITLE
fix: Fix mnemonic handling on the Import Wallet screen

### DIFF
--- a/packages/adena-extension/src/components/molecules/web-seed-input/index.tsx
+++ b/packages/adena-extension/src/components/molecules/web-seed-input/index.tsx
@@ -78,6 +78,15 @@ export const WebSeedInput = ({ errorMessage, onChange }: WebSeedInputProps): Rea
     [type, wordList],
   );
 
+  const onChangeWebSeedInputByWords = useCallback(
+    (value: string) => {
+      const words = _getFilledWordList(type, value.split(' '));
+      setWordList(words);
+      onChange({ type, value: words.join(' ') });
+    },
+    [type],
+  );
+
   const TypeMenuItem = useCallback(
     ({ title, _type }: { title: string; _type: WebSeedInputType }): ReactElement => {
       const selected = type === _type;
@@ -130,8 +139,7 @@ export const WebSeedInput = ({ errorMessage, onChange }: WebSeedInputProps): Rea
                   error={!!errorMessage}
                   onChange={(value: string): void => {
                     if (index === 0 && value.split(' ').length > 1) {
-                      setWordList(value.split(' '));
-                      onChange({ type, value });
+                      onChangeWebSeedInputByWords(value);
                     } else {
                       onChangeWord(index, value);
                     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:
- Fix disabled button bug when pasting 24-word mnemonic into the 12-word field