### PR TITLE
fix: apply responsive components to the `Enter Your Password` screen

### DIFF
--- a/packages/adena-extension/src/pages/popup/wallet/approve-login/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-login/index.tsx
@@ -8,7 +8,7 @@ import styled, { useTheme } from 'styled-components';
 import { PasswordValidationError } from '@common/errors';
 import { decodeParameter, parseParameters } from '@common/utils/client-utils';
 import { validateEmptyPassword } from '@common/validation';
-import { Button, DefaultInput, ErrorText, Text } from '@components/atoms';
+import { Button, DefaultInput, Text } from '@components/atoms';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { useLoadAccounts } from '@hooks/use-load-accounts';
@@ -23,9 +23,9 @@ import LoadingApproveTransaction from './loading-approve-transaction';
 const text = 'Enter\nYour Password';
 const Wrapper = styled.div`
   ${mixins.flex({ justify: 'flex-start' })};
-  max-width: 380px;
-  min-height: 514px;
-  padding: 29px 20px 24px;
+  max-width: 100%;
+  min-height: 100%;
+  padding: 29px 20px 72px;
 `;
 
 export const ApproveLogin = (): JSX.Element => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- style

### What this PR does:
- Apply a responsive UI on the password entry page.
