### PR TITLE
feat: Use a separate tm2-js-client per network

### DIFF
--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -74,8 +74,8 @@
     "webpack-merge": "^5.10.0"
   },
   "dependencies": {
-    "@gnolang/gno-js-client": "1.2.1",
-    "@gnolang/tm2-js-client": "1.1.6",
+    "@gnolang/gno-js-client": "1.2.3",
+    "@gnolang/tm2-js-client": "1.2.0",
     "@tanstack/react-query": "^4.36.1",
     "@vespaiach/axios-fetch-adapter": "^0.3.1",
     "adena-module": "*",

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -45,6 +45,7 @@
     "@cosmjs/ledger-amino": "^0.32.2",
     "@gnolang/gno-js-client": "1.2.1",
     "@gnolang/tm2-js-client": "1.1.6",
+    "@gnolang/tm2-js-client-legacy": "npm:@gnolang/tm2-js-client@1.1.7",
     "@ledgerhq/hw-transport": "^6.30.4",
     "@ledgerhq/hw-transport-mocker": "^6.28.4",
     "@ledgerhq/hw-transport-webhid": "^6.28.4",

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@cosmjs/ledger-amino": "^0.32.2",
-    "@gnolang/gno-js-client": "1.2.1",
-    "@gnolang/tm2-js-client": "1.1.6",
+    "@gnolang/gno-js-client": "1.2.3",
+    "@gnolang/tm2-js-client": "1.2.0",
     "@gnolang/tm2-js-client-legacy": "npm:@gnolang/tm2-js-client@1.1.7",
     "@ledgerhq/hw-transport": "^6.30.4",
     "@ledgerhq/hw-transport-mocker": "^6.28.4",

--- a/packages/adena-module/src/wallet/keyring/hd-wallet-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/hd-wallet-keyring.ts
@@ -6,9 +6,10 @@ import {
   Provider,
   TransactionEndpoint,
 } from '@gnolang/tm2-js-client';
+import { Wallet as Tm2WalletLegacy } from '@gnolang/tm2-js-client-legacy';
 import { v4 as uuidv4 } from 'uuid';
 import { Bip39, EnglishMnemonic } from '../../crypto';
-import { decodeTxMessages, Document, documentToTx } from './../..';
+import { useTm2Wallet, decodeTxMessages, Document, documentToTx } from './../..';
 import { Keyring, KeyringData, KeyringType } from './keyring';
 
 export class HDWalletKeyring implements Keyring {
@@ -58,12 +59,14 @@ export class HDWalletKeyring implements Keyring {
     signed: Tx;
     signature: TxSignature[];
   }> {
-    const wallet = await Tm2Wallet.fromMnemonic(this.mnemonic, { accountIndex: hdPath });
+    const wallet = await useTm2Wallet(document).fromMnemonic(this.mnemonic, {
+      accountIndex: hdPath,
+    });
     wallet.connect(provider);
     return this.signByWallet(wallet, document);
   }
 
-  private async signByWallet(wallet: Tm2Wallet, document: Document) {
+  private async signByWallet(wallet: Tm2Wallet | Tm2WalletLegacy, document: Document) {
     const tx = documentToTx(document);
     const signedTx = await wallet.signTransaction(tx, decodeTxMessages);
     return {

--- a/packages/adena-module/src/wallet/keyring/keyring-util.ts
+++ b/packages/adena-module/src/wallet/keyring/keyring-util.ts
@@ -5,6 +5,11 @@ import { Keyring } from './keyring';
 import { LedgerKeyring } from './ledger-keyring';
 import { PrivateKeyKeyring } from './private-key-keyring';
 import { Web3AuthKeyring } from './web3-auth-keyring';
+import { Document } from './../..';
+import { Wallet as Tm2Wallet } from '@gnolang/tm2-js-client';
+import { Wallet as Tm2WalletLegacy } from '@gnolang/tm2-js-client-legacy';
+
+const LEGACY_NETWORKS = ['test3'];
 
 export function isHDWalletKeyring(keyring: Keyring): keyring is HDWalletKeyring {
   return keyring.type === 'HD_WALLET';
@@ -39,4 +44,11 @@ export function hasPrivateKey(
     return true;
   }
   return false;
+}
+
+export function useTm2Wallet(document: Document): typeof Tm2Wallet | typeof Tm2WalletLegacy {
+  if (LEGACY_NETWORKS.includes(document.chain_id)) {
+    return Tm2WalletLegacy;
+  }
+  return Tm2Wallet;
 }

--- a/packages/adena-module/src/wallet/keyring/ledger-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/ledger-keyring.ts
@@ -1,9 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Provider, TransactionEndpoint, Wallet as Tm2Wallet } from '@gnolang/tm2-js-client';
+import { Wallet as Tm2WalletLegacy } from '@gnolang/tm2-js-client-legacy';
 import { Keyring, KeyringData, KeyringType } from './keyring';
 import { generateHDPath, Tx } from '@gnolang/tm2-js-client';
 import { LedgerConnector } from '@cosmjs/ledger-amino';
-import { Document, documentToTx, decodeTxMessages } from './../..';
+import { Document, documentToTx, decodeTxMessages, useTm2Wallet } from './../..';
 
 export class LedgerKeyring implements Keyring {
   public readonly id: string;
@@ -38,14 +39,14 @@ export class LedgerKeyring implements Keyring {
     if (!this.connector) {
       throw new Error('Ledger connector does not found');
     }
-    const wallet = Tm2Wallet.fromLedger(this.connector, {
+    const wallet = await useTm2Wallet(document).fromLedger(this.connector, {
       accountIndex: hdPath,
     });
     wallet.connect(provider);
     return this.signByWallet(wallet, document);
   }
 
-  private async signByWallet(wallet: Tm2Wallet, document: Document) {
+  private async signByWallet(wallet: Tm2Wallet | Tm2WalletLegacy, document: Document) {
     const tx = documentToTx(document);
     const signedTx = await wallet.signTransaction(tx, decodeTxMessages);
     return {

--- a/packages/adena-module/src/wallet/keyring/private-key-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/private-key-keyring.ts
@@ -1,7 +1,8 @@
 import { Provider, TransactionEndpoint, Tx, Wallet as Tm2Wallet } from '@gnolang/tm2-js-client';
+import { Wallet as Tm2WalletLegacy } from '@gnolang/tm2-js-client-legacy';
 import { v4 as uuidv4 } from 'uuid';
 import { Keyring, KeyringData, KeyringType } from './keyring';
-import { Document, documentToTx, decodeTxMessages } from './../..';
+import { Document, documentToTx, decodeTxMessages, useTm2Wallet } from './../..';
 
 export class PrivateKeyKeyring implements Keyring {
   public readonly id: string;
@@ -28,12 +29,12 @@ export class PrivateKeyKeyring implements Keyring {
   }
 
   async sign(provider: Provider, document: Document) {
-    const wallet = await Tm2Wallet.fromPrivateKey(this.privateKey);
+    const wallet = await useTm2Wallet(document).fromPrivateKey(this.privateKey);
     wallet.connect(provider);
     return this.signByWallet(wallet, document);
   }
 
-  private async signByWallet(wallet: Tm2Wallet, document: Document) {
+  private async signByWallet(wallet: Tm2Wallet | Tm2WalletLegacy, document: Document) {
     const tx = documentToTx(document);
     const signedTx = await wallet.signTransaction(tx, decodeTxMessages);
     return {

--- a/packages/adena-module/src/wallet/keyring/web3-auth-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/web3-auth-keyring.ts
@@ -1,8 +1,9 @@
 import { Provider, TransactionEndpoint, Tx, Wallet as Tm2Wallet } from '@gnolang/tm2-js-client';
+import { Wallet as Tm2WalletLegacy } from '@gnolang/tm2-js-client-legacy';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Keyring, KeyringData, KeyringType } from './keyring';
-import { Document, documentToTx, decodeTxMessages } from './../..';
+import { Document, documentToTx, decodeTxMessages, useTm2Wallet } from './../..';
 import { hexToArray } from './../../utils/data';
 
 export class Web3AuthKeyring implements Keyring {
@@ -30,12 +31,12 @@ export class Web3AuthKeyring implements Keyring {
   }
 
   async sign(provider: Provider, document: Document) {
-    const wallet = await Tm2Wallet.fromPrivateKey(this.privateKey);
+    const wallet = await useTm2Wallet(document).fromPrivateKey(this.privateKey);
     wallet.connect(provider);
     return this.signByWallet(wallet, document);
   }
 
-  private async signByWallet(wallet: Tm2Wallet, document: Document) {
+  private async signByWallet(wallet: Tm2Wallet | Tm2WalletLegacy, document: Document) {
     const tx = documentToTx(document);
     const signedTx = await wallet.signTransaction(tx, decodeTxMessages);
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,6 +2126,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gnolang/tm2-js-client-legacy@npm:@gnolang/tm2-js-client@1.1.7":
+  version: 1.1.7
+  resolution: "@gnolang/tm2-js-client@npm:1.1.7"
+  dependencies:
+    "@cosmjs/amino": ^0.32.0
+    "@cosmjs/crypto": ^0.32.0
+    "@cosmjs/ledger-amino": ^0.32.0
+    "@types/uuid": ^9.0.4
+    axios: ^1.4.0
+    long: ^5.2.3
+    protobufjs: ^7.2.3
+    uuid: ^9.0.1
+    ws: ^8.16.0
+  checksum: 75d36a02a3e52dffa1a0c41629e5eb8fcadca4353a580324f2733dfd153471b7e2678ce92dad1eca91bd5b826de2b86ff3498b05d77b0613242e6f02047ed4d9
+  languageName: node
+  linkType: hard
+
 "@gnolang/tm2-js-client@npm:1.1.6, @gnolang/tm2-js-client@npm:^1.1.6":
   version: 1.1.6
   resolution: "@gnolang/tm2-js-client@npm:1.1.6"
@@ -7420,6 +7437,7 @@ __metadata:
     "@cosmjs/ledger-amino": ^0.32.2
     "@gnolang/gno-js-client": 1.2.1
     "@gnolang/tm2-js-client": 1.1.6
+    "@gnolang/tm2-js-client-legacy": "npm:@gnolang/tm2-js-client@1.1.7"
     "@ledgerhq/hw-transport": ^6.30.4
     "@ledgerhq/hw-transport-mocker": ^6.28.4
     "@ledgerhq/hw-transport-webhid": ^6.28.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,15 +2114,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gnolang/gno-js-client@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@gnolang/gno-js-client@npm:1.2.1"
+"@gnolang/gno-js-client@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@gnolang/gno-js-client@npm:1.2.3"
   dependencies:
     "@cosmjs/ledger-amino": ^0.32.0
-    "@gnolang/tm2-js-client": ^1.1.6
+    "@gnolang/tm2-js-client": ^1.2.0
     long: ^5.2.3
     protobufjs: ^7.2.3
-  checksum: ba6117b92abb972888f058468d62f756335a17cf7a6cb29cd0fe09a1afc9f8a3534bff758482f6c6763d490d9006fe6f5c027cdefba342a0bea005270d15311a
+  checksum: 6dcac75e01d516c37009903ec91fad38d9a00b8dfc40a4a5d5a279a1beefba7b78da8af33761a2d11e29e8ce9e3158e7a2b7239847b9908f964207c9c9039419
   languageName: node
   linkType: hard
 
@@ -2143,9 +2143,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gnolang/tm2-js-client@npm:1.1.6, @gnolang/tm2-js-client@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "@gnolang/tm2-js-client@npm:1.1.6"
+"@gnolang/tm2-js-client@npm:1.2.0, @gnolang/tm2-js-client@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@gnolang/tm2-js-client@npm:1.2.0"
   dependencies:
     "@cosmjs/amino": ^0.32.0
     "@cosmjs/crypto": ^0.32.0
@@ -2155,8 +2155,8 @@ __metadata:
     long: ^5.2.3
     protobufjs: ^7.2.3
     uuid: ^9.0.1
-    ws: ^8.13.0
-  checksum: 873c8ecfc2336161e5c6aae598fdf42e4fa8fafb2775b3debdce14b10c377d90d964cda332a0aff89a7cefbca199020ac88ad5019ac6943c4f846bcea7c29f00
+    ws: ^8.16.0
+  checksum: a18932afd1649b7f16a3f16a96ded271b7ff264907e02621b4f4d88073f80ded47afab897d715019d2f1457c7a68c194f2e18e3da4e6057e154f55a59522874e
   languageName: node
   linkType: hard
 
@@ -7351,8 +7351,8 @@ __metadata:
     "@babel/preset-env": ^7.23.9
     "@babel/preset-react": ^7.23.3
     "@babel/preset-typescript": ^7.23.3
-    "@gnolang/gno-js-client": 1.2.1
-    "@gnolang/tm2-js-client": 1.1.6
+    "@gnolang/gno-js-client": 1.2.3
+    "@gnolang/tm2-js-client": 1.2.0
     "@jest/globals": ^29.7.0
     "@storybook/addon-essentials": ^7.6.17
     "@storybook/addon-interactions": ^7.6.17
@@ -7435,8 +7435,8 @@ __metadata:
     "@babel/preset-flow": ^7.23.3
     "@babel/preset-typescript": ^7.23.3
     "@cosmjs/ledger-amino": ^0.32.2
-    "@gnolang/gno-js-client": 1.2.1
-    "@gnolang/tm2-js-client": 1.1.6
+    "@gnolang/gno-js-client": 1.2.3
+    "@gnolang/tm2-js-client": 1.2.0
     "@gnolang/tm2-js-client-legacy": "npm:@gnolang/tm2-js-client@1.1.7"
     "@ledgerhq/hw-transport": ^6.30.4
     "@ledgerhq/hw-transport-mocker": ^6.28.4
@@ -20625,7 +20625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.13.0, ws@npm:^8.16.0, ws@npm:^8.2.3":
+"ws@npm:^8.11.0, ws@npm:^8.16.0, ws@npm:^8.2.3":
   version: 8.16.0
   resolution: "ws@npm:8.16.0"
   peerDependencies:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:
- Due to changes in the signing process, we use a separate `tm2-js-client` for each network.
- The `test3` network uses an `tm2-js-client@1.1.7`. 