### PR TITLE
chore: Only lock testnet3 and portal-loop from the network list

### DIFF
--- a/packages/adena-extension/src/resources/chains/chains.json
+++ b/packages/adena-extension/src/resources/chains/chains.json
@@ -29,7 +29,7 @@
   },
   {
     "id": "dev",
-    "default": true,
+    "default": false,
     "main": false,
     "chainId": "dev",
     "chainName": "GNO.LAND",
@@ -57,7 +57,7 @@
   },
   {
     "id": "gnoswap",
-    "default": true,
+    "default": false,
     "main": false,
     "chainId": "beta.gnoswap",
     "chainName": "Gnoswap-Testnet",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- chore

### What this PR does:
- Change network information to be editable except for official networks.
