### PR TITLE
fix: fix a ui align center in select account

### DIFF
--- a/packages/adena-extension/src/pages/web/account-import-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/account-import-screen/index.tsx
@@ -21,6 +21,10 @@ const HasWallet = ({ wallet }: { wallet: Wallet }): ReactElement => {
     useAccountImportScreenReturn;
 
   const extended = useMemo(() => {
+    if (step === 'SELECT_ACCOUNT') {
+      return true;
+    }
+
     return inputType === '24seeds';
   }, [inputType]);
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- styles

### What this PR does:
- On the screen for adding an account with Mnemonic Wallet, align the component to the centre. 
