### PR TITLE
feat: improve the account with side menu UI

### DIFF
--- a/packages/adena-extension/src/components/atoms/copy-icon-button/index.tsx
+++ b/packages/adena-extension/src/components/atoms/copy-icon-button/index.tsx
@@ -1,13 +1,14 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { CopyButtonWrapper } from './copy-icon-button.styles';
 import IconCopy from '@assets/icon-copy';
 import IconCopyCheck from '@assets/icon-copy-check';
+import React, { useCallback, useEffect, useState } from 'react';
+import { CopyButtonWrapper } from './copy-icon-button.styles';
 
 export interface CopyIconButtonProps {
   className?: string;
   copyText: string;
   style?: React.CSSProperties;
-  size?: number
+  size?: number;
+  onClick?: () => void;
 }
 
 export const CopyIconButton: React.FC<CopyIconButtonProps> = ({
@@ -15,6 +16,7 @@ export const CopyIconButton: React.FC<CopyIconButtonProps> = ({
   copyText,
   style = {},
   size = 16,
+  onClick,
 }) => {
   const [checked, setChecked] = useState<boolean>(false);
 
@@ -31,12 +33,20 @@ export const CopyIconButton: React.FC<CopyIconButtonProps> = ({
       event.stopPropagation();
       setChecked(true);
       navigator.clipboard.writeText(copyText);
+
+      !!onClick && onClick();
     },
-    [copyText, checked],
+    [copyText, checked, onClick],
   );
 
   return (
-    <CopyButtonWrapper className={className} style={style} size={size} checked={checked} onClick={onClickCopyButton}>
+    <CopyButtonWrapper
+      className={className}
+      style={style}
+      size={size}
+      checked={checked}
+      onClick={onClickCopyButton}
+    >
       {checked ? <IconCopyCheck /> : <IconCopy />}
     </CopyButtonWrapper>
   );

--- a/packages/adena-extension/src/components/atoms/highlight-number/index.tsx
+++ b/packages/adena-extension/src/components/atoms/highlight-number/index.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { FontsType } from '@styles/theme';
+import BigNumber from 'bignumber.js';
+import React, { useMemo } from 'react';
 import { HighlightNumberWrapper } from './highlight-number.styles';
 
 export interface HighlightNumberProps {
@@ -20,6 +21,10 @@ export const HighlightNumber: React.FC<HighlightNumberProps> = ({
   const hasDecimal = value.includes('.');
   const [integer, decimal] = hasDecimal ? value.split('.') : [value, ''];
 
+  const integerStr = useMemo(() => {
+    return BigNumber(integer.replace(/,/g, '')).toFormat(0);
+  }, [integer]);
+
   return (
     <HighlightNumberWrapper
       fontColor={fontColor}
@@ -27,7 +32,7 @@ export const HighlightNumber: React.FC<HighlightNumberProps> = ({
       minimumFontSize={minimumFontSize}
       lineHeight={lineHeight}
     >
-      <span className='value integer'>{integer}</span>
+      <span className='value integer'>{integerStr}</span>
       <span className='value decimal'>
         {hasDecimal ? '.' : ''}
         {decimal}

--- a/packages/adena-extension/src/components/molecules/token-balance/token-balance.styles.ts
+++ b/packages/adena-extension/src/components/molecules/token-balance/token-balance.styles.ts
@@ -1,4 +1,4 @@
-import { FontsType, fonts } from '@styles/theme';
+import { fonts, FontsType } from '@styles/theme';
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
 
 interface TokenBalanceWrapperProps {
@@ -20,19 +20,19 @@ export const TokenBalanceWrapper = styled.div<TokenBalanceWrapperProps>`
           flex-direction: row;
         `
       : maxWidth
-      ? css`
-          flex-flow: row wrap;
-          max-width: ${maxWidth}px;
-        `
-      : css`
-          flex-direction: column;
-        `}
+        ? css`
+            flex-flow: row wrap;
+            max-width: ${maxWidth}px;
+          `
+        : css`
+            flex-direction: column;
+          `}
   align-items: center;
   width: fit-content;
   height: auto;
   text-align: center;
   justify-content: center;
-  column-gap: 9px;
+  column-gap: 4px;
 
   .denom-wrapper {
     display: inline-flex;

--- a/packages/adena-extension/src/components/pages/account-details/account-details/account-details.spec.tsx
+++ b/packages/adena-extension/src/components/pages/account-details/account-details/account-details.spec.tsx
@@ -10,10 +10,14 @@ describe('AccountDetails Component', () => {
   it('AccountDetails render', () => {
     const args: AccountDetailsProps = {
       hasPrivateKey: true,
+      hasSeedPhrase: true,
       originName: '',
       name: '',
       address: '',
       moveGnoscan: () => {
+        return;
+      },
+      moveRevealSeedPhrase: () => {
         return;
       },
       moveExportPrivateKey: () => {

--- a/packages/adena-extension/src/components/pages/account-details/account-details/index.tsx
+++ b/packages/adena-extension/src/components/pages/account-details/account-details/index.tsx
@@ -1,15 +1,17 @@
-import React, { useCallback } from 'react';
-import { AccountDetailsWrapper } from './account-details.styles';
-import AccountNameInput from '../account-name-input';
-import { QRCodeSVG } from 'qrcode.react';
 import { CopyIconButton, FullButtonRightIcon } from '@components/atoms';
+import { QRCodeSVG } from 'qrcode.react';
+import React, { useCallback } from 'react';
+import AccountNameInput from '../account-name-input';
+import { AccountDetailsWrapper } from './account-details.styles';
 
 export interface AccountDetailsProps {
   hasPrivateKey: boolean;
+  hasSeedPhrase: boolean;
   originName: string;
   name: string;
   address: string;
   moveGnoscan: () => void;
+  moveRevealSeedPhrase: () => void;
   moveExportPrivateKey: () => void;
   setName: (name: string) => void;
   reset: () => void;
@@ -17,12 +19,14 @@ export interface AccountDetailsProps {
 
 const AccountDetails: React.FC<AccountDetailsProps> = ({
   hasPrivateKey,
+  hasSeedPhrase,
   originName,
   name,
   address,
   setName,
   reset,
   moveGnoscan,
+  moveRevealSeedPhrase,
   moveExportPrivateKey,
 }) => {
   const onClickViewOnGnoscan = useCallback(() => {
@@ -35,6 +39,13 @@ const AccountDetails: React.FC<AccountDetailsProps> = ({
     }
     moveExportPrivateKey();
   }, [hasPrivateKey, moveExportPrivateKey]);
+
+  const onClickRevealSeedPhrase = useCallback(() => {
+    if (!hasSeedPhrase) {
+      return;
+    }
+    moveRevealSeedPhrase();
+  }, [hasSeedPhrase, moveRevealSeedPhrase]);
 
   return (
     <AccountDetailsWrapper>
@@ -62,6 +73,11 @@ const AccountDetails: React.FC<AccountDetailsProps> = ({
           disabled={!hasPrivateKey}
           title={'Export Private Key'}
           onClick={onClickExportPrivateKey}
+        />
+        <FullButtonRightIcon
+          disabled={!hasSeedPhrase}
+          title={'Reveal Seed Phrase'}
+          onClick={onClickRevealSeedPhrase}
         />
       </div>
     </AccountDetailsWrapper>

--- a/packages/adena-extension/src/components/pages/router/side-menu-account-item/side-menu-account-item.spec.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu-account-item/side-menu-account-item.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import { GlobalPopupStyle } from '@styles/global-style';
+import theme from '@styles/theme';
+import { render } from '@testing-library/react';
+import { SideMenuAccountItemProps } from '@types';
 import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
-import { render } from '@testing-library/react';
-import theme from '@styles/theme';
-import { GlobalPopupStyle } from '@styles/global-style';
 import SideMenuAccountItem from './side-menu-account-item';
-import { SideMenuAccountItemProps } from '@types';
 
 describe('SideMenuAccountItem Component', () => {
   it('SideMenuAccountItem render', () => {
@@ -17,6 +17,10 @@ describe('SideMenuAccountItem Component', () => {
         address: '',
         balance: '',
         type: 'HD_WALLET',
+      },
+      focusedAccountId: '',
+      focusAccountId: () => {
+        return;
       },
       changeAccount: () => {
         return;

--- a/packages/adena-extension/src/components/pages/router/side-menu-account-item/side-menu-account-item.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu-account-item/side-menu-account-item.tsx
@@ -6,6 +6,9 @@ import IconQRCode from '@assets/icon-qrcode';
 import { CopyIconButton, Portal } from '@components/atoms';
 import { SideMenuAccountItemProps } from '@types';
 
+import { GNOT_TOKEN } from '@common/constants/token.constant';
+import { TokenBalance } from '@components/molecules';
+import { useTheme } from 'styled-components';
 import {
   SideMenuAccountItemMoreInfoWrapper,
   SideMenuAccountItemWrapper,
@@ -20,6 +23,7 @@ const SideMenuAccountItem: React.FC<SideMenuAccountItemProps> = ({
   moveGnoscan,
   moveAccountDetail,
 }) => {
+  const theme = useTheme();
   const { accountId, name, address, balance, type } = account;
   const [openedMoreInfo, setOpenedMoreInfo] = useState(false);
   const [positionX, setPositionX] = useState(0);
@@ -101,7 +105,18 @@ const SideMenuAccountItem: React.FC<SideMenuAccountItemProps> = ({
           {label !== null && <span className='label'>{label}</span>}
         </div>
         <div className='balance-wrapper'>
-          <span className='balance'>{balance}</span>
+          {balance === '-' ? (
+            <span className='balance'>{balance}</span>
+          ) : (
+            <TokenBalance
+              value={balance}
+              denom={GNOT_TOKEN.symbol}
+              fontColor={theme.neutral.a}
+              orientation='HORIZONTAL'
+              minimumFontSize='11px'
+              fontStyleKey='body3Reg'
+            />
+          )}
         </div>
       </div>
 

--- a/packages/adena-extension/src/components/pages/router/side-menu-account-list/side-menu-account-list.spec.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu-account-list/side-menu-account-list.spec.tsx
@@ -12,6 +12,10 @@ describe('SideMenuAccountList Component', () => {
     const args: SideMenuAccountListProps = {
       currentAccountId: '',
       accounts: [],
+      focusedAccountId: '',
+      focusAccountId: () => {
+        return; 
+      },
       changeAccount: () => {
         return;
       },

--- a/packages/adena-extension/src/components/pages/router/side-menu-account-list/side-menu-account-list.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu-account-list/side-menu-account-list.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 
-import { SideMenuAccountListWrapper } from './side-menu-account-list.styles';
-import SideMenuAccountItem from '../side-menu-account-item/side-menu-account-item';
 import { SideMenuAccountListProps } from '@types';
+import SideMenuAccountItem from '../side-menu-account-item/side-menu-account-item';
+import { SideMenuAccountListWrapper } from './side-menu-account-list.styles';
 
 const SideMenuAccountList: React.FC<SideMenuAccountListProps> = ({
   currentAccountId,
   accounts,
+  focusedAccountId,
   changeAccount,
   moveGnoscan,
+  focusAccountId,
   moveAccountDetail,
 }) => {
   return (
@@ -18,7 +20,9 @@ const SideMenuAccountList: React.FC<SideMenuAccountListProps> = ({
           key={index}
           selected={account.accountId === currentAccountId}
           account={account}
+          focusedAccountId={focusedAccountId}
           changeAccount={changeAccount}
+          focusAccountId={focusAccountId}
           moveGnoscan={moveGnoscan}
           moveAccountDetail={moveAccountDetail}
         />

--- a/packages/adena-extension/src/components/pages/router/side-menu-layout/side-menu-container.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu-layout/side-menu-container.tsx
@@ -113,7 +113,7 @@ const SideMenuContainer: React.FC<SideMenuContainerProps> = ({ open, setOpen }) 
         if (!amount) {
           return '-';
         }
-        return `${amount.value} ${amount.denom}`;
+        return `${amount.value}`;
       }
 
       return Promise.all(

--- a/packages/adena-extension/src/components/pages/router/side-menu-layout/side-menu-container.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu-layout/side-menu-container.tsx
@@ -1,6 +1,6 @@
+import { Account } from 'adena-module';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Account } from 'adena-module';
 
 import { formatNickname } from '@common/utils/client-utils';
 import SideMenu from '@components/pages/router/side-menu/side-menu';
@@ -11,11 +11,11 @@ import { useLoadAccounts } from '@hooks/use-load-accounts';
 import { useNetwork } from '@hooks/use-network';
 import { useTokenBalance } from '@hooks/use-token-balance';
 
-import { SideMenuAccountInfo, TokenBalanceType, RoutePath } from '@types';
+import { SCANNER_URL } from '@common/constants/resource.constant';
+import { makeQueryString } from '@common/utils/string-utils';
 import useLink from '@hooks/use-link';
 import { useQuery } from '@tanstack/react-query';
-import { makeQueryString } from '@common/utils/string-utils';
-import { SCANNER_URL } from '@common/constants/resource.constant';
+import { RoutePath, SideMenuAccountInfo, TokenBalanceType } from '@types';
 
 interface SideMenuContainerProps {
   open: boolean;
@@ -34,6 +34,7 @@ const SideMenuContainer: React.FC<SideMenuContainerProps> = ({ open, setOpen }) 
   const [locked, setLocked] = useState(true);
   const { currentAccount } = useCurrentAccount();
   const [latestAccountInfos, setLatestAccountInfos] = useState<SideMenuAccountInfo[]>([]);
+  const [focusedAccountId, setFocusedAccountId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) {
@@ -72,6 +73,10 @@ const SideMenuContainer: React.FC<SideMenuContainerProps> = ({ open, setOpen }) 
     },
     [setOpen],
   );
+
+  const focusAccountId = useCallback((accountId: string | null) => {
+    setFocusedAccountId(accountId);
+  }, []);
 
   const changeAccount = useCallback(
     async (accountId: string) => {
@@ -136,7 +141,9 @@ const SideMenuContainer: React.FC<SideMenuContainerProps> = ({ open, setOpen }) 
       locked={locked}
       currentAccountId={currentAccountId}
       accounts={locked ? [] : latestAccountInfos}
+      focusedAccountId={focusedAccountId}
       changeAccount={changeAccount}
+      focusAccountId={focusAccountId}
       movePage={movePage}
       openLink={onOpenLink}
       openRegister={openRegister}

--- a/packages/adena-extension/src/components/pages/router/side-menu/side-menu.spec.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu/side-menu.spec.tsx
@@ -15,6 +15,10 @@ describe('SideMenu Component', () => {
       locked: false,
       currentAccountId: null,
       accounts: [],
+      focusedAccountId: '',
+      focusAccountId: () => {
+        return; 
+      },
       changeAccount: () => {
         return;
       },

--- a/packages/adena-extension/src/components/pages/router/side-menu/side-menu.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu/side-menu.tsx
@@ -1,24 +1,26 @@
 import React, { useCallback } from 'react';
 
-import { SideMenuWrapper } from './side-menu.styles';
+import IconHelp from '@assets/help-fill.svg';
+import IconAdd from '@assets/icon-add';
+import IconLock from '@assets/icon-side-menu-lock.svg';
+import IconSetting from '@assets/icon-side-menu-setting.svg';
 import LogoAdena from '@assets/logo-withIcon.svg';
+import IconRestore from '@assets/restore.svg';
 import { Icon } from '@components/atoms';
 import SideMenuAccountList from '@components/pages/router/side-menu-account-list/side-menu-account-list';
 import SideMenuLink from '@components/pages/router/side-menu-link/side-menu-link';
-import IconAdd from '@assets/icon-add';
-import IconSetting from '@assets/icon-side-menu-setting.svg';
-import IconLock from '@assets/icon-side-menu-lock.svg';
-import IconRestore from '@assets/restore.svg';
-import IconHelp from '@assets/help-fill.svg';
-import { SideMenuProps, RoutePath } from '@types';
+import { RoutePath, SideMenuProps } from '@types';
+import { SideMenuWrapper } from './side-menu.styles';
 
 const SideMenu: React.FC<SideMenuProps> = ({
   scannerUrl,
   scannerQueryString,
   locked,
   currentAccountId,
+  focusedAccountId,
   accounts,
   movePage,
+  focusAccountId,
   openLink,
   openRegister,
   changeAccount,
@@ -80,7 +82,9 @@ const SideMenu: React.FC<SideMenuProps> = ({
         <SideMenuAccountList
           currentAccountId={currentAccountId}
           accounts={accounts}
+          focusedAccountId={focusedAccountId}
           changeAccount={changeAccount}
+          focusAccountId={focusAccountId}
           moveGnoscan={moveGnoscan}
           moveAccountDetail={moveAccountDetail}
         />

--- a/packages/adena-extension/src/types/side-menu.ts
+++ b/packages/adena-extension/src/types/side-menu.ts
@@ -14,7 +14,9 @@ export interface SideMenuProps {
   locked: boolean;
   currentAccountId: string | null;
   accounts: SideMenuAccountInfo[];
+  focusedAccountId: string | null;
   changeAccount: (accountId: string) => void;
+  focusAccountId: (accountId: string | null) => void;
   openLink: (link: string) => void;
   openRegister: () => void;
   movePage: (link: string) => void;
@@ -25,15 +27,19 @@ export interface SideMenuProps {
 export interface SideMenuAccountItemProps {
   selected: boolean;
   account: SideMenuAccountInfo;
+  focusedAccountId: string | null;
   changeAccount: (accountId: string) => void;
+  focusAccountId: (accountId: string | null) => void;
   moveGnoscan: (address: string) => void;
   moveAccountDetail: (accountId: string) => void;
 }
 
 export interface SideMenuAccountListProps {
   currentAccountId: string | null;
+  focusedAccountId: string | null;
   accounts: SideMenuAccountInfo[];
   changeAccount: (accountId: string) => void;
+  focusAccountId: (accountId: string | null) => void;
   moveGnoscan: (address: string) => void;
   moveAccountDetail: (accountId: string) => void;
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:
- Resize the decimal text in the side menu account balance for readability.
- Adjust the spacing between the balance and the symbol in components that show common balances.
- Change the event that exits the dropdown in the side menu to fire when the mouse is clicked.
- Add a button to navigate to the Reveal Seed Phrase page from the account details page.

