### PR TITLE
feat: add a injection method to get network information

### DIFF
--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -75,7 +75,7 @@
     "webpack-merge": "^5.10.0"
   },
   "dependencies": {
-    "@adena-wallet/sdk": "^0.0.1",
+    "@adena-wallet/sdk": "^0.0.2",
     "@gnolang/gno-js-client": "1.3.0",
     "@gnolang/tm2-js-client": "1.2.1",
     "@tanstack/react-query": "^4.36.1",

--- a/packages/adena-extension/src/inject.ts
+++ b/packages/adena-extension/src/inject.ts
@@ -1,4 +1,4 @@
-import { WalletResponse } from '@adena-wallet/sdk';
+import { AdenaWallet, WalletResponse } from '@adena-wallet/sdk';
 import manifest from '@public/manifest.json';
 
 import { EVENT_KEYS } from '@common/constants/event-key.constant';
@@ -10,6 +10,7 @@ import {
   AddNetworkResponse,
   DoContractResponse,
   GetAccountResponse,
+  GetNetworkResponse,
   SignTxResponse,
   SwitchNetworkResponse,
   TransactionParams,
@@ -36,6 +37,11 @@ const init = (): void => {
     async GetAccount(): Promise<GetAccountResponse> {
       const executor = new AdenaExecutor();
       const response = await executor.getAccount();
+      return response;
+    },
+    async GetNetwork(): Promise<GetNetworkResponse> {
+      const executor = new AdenaExecutor();
+      const response = await executor.getNetwork();
       return response;
     },
     async Sign(message: TransactionParams): Promise<WalletResponse<unknown>> {
@@ -75,7 +81,7 @@ const init = (): void => {
     },
   };
 
-  window.adena = adena;
+  window.adena = adena as unknown as AdenaWallet;
 };
 
 init();

--- a/packages/adena-extension/src/inject/executor/executor.ts
+++ b/packages/adena-extension/src/inject/executor/executor.ts
@@ -20,6 +20,7 @@ import {
   AddNetworkResponse,
   DoContractResponse,
   GetAccountResponse,
+  GetNetworkResponse,
   SignTxResponse,
   SwitchNetworkResponse,
   TransactionParams,
@@ -62,7 +63,7 @@ export class AdenaExecutor {
     const eventMessage = AdenaExecutor.createEventMessage(WalletResponseExecuteType.ADD_ESTABLISH, {
       name: name ?? 'Unknown',
     });
-    return this.sendEventMessage<boolean>(eventMessage);
+    return this.sendEventMessage<Record<string, never>>(eventMessage);
   };
 
   public doContract = (params: TransactionParams): Promise<DoContractResponse> => {
@@ -79,6 +80,11 @@ export class AdenaExecutor {
 
   public getAccount = (): Promise<GetAccountResponse> => {
     const eventMessage = AdenaExecutor.createEventMessage(WalletResponseExecuteType.GET_ACCOUNT);
+    return this.sendEventMessage(eventMessage);
+  };
+
+  public getNetwork = (): Promise<GetNetworkResponse> => {
+    const eventMessage = AdenaExecutor.createEventMessage(WalletResponseExecuteType.GET_NETWORK);
     return this.sendEventMessage(eventMessage);
   };
 

--- a/packages/adena-extension/src/inject/message/message-handler.ts
+++ b/packages/adena-extension/src/inject/message/message-handler.ts
@@ -82,6 +82,23 @@ export class MessageHandler {
             );
           });
         break;
+      case 'GET_NETWORK':
+        HandlerMethod.checkEstablished(message, sendResponse)
+          .then((isEstablished) => {
+            if (isEstablished) {
+              HandlerMethod.getNetwork(message, sendResponse);
+            }
+          })
+          .catch(() => {
+            sendResponse(
+              InjectionMessageInstance.failure(
+                WalletResponseFailureType.UNRESOLVED_TRANSACTION_EXISTS,
+                message,
+                message.key,
+              ),
+            );
+          });
+        break;
       case 'ADD_ESTABLISH':
         HandlerMethod.addEstablish(message, sendResponse);
         break;

--- a/packages/adena-extension/src/inject/message/methods/wallet.ts
+++ b/packages/adena-extension/src/inject/message/methods/wallet.ts
@@ -56,6 +56,54 @@ export const getAccount = async (
   }
 };
 
+export const getNetwork = async (
+  requestData: InjectionMessage,
+  sendResponse: (message: any) => void,
+): Promise<void> => {
+  try {
+    const core = new InjectCore();
+
+    const isLocked = await core.walletService.isLocked();
+    if (isLocked) {
+      sendResponse(
+        InjectionMessageInstance.failure(
+          WalletResponseFailureType.WALLET_LOCKED,
+          {},
+          requestData.key,
+        ),
+      );
+      return;
+    }
+
+    const currentAccountAddress = await core.getCurrentAddress();
+    const network = await core.getCurrentNetwork();
+    if (!currentAccountAddress || !network) {
+      sendResponse(
+        InjectionMessageInstance.failure(WalletResponseFailureType.NO_ACCOUNT, {}, requestData.key),
+      );
+      return;
+    }
+
+    sendResponse(
+      InjectionMessageInstance.success(
+        WalletResponseSuccessType.GET_NETWORK_SUCCESS,
+        {
+          chainId: network.chainId,
+          networkName: network.networkName,
+          addressPrefix: network.addressPrefix,
+          rpcUrl: network.rpcUrl,
+          indexerUrl: network.indexerUrl || null,
+        },
+        requestData.key,
+      ),
+    );
+  } catch (error) {
+    sendResponse(
+      InjectionMessageInstance.failure(WalletResponseFailureType.NO_ACCOUNT, {}, requestData.key),
+    );
+  }
+};
+
 export const addEstablish = async (
   message: InjectionMessage,
   sendResponse: (message: any) => void,

--- a/packages/adena-extension/src/inject/types/general.ts
+++ b/packages/adena-extension/src/inject/types/general.ts
@@ -5,7 +5,7 @@ export enum AddEstablishResponseType {
   ALREADY_CONNECTED = 'ALREADY_CONNECTED',
 }
 
-export type AddEstablishResponse = AdenaResponse<boolean>;
+export type AddEstablishResponse = AdenaResponse<Record<string, never>>;
 
 export type AdenaAddEstablish = (name: string) => Promise<AddEstablishResponse>;
 

--- a/packages/adena-extension/src/inject/types/network.ts
+++ b/packages/adena-extension/src/inject/types/network.ts
@@ -23,3 +23,13 @@ interface SwitchNetworkResponseData {
 export type SwitchNetworkResponse = AdenaResponse<SwitchNetworkResponseData>;
 
 export type AdenaSwitchNetwork = (chainId: string) => Promise<SwitchNetworkResponse>;
+
+interface GetNetworkResponseData {
+  chainId: string;
+  networkName: string;
+  addressPrefix: string;
+  rpcUrl: string;
+  indexerUrl: string | null;
+}
+
+export type GetNetworkResponse = AdenaResponse<GetNetworkResponseData>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,9 +5,9 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@adena-wallet/sdk@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@adena-wallet/sdk@npm:0.0.1"
+"@adena-wallet/sdk@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "@adena-wallet/sdk@npm:0.0.2"
   dependencies:
     "@gnolang/gno-js-client": ^1.3.0
     "@gnolang/tm2-js-client": ^1.2.1
@@ -15,7 +15,7 @@ __metadata:
     "@web3auth/base-provider": ^8.12.4
     "@web3auth/no-modal": ^8.12.4
     "@web3auth/openlogin-adapter": ^8.12.4
-  checksum: 2432984b2310cf96af017fe53be4631b92f672021f6d74fc8179e8eeeec06f0a1b15d668261c79f43f0575be1a820c6675440c6ed6c75c98c0098eb7dacd5f6d
+  checksum: 68996ed316e9f9dc30c16577bc7721407e73c6ba21048a89b7302597267e3beb2775cc4678aa5aa49cbc9ebbeb7e03a386c455efe2d9d6462a95802aa4dc99d1
   languageName: node
   linkType: hard
 
@@ -7878,7 +7878,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "adena-extension@workspace:packages/adena-extension"
   dependencies:
-    "@adena-wallet/sdk": ^0.0.1
+    "@adena-wallet/sdk": ^0.0.2
     "@babel/core": ^7.23.9
     "@babel/preset-env": ^7.23.9
     "@babel/preset-react": ^7.23.3


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:

Add a method to inject that retrieves the current network information.

Users can retrieve network information by executing `adena.GetNetwork()`.

Example response.
```
{
    “status": “success”,
    “data": {
        “chainId": “test4”,
        “networkName": “Testnet 4”,
        “addressPrefix": “g”,
        “rpcUrl": “https://rpc.test4.gno.land:443”,
        “indexerUrl": “https://test4.indexer.onbloc.xyz”
    },
    “code": 0,
    “message": “Get Network Information.”,
    “type": “GET_NETWORK”
}
```