### PR TITLE
fix: handle exceptions for the first hash value of a transaction

### DIFF
--- a/packages/adena-extension/src/hooks/wallet/token-details/use-token-transactions-page.ts
+++ b/packages/adena-extension/src/hooks/wallet/token-details/use-token-transactions-page.ts
@@ -78,8 +78,16 @@ export const useTokenTransactionsPage = (
     return allTransactions.pages.flatMap((page) => page?.transactions || []);
   }, [allTransactions]);
 
+  const firstTransactionHash = useMemo(() => {
+    if (!transactions || transactions.length === 0) {
+      return '';
+    }
+
+    return transactions[0]?.hash;
+  }, [transactions]);
+
   const { data, isFetched, status, isLoading, isFetching } = useMakeTransactionsWithTime(
-    `token-details/page/history/${currentNetwork.chainId}/${transactions?.[0].hash}/${tokenPath}`,
+    `token-details/page/history/${currentNetwork.chainId}/${firstTransactionHash}/${tokenPath}`,
     transactions,
   );
 

--- a/packages/adena-extension/src/hooks/wallet/transaction-history/use-transaction-history-page.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-history/use-transaction-history-page.ts
@@ -83,8 +83,16 @@ export const useTransactionHistoryPage = ({
     );
   }, [allTransactions?.pages]);
 
+  const firstTransactionHash = useMemo(() => {
+    if (!transactions || transactions.length === 0) {
+      return '';
+    }
+
+    return transactions[0]?.hash;
+  }, [transactions]);
+
   const { data, isFetched, status, isLoading, isFetching } = useMakeTransactionsWithTime(
-    `history/page/all/${currentNetwork.chainId}/${transactions?.[0].hash}`,
+    `history/page/all/${currentNetwork.chainId}/${firstTransactionHash}`,
     transactions,
   );
 

--- a/packages/adena-extension/src/hooks/wallet/transaction-history/use-transaction-history.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-history/use-transaction-history.ts
@@ -72,8 +72,16 @@ export const useTransactionHistory = ({
     return allTransactions.slice(0, blockIndex || 0);
   }, [allTransactions, blockIndex]);
 
+  const firstTransactionHash = useMemo(() => {
+    if (!transactions || transactions.length === 0) {
+      return '';
+    }
+
+    return transactions[0]?.hash;
+  }, [transactions]);
+
   const { data, isFetched, status, isLoading, isFetching } = useMakeTransactionsWithTime(
-    `history/common/all/${currentNetwork.chainId}/${transactions?.[0].hash}`,
+    `history/common/all/${currentNetwork.chainId}/${firstTransactionHash}`,
     transactions,
   );
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:
Occurs when trying to access the first transaction hash value used as a key value when there is no historical data.
- Adds guarding when accessing transaction hash values.