### PR TITLE
fix: responsive positioning of help tooltips

### DIFF
--- a/packages/adena-extension/src/components/molecules/web-help-overlay/web-help-overlay.stories.tsx
+++ b/packages/adena-extension/src/components/molecules/web-help-overlay/web-help-overlay.stories.tsx
@@ -12,6 +12,7 @@ export const Default: StoryObj<WebHelpOverlayProps> = {
   args: {
     items: [
       {
+        position: 'bottom',
         x: 5,
         y: 5,
         tooltipInfo: {
@@ -27,6 +28,7 @@ export const Default: StoryObj<WebHelpOverlayProps> = {
       {
         x: 15,
         y: 5,
+        position: 'bottom',
         tooltipInfo: {
           securityRate: 2,
           convenienceRate: 2,
@@ -40,6 +42,7 @@ export const Default: StoryObj<WebHelpOverlayProps> = {
       {
         x: 25,
         y: 5,
+        position: 'bottom',
         tooltipInfo: {
           securityRate: 2,
           convenienceRate: 2,

--- a/packages/adena-extension/src/components/molecules/web-help-overlay/web-help-overlay.tsx
+++ b/packages/adena-extension/src/components/molecules/web-help-overlay/web-help-overlay.tsx
@@ -5,6 +5,7 @@ import { WebHelpOverlayItemWrapper, WebHelpOverlayWrapper } from './web-help-ove
 export interface OverlayItem {
   x: number;
   y: number;
+  position: 'top' | 'bottom';
   tooltipInfo: {
     securityRate: number;
     convenienceRate: number;
@@ -42,6 +43,7 @@ const WebHelpOverlay: React.FC<WebHelpOverlayProps> = ({ items, onFinish }) => {
             <WebHelpTooltip
               securityRate={item.tooltipInfo.securityRate}
               convenienceRate={item.tooltipInfo.convenienceRate}
+              position={item.position}
               confirm={nextItem}
             >
               {item.tooltipInfo.content}

--- a/packages/adena-extension/src/components/molecules/web-help-tooltip/web-help-tooltip.styles.ts
+++ b/packages/adena-extension/src/components/molecules/web-help-tooltip/web-help-tooltip.styles.ts
@@ -12,6 +12,11 @@ export const WebHelpTooltipWrapper = styled(View)`
 export const WebHelpTooltipBoxArrowWrapper = styled(View)`
   position: relative;
   z-index: 5;
+
+  &.reverse img {
+    transform: rotate(180deg);
+    margin-top: -1px;
+  }
 `;
 
 export const WebHelpTooltipBoxWrapper = styled(View)`

--- a/packages/adena-extension/src/components/molecules/web-help-tooltip/web-help-tooltip.tsx
+++ b/packages/adena-extension/src/components/molecules/web-help-tooltip/web-help-tooltip.tsx
@@ -14,6 +14,7 @@ import _ from 'lodash';
 export interface WebHelpTooltipProps {
   securityRate: number;
   convenienceRate: number;
+  position: 'top' | 'bottom';
   confirm: () => void;
 }
 
@@ -21,13 +22,16 @@ const WebHelpTooltip: React.FC<PropsWithChildren<WebHelpTooltipProps>> = ({
   securityRate,
   convenienceRate,
   confirm,
+  position,
   children,
 }) => {
   return (
     <WebHelpTooltipWrapper>
-      <WebHelpTooltipBoxArrowWrapper>
-        <WebImg src={IconBoxArrow} width={23} height={12} />
-      </WebHelpTooltipBoxArrowWrapper>
+      {position === 'bottom' && (
+        <WebHelpTooltipBoxArrowWrapper>
+          <WebImg src={IconBoxArrow} width={23} height={12} />
+        </WebHelpTooltipBoxArrowWrapper>
+      )}
 
       <WebHelpTooltipBoxWrapper>
         <div className='content-wrapper'>{children}</div>
@@ -60,6 +64,12 @@ const WebHelpTooltip: React.FC<PropsWithChildren<WebHelpTooltipProps>> = ({
         </div>
         <WebButton figure='primary' size='full' text='I got it' onClick={confirm} />
       </WebHelpTooltipBoxWrapper>
+
+      {position === 'top' && (
+        <WebHelpTooltipBoxArrowWrapper className='reverse'>
+          <WebImg src={IconBoxArrow} width={23} height={12} />
+        </WebHelpTooltipBoxArrowWrapper>
+      )}
     </WebHelpTooltipWrapper>
   );
 };

--- a/packages/adena-extension/src/components/pages/web/wallet-creation-help-overlay/wallet-creation-help-overlay.tsx
+++ b/packages/adena-extension/src/components/pages/web/wallet-creation-help-overlay/wallet-creation-help-overlay.tsx
@@ -11,6 +11,31 @@ export interface WalletCreationHelpOverlayProps {
   onFinish: () => void;
 }
 
+function getTooltipPositionY(
+  y: number,
+  height: number,
+  windowHeight: number,
+): {
+  position: 'top' | 'bottom';
+  height: number;
+} {
+  const positionY = y;
+  const boxHeight = height;
+  const tooltipHeight = 214;
+
+  if (windowHeight === 0 || y + boxHeight + tooltipHeight < windowHeight) {
+    return {
+      position: 'bottom',
+      height: positionY + boxHeight + 10,
+    };
+  }
+
+  return {
+    position: 'top',
+    height: positionY - tooltipHeight - 10,
+  };
+}
+
 const WalletCreationHelpOverlay: React.FC<WalletCreationHelpOverlayProps> = ({
   hardwareWalletButtonRef,
   airgapAccountButtonRef,
@@ -24,9 +49,11 @@ const WalletCreationHelpOverlay: React.FC<WalletCreationHelpOverlayProps> = ({
   const hardwareWalletHelpItem: OverlayItem | null = useMemo(() => {
     if (!hardwareWalletButtonRef?.current) return null;
     const { x, y, width, height } = hardwareWalletButtonRef.current.getBoundingClientRect();
+    const tooltipPositionInfo = getTooltipPositionY(y, height, windowSize.height);
     return {
       x: x + width / 2,
-      y: y + height + 10,
+      y: tooltipPositionInfo.height,
+      position: tooltipPositionInfo.position,
       tooltipInfo: {
         securityRate: 2,
         convenienceRate: 2,
@@ -44,9 +71,11 @@ const WalletCreationHelpOverlay: React.FC<WalletCreationHelpOverlayProps> = ({
   const airgapAccountHelpItem: OverlayItem | null = useMemo(() => {
     if (!airgapAccountButtonRef?.current) return null;
     const { x, y, width, height } = airgapAccountButtonRef.current.getBoundingClientRect();
+    const tooltipPositionInfo = getTooltipPositionY(y, height, windowSize.height);
     return {
       x: x + width / 2,
-      y: y + height + 10,
+      y: tooltipPositionInfo.height,
+      position: tooltipPositionInfo.position,
       tooltipInfo: {
         securityRate: 3,
         convenienceRate: 1,
@@ -64,9 +93,11 @@ const WalletCreationHelpOverlay: React.FC<WalletCreationHelpOverlayProps> = ({
   const advancedOptionHelpItem: OverlayItem | null = useMemo(() => {
     if (!advancedOptionButtonRef?.current) return null;
     const { x, y, width, height } = advancedOptionButtonRef.current.getBoundingClientRect();
+    const tooltipPositionInfo = getTooltipPositionY(y, height, windowSize.height);
     return {
       x: x + width / 2,
-      y: y + height + 10,
+      y: tooltipPositionInfo.height,
+      position: tooltipPositionInfo.position,
       tooltipInfo: {
         securityRate: 1,
         convenienceRate: 3,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- fix

### What this PR does:

Resolve #527 issues. 
Expose the tooltip at the top if its position exceeds the screen size.

[Default]
<img width="756" alt="image" src="https://github.com/user-attachments/assets/1e48da62-6547-4310-9e17-fc1e6d65bbcf">

[Responseive]
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a868f1ba-ad8d-41e6-bdf4-f021d467fcdd">
