### PR TITLE
fix: change query filter options for retrieving failed transactions

### DIFF
--- a/packages/adena-extension/src/repositories/transaction/transaction-history.queries.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history.queries.ts
@@ -6,7 +6,6 @@ export const makeAccountTransactionsQuery = (
   {
     transactions(
       filter: {
-        success: true
         messages: [
           {
             type_url: send
@@ -125,7 +124,6 @@ export const makeNativeTransactionsQuery = (
   {
     transactions(
       filter: {
-        success: true
         messages: [
           {
             type_url: send
@@ -192,7 +190,6 @@ export const makeGRC20TransferTransactionsQuery = (
   {
     transactions(
       filter: {
-        success: true
         messages: [
           {
             type_url: exec


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

Fixes an issue where failed transactions are not shown in the Adena transaction history.
- Remove the `success` filter option from indexer queries that look up a list of transactions.

Related issues: https://github.com/onbloc/adena-wallet/issues/626