### PR TITLE
feat: Allow AddEstablish to connect to an already connected app

### DIFF
--- a/packages/adena-extension/src/inject/message/methods/wallet.ts
+++ b/packages/adena-extension/src/inject/message/methods/wallet.ts
@@ -53,7 +53,7 @@ export const addEstablish = async (
   if (!isLocked) {
     const isEstablished = await core.establishService.isEstablishedBy(accountId, siteName);
     if (isEstablished) {
-      sendResponse(InjectionMessageInstance.failure('ALREADY_CONNECTED', {}, message.key));
+      sendResponse(InjectionMessageInstance.success('CONNECTION_SUCCESS', {}, message.key));
       return true;
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:
- `adena.AddEstablish()` function returns a success response if the website is already registered.
