### PR TITLE
fix: [ADN-649] wrong seed when exporting via sidebar

### DIFF
--- a/packages/adena-extension/src/hooks/web/wallet-export/use-wallet-export-screen.ts
+++ b/packages/adena-extension/src/hooks/web/wallet-export/use-wallet-export-screen.ts
@@ -100,6 +100,7 @@ const useWalletExportScreen = (): UseWalletExportReturn => {
         setExportType('PRIVATE_KEY');
         break;
       case 'SEED_PHRASE':
+        setExportAccountId(exportAccountId);
         setExportType('SEED_PHRASE');
         break;
       default:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
- bug

### What this PR does:
The desired account export did not occur when the action was run.