### PR TITLE
fix: prevent loading when the network fails

### DIFF
--- a/packages/adena-extension/src/router/popup/loading-main.tsx
+++ b/packages/adena-extension/src/router/popup/loading-main.tsx
@@ -59,15 +59,16 @@ const LoadingMain = (): ReactElement => {
     if (state === 'CREATE' || state === 'LOGIN') {
       return false;
     }
-    if (isLoadingImage) {
-      return true;
-    }
     if (state === 'FINISH') {
       // If `failedNetwork` is null, it is loading.
       if (failedNetwork) {
         return false;
       }
       if (failedNetwork === false) {
+        if (isLoadingImage) {
+          return true;
+        }
+
         if (currentBalances.length > 0) {
           return false;
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->

- bug

### What this PR does:

- Prevent loading when the network fails.
- Change the exposure conditions for the loading screen.

