### PR TITLE
fix: check the source when handling events

### DIFF
--- a/packages/adena-extension/src/content.ts
+++ b/packages/adena-extension/src/content.ts
@@ -21,21 +21,24 @@ const loadScript = (): void => {
 };
 
 const initListener = (): void => {
-  window.addEventListener(
-    'message',
-    (event) => {
-      try {
-        if (event.data?.status === 'request') {
-          sendMessage(event);
-        } else {
-          return event.data;
-        }
-      } catch (e) {
-        console.error(e);
+  const listener = (event: MessageEvent): void => {
+    if (event.origin !== window.location.origin) {
+      console.warn(`Untrusted origin: ${event.origin}`);
+      return;
+    }
+
+    try {
+      if (event.data?.status === 'request') {
+        sendMessage(event);
+      } else {
+        return event.data;
       }
-    },
-    false,
-  );
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  window.addEventListener('message', listener, false);
 };
 
 const initExtensionListener = (): void => {

--- a/packages/adena-extension/src/content.ts
+++ b/packages/adena-extension/src/content.ts
@@ -5,7 +5,9 @@ const sendMessage = (event: MessageEvent): void => {
   const message = event.data;
   chrome.runtime.sendMessage(message, (response) => {
     Promise.resolve(response).then((result) => {
-      event.source?.postMessage(result);
+      event.source?.postMessage(result, {
+        targetOrigin: event.origin,
+      });
     });
     return true;
   });

--- a/packages/adena-extension/src/inject/executor/executor.ts
+++ b/packages/adena-extension/src/inject/executor/executor.ts
@@ -169,7 +169,8 @@ export class AdenaExecutor {
       hostname: window.location.hostname,
       key: this.eventKey,
     };
-    window.postMessage(this.eventMessage, '*');
+
+    window.postMessage(this.eventMessage, window.location.origin);
     this.messages[this.eventKey] = {
       request: this.eventMessage,
       response: undefined,

--- a/packages/adena-extension/src/inject/executor/executor.ts
+++ b/packages/adena-extension/src/inject/executor/executor.ts
@@ -201,6 +201,11 @@ export class AdenaExecutor {
   };
 
   private messageHandler = (event: MessageEvent<InjectionMessage>): void => {
+    if (event.origin !== window.location.origin) {
+      console.warn(`Untrusted origin: ${event.origin}`);
+      return;
+    }
+
     const eventData = event.data;
     if (eventData.status) {
       const { key, status, data, code, message, type } = eventData;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->

- fix

### What this PR does:

- Restrict event messages to be delivered only to the source on the current page.
The trusted domains that can then execute Adena commands are managed by an in-service feature in Adena.

- Check the event source address in the event message listener function.
- When sending an event message, specify the target origin.
