### PR TITLE
feat: improve sensitive data exposure page

### DIFF
--- a/packages/adena-extension/src/pages/web/wallet-create-screen/get-mnemonic-step.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-create-screen/get-mnemonic-step.tsx
@@ -1,13 +1,13 @@
-import { ReactElement, useState } from 'react';
+import { ReactElement, useMemo, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import IconWarning from '@assets/web/warning.svg';
 
 import { Row, View, WebButton, WebCheckBox, WebImg, WebText } from '@components/atoms';
+import { WebCopyButton } from '@components/atoms/web-copy-button';
+import { WebHoldButton } from '@components/atoms/web-hold-button';
 import { WebSeedBox } from '@components/molecules';
 import { UseWalletCreateReturn } from '@hooks/web/use-wallet-create-screen';
-import { WebHoldButton } from '@components/atoms/web-hold-button';
-import { WebCopyButton } from '@components/atoms/web-copy-button';
 
 const StyledContainer = styled(View)`
   width: 100%;
@@ -36,6 +36,18 @@ const GetMnemonicStep = ({
   const [ableToReveal, setAbleToReveal] = useState(false);
   const [agreeAbleToReveals, setAgreeAbleToReveals] = useState(false);
   const [checkSavedMnemonic, setCheckSavedMnemonic] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const warningCopiedMessage = useMemo(() => {
+    if (!copied) {
+      return '';
+    }
+    return 'You have copied sensitive info. Make sure you do not paste it in public or shared environments, and clear your clipboard as soon as you’ve used it.';
+  }, [copied]);
+
+  const onCopy = (): void => {
+    setCopied(true);
+  };
 
   return (
     <StyledContainer>
@@ -47,6 +59,15 @@ const GetMnemonicStep = ({
             This phrase is the only way to recover this wallet. DO NOT share it with anyone.
           </WebText>
         </StyledWarnBox>
+
+        {warningCopiedMessage && (
+          <StyledWarnBox>
+            <WebImg src={IconWarning} size={20} />
+            <WebText type='body6' color={theme.webWarning._100}>
+              {warningCopiedMessage}
+            </WebText>
+          </StyledWarnBox>
+        )}
       </StyledMessageBox>
 
       <View style={{ width: '100%', gap: 16 }}>
@@ -56,7 +77,7 @@ const GetMnemonicStep = ({
           <>
             <Row style={{ justifyContent: 'center', columnGap: 12 }}>
               <WebHoldButton onFinishHold={(response): void => setShowBlur(!response)} />
-              <WebCopyButton width={80} copyText={seeds} />
+              <WebCopyButton width={80} copyText={seeds} onCopy={onCopy} />
             </Row>
             <Row style={{ columnGap: 8, alignItems: 'center', marginTop: 8 }}>
               <WebCheckBox

--- a/packages/adena-extension/src/pages/web/wallet-export-screen/result.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-export-screen/result.tsx
@@ -48,6 +48,7 @@ const WalletExportResult: React.FC<WalletExportResultProps> = ({ exportType, exp
   const theme = useTheme();
   const [blur, setBlur] = useState(true);
   const [initializedDone, setInitializedDone] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const title = useMemo(() => {
     if (exportType === 'PRIVATE_KEY') {
@@ -62,6 +63,13 @@ const WalletExportResult: React.FC<WalletExportResultProps> = ({ exportType, exp
     }
     return 'Your seed phrase is the only way to recover your wallet. Keep it somewhere safe and secret.';
   }, [exportType]);
+
+  const warningCopiedMessage = useMemo(() => {
+    if (!copied) {
+      return '';
+    }
+    return 'You have copied sensitive info. Make sure you do not paste it in public or shared environments, and clear your clipboard as soon as you’ve used it.';
+  }, [copied]);
 
   const seeds = useMemo((): string[] => {
     if (exportType !== 'SEED_PHRASE' || !exportData) {
@@ -97,6 +105,10 @@ const WalletExportResult: React.FC<WalletExportResultProps> = ({ exportType, exp
       });
   };
 
+  const onCopy = (): void => {
+    setCopied(true);
+  };
+
   return (
     <StyledContainer>
       <StyledMessageBox>
@@ -107,6 +119,15 @@ const WalletExportResult: React.FC<WalletExportResultProps> = ({ exportType, exp
             {warningMessage}
           </WebText>
         </StyledWarnBox>
+
+        {warningCopiedMessage && (
+          <StyledWarnBox center={exportType === 'SEED_PHRASE'}>
+            <WebImg src={IconWarning} size={20} />
+            <WebText type='body6' color={theme.webWarning._100}>
+              {warningCopiedMessage}
+            </WebText>
+          </StyledWarnBox>
+        )}
       </StyledMessageBox>
 
       <StyledInputBox>
@@ -116,7 +137,7 @@ const WalletExportResult: React.FC<WalletExportResultProps> = ({ exportType, exp
         )}
         <Row style={{ gap: 16, justifyContent: 'center' }}>
           <WebHoldButton onFinishHold={onFinishHold} />
-          <WebCopyButton width={80} copyText={exportData || ''} />
+          <WebCopyButton width={80} copyText={exportData || ''} onCopy={onCopy} />
         </Row>
       </StyledInputBox>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:
- Shows an error message when copying a user's mnemonic and private key to the clipboard.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/58d7c338-ffcb-458e-8e6d-742bf2fd8e93" />

- Sets the default timeout to clear the clipboard when copying the clipboard. (30 seconds)

