### PR TITLE
fix: display grc721 token uri

### DIFF
--- a/packages/adena-extension/src/components/molecules/nft-card-image/nft-card-image.tsx
+++ b/packages/adena-extension/src/components/molecules/nft-card-image/nft-card-image.tsx
@@ -12,11 +12,6 @@ export interface NFTCardImageProps {
 
 const NFTCardImage: React.FC<NFTCardImageProps> = ({ isFetched, image, hasBadge = false }) => {
   const [hasError, setHasError] = useState(false);
-  const [loaded, setLoaded] = useState(false);
-
-  const handleLoad = (): void => {
-    setLoaded(true);
-  };
 
   const handleError = (): void => {
     setHasError(true);
@@ -30,7 +25,7 @@ const NFTCardImage: React.FC<NFTCardImageProps> = ({ isFetched, image, hasBadge 
     );
   }
 
-  if (!image || !loaded || hasError) {
+  if (!image || hasError) {
     return (
       <NFTCardImageWrapper className='empty'>
         <img className='empty-image' src={IconEmptyImage} alt='empty image' />
@@ -42,8 +37,7 @@ const NFTCardImage: React.FC<NFTCardImageProps> = ({ isFetched, image, hasBadge 
     <NFTCardImageWrapper>
       <img
         className='nft-image'
-        src={image}
-        onLoad={handleLoad}
+        src={image || IconEmptyImage}
         onError={handleError}
         alt='nft image'
       />


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

Fixes an issue that prevented the GRC721 card image from displaying.