### PR TITLE
feat: Define and create new handler for new `vm_noop` message type

### DIFF
--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -74,7 +74,7 @@
     "webpack-merge": "^5.10.0"
   },
   "dependencies": {
-    "@gnolang/gno-js-client": "1.3.0",
+    "@gnolang/gno-js-client": "git+https://github.com/VAR-META-Tech/gno-js-client.git#msg_noop",
     "@gnolang/tm2-js-client": "1.2.1",
     "@tanstack/react-query": "^4.36.1",
     "@vespaiach/axios-fetch-adapter": "^0.3.1",

--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@gnolang/gno-js-client": "git+https://github.com/VAR-META-Tech/gno-js-client.git#msg_noop",
-    "@gnolang/tm2-js-client": "1.2.1",
+    "@gnolang/tm2-js-client": "git+https://github.com/VAR-META-Tech/tm2-js-client.git#msg_noop",
     "@tanstack/react-query": "^4.36.1",
     "@vespaiach/axios-fetch-adapter": "^0.3.1",
     "adena-module": "*",

--- a/packages/adena-extension/src/common/validation/validation-message.ts
+++ b/packages/adena-extension/src/common/validation/validation-message.ts
@@ -134,3 +134,19 @@ export const validateTransactionMessageOfRun = (message: { [key in string]: any 
   }
   return true;
 };
+
+export const validateTransactionMessageOfVmNoop = (message: { [key in string]: any }): boolean => {
+  if (!message.type || !message.value) {
+    return false;
+  }
+  if (message.type !== '/vm.m_noop') {
+    return false;
+  }
+  if (typeof message.value !== 'object') {
+    return false;
+  }
+  if (Object.keys(message.value).indexOf('caller') === -1) {
+    return false;
+  }
+  return true;
+};

--- a/packages/adena-extension/src/inject/executor/executor.ts
+++ b/packages/adena-extension/src/inject/executor/executor.ts
@@ -6,6 +6,7 @@ import {
   validateTransactionMessageOfBankSend,
   validateTransactionMessageOfRun,
   validateTransactionMessageOfVmCall,
+  validateTransactionMessageOfVmNoop,
 } from '@common/validation/validation-message';
 
 type Params = { [key in string]: any };
@@ -130,6 +131,11 @@ export class AdenaExecutor {
           break;
         case '/vm.m_run':
           if (!validateTransactionMessageOfRun(message)) {
+            return InjectionMessageInstance.failure('INVALID_FORMAT');
+          }
+          break;
+        case '/vm.m_noop':
+          if (!validateTransactionMessageOfVmNoop(message)) {
             return InjectionMessageInstance.failure('INVALID_FORMAT');
           }
           break;

--- a/packages/adena-extension/src/inject/message/methods/transaction.ts
+++ b/packages/adena-extension/src/inject/message/methods/transaction.ts
@@ -100,7 +100,7 @@ export const validateInjectionAddress = (currentAccountAddress: string): boolean
 };
 
 export const validateInjectionTransactionType = (requestData: InjectionMessage): any => {
-  const messageTypes = ['/bank.MsgSend', '/vm.m_call', '/vm.m_addpkg', '/vm.m_run'];
+  const messageTypes = ['/bank.MsgSend', '/vm.m_call', '/vm.m_addpkg', '/vm.m_run', '/vm.m_noop'];
   return requestData.data?.messages.every((message: any) => messageTypes.includes(message?.type));
 };
 

--- a/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
@@ -96,6 +96,10 @@ const ApproveTransactionContainer: React.FC = () => {
   }, [document]);
 
   const isErrorNetworkFee = useMemo(() => {
+    //skip for case sign msg for sponsor service
+    if (document?.msgs[0].type === '/vm.m_noop') {
+      return false;
+    }
     return BigNumber(currentBalance).shiftedBy(-6).isLessThan(networkFee.amount);
   }, [currentBalance, networkFee]);
 

--- a/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
@@ -95,9 +95,12 @@ const ApproveTransactionContainer: React.FC = () => {
     };
   }, [document]);
 
+  const isSponsorService = useMemo(() => {
+    return (document?.msgs?.length ?? 0) > 1 && document?.msgs[0].type === '/vm.m_noop';
+  }, [document]);
+
   const isErrorNetworkFee = useMemo(() => {
-    //skip for case sign msg for sponsor service
-    if (document?.msgs[0].type === '/vm.m_noop') {
+    if (isSponsorService) {
       return false;
     }
     return BigNumber(currentBalance).shiftedBy(-6).isLessThan(networkFee.amount);

--- a/packages/adena-extension/src/repositories/transaction/response/transaction-history-response.ts
+++ b/packages/adena-extension/src/repositories/transaction/response/transaction-history-response.ts
@@ -52,3 +52,7 @@ export interface HistoryItemVmMAddPkg extends HistoryItem {
     }[];
   };
 }
+
+export interface HistoryItemVmMNoop extends HistoryItem {
+  caller: string;
+}

--- a/packages/adena-extension/src/services/transaction/message/vm/vm.ts
+++ b/packages/adena-extension/src/services/transaction/message/vm/vm.ts
@@ -61,3 +61,17 @@ export const createMessageOfVmRun = (info: {
     },
   };
 };
+
+export const createMessageOfVmNoop = (info: {
+  caller: string;
+}): {
+  type: string;
+  value: { caller: string;};
+} => {
+  return {
+    type: '/vm.m_noop',
+    value: {
+      caller: info.caller,
+    },
+  };
+};

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@cosmjs/ledger-amino": "^0.32.4",
-    "@gnolang/gno-js-client": "1.3.0",
+    "@gnolang/gno-js-client": "git+https://github.com/VAR-META-Tech/gno-js-client.git#msg_noop",
     "@gnolang/tm2-js-client": "1.2.1",
     "@ledgerhq/hw-transport": "^6.30.4",
     "@ledgerhq/hw-transport-mocker": "^6.28.4",

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@cosmjs/ledger-amino": "^0.32.4",
     "@gnolang/gno-js-client": "git+https://github.com/VAR-META-Tech/gno-js-client.git#msg_noop",
-    "@gnolang/tm2-js-client": "1.2.1",
+    "@gnolang/tm2-js-client": "git+https://github.com/VAR-META-Tech/tm2-js-client.git#msg_noop",
     "@ledgerhq/hw-transport": "^6.30.4",
     "@ledgerhq/hw-transport-mocker": "^6.28.4",
     "@ledgerhq/hw-transport-webhid": "^6.28.4",

--- a/packages/adena-module/src/utils/messages.ts
+++ b/packages/adena-module/src/utils/messages.ts
@@ -1,5 +1,5 @@
 import { Any, PubKeySecp256k1, Tx, TxFee, TxSignature } from '@gnolang/tm2-js-client';
-import { MsgCall, MsgAddPackage, MsgSend, MsgEndpoint } from '@gnolang/gno-js-client';
+import { MsgCall, MsgAddPackage, MsgSend, MsgEndpoint, MsgNoop } from '@gnolang/gno-js-client';
 import { MemPackage, MemFile, MsgRun } from '@gnolang/gno-js-client/bin/proto/gno/vm';
 import { fromBase64 } from '../encoding';
 
@@ -54,6 +54,14 @@ export const decodeTxMessages = (messages: Any[]): any[] => {
       case MsgEndpoint.MSG_RUN: {
         const decodedMessage = MsgRun.decode(m.value);
         const messageJson = MsgRun.toJSON(decodedMessage) as object;
+        return {
+          '@type': m.typeUrl,
+          ...messageJson,
+        };
+      }
+      case MsgEndpoint.MSG_NOOP: {
+        const decodedMessage = MsgNoop.decode(m.value);
+        const messageJson = MsgNoop.toJSON(decodedMessage) as any;
         return {
           '@type': m.typeUrl,
           ...messageJson,
@@ -126,6 +134,16 @@ function encodeMessageValue(message: { type: string; value: any }) {
       return Any.create({
         typeUrl: MsgEndpoint.MSG_RUN,
         value: MsgRun.encode(msgRun).finish(),
+      });
+    }
+    case MsgEndpoint.MSG_NOOP: {
+      const value = message.value;
+      const result = MsgNoop.create({
+        caller: value.caller,
+      });
+      return Any.create({
+        typeUrl: MsgEndpoint.MSG_NOOP,
+        value: MsgNoop.encode(result).finish(),
       });
     }
     default: {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
* feature

<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->

### What this PR does:
In the view of sponsor feature, this PR aims to:

* Add supporting for signing a sponsor message from sponsor service.
* Skipping balances check when dapps/ users want to make a sponsor transaction. 

#### We are now using our version of `gno`, tm2-js-client`, ... and will update to make this PR ready after these PRs are merged.

Read more about `sponsor-service` at:
- Gno PRs: [#2630](https://github.com/gnolang/gno/pull/2630), [#2209](https://github.com/gnolang/gno/pull/2209)
- HackMD introduction [here](https://hackmd.io/@thinhnx/B1rtb2NtR)
- `updating...`

