### PR TITLE
fix: add GraphQL introspection guard

### DIFF
--- a/packages/adena-extension/src/repositories/common/token.ts
+++ b/packages/adena-extension/src/repositories/common/token.ts
@@ -795,6 +795,12 @@ export class TokenRepository implements ITokenRepository {
     query: string,
     header?: { [key in string]: number } | null,
   ): Promise<T | null> => {
+    if (query.includes('__schema') || query.includes('__typename')) {
+      console.warn('GraphQL Introspection queries are blocked.');
+
+      return Promise.resolve(null);
+    }
+
     return axiosInstance
       .post<T>(
         url,

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
@@ -194,7 +194,7 @@ export function mapVMTransaction(
   const firstMessage = getDefaultMessage(tx.messages);
 
   if (tx.messages.length > 1) {
-    const isAddPackage = firstMessage.value?.__typename === 'MsgAddPackage';
+    const isAddPackage = isAddPackageValue(firstMessage.value);
     const messageValue: any = firstMessage.value;
     return {
       hash: tx.hash,
@@ -222,7 +222,7 @@ export function mapVMTransaction(
     };
   }
 
-  if (firstMessage.value.__typename === 'MsgAddPackage') {
+  if (firstMessage.value === 'MsgAddPackage') {
     return {
       hash: tx.hash,
       height: tx.block_height,
@@ -245,7 +245,7 @@ export function mapVMTransaction(
     };
   }
 
-  if (firstMessage.value.__typename === 'MsgCall') {
+  if (isMsgCallValue(firstMessage.value)) {
     const messageValue = firstMessage.value as MsgCallValue;
     const isTransfer = messageValue.func === 'Transfer';
     const isTransferGRC721 = messageValue.func === 'TransferFrom';
@@ -351,4 +351,14 @@ export function mapVMTransaction(
       denom: `${tx.gas_fee.denom}`,
     },
   };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isAddPackageValue(value: any): value is AddPackageValue {
+  return value.creator !== undefined && value.package !== undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isMsgCallValue(value: any): value is MsgCallValue {
+  return value.caller !== undefined && value.pkg_path !== undefined;
 }

--- a/packages/adena-extension/src/repositories/transaction/response/transaction-history-query-response.ts
+++ b/packages/adena-extension/src/repositories/transaction/response/transaction-history-query-response.ts
@@ -24,21 +24,18 @@ export interface Amount {
 }
 
 export interface BankSendValue {
-  __typename: string;
   from_address: string;
   to_address: string;
   amount: string;
 }
 
 export interface MsgRunValue {
-  __typename: string;
   caller?: string;
   send?: string;
   package?: Package;
 }
 
 export interface MsgCallValue {
-  __typename: string;
   caller?: string;
   send?: string;
   pkg_path?: string;
@@ -47,7 +44,6 @@ export interface MsgCallValue {
 }
 
 export interface AddPackageValue {
-  __typename: string;
   creator?: string;
   deposit?: string;
   package?: Package;
@@ -63,7 +59,6 @@ export interface Package {
 }
 
 export interface Event {
-  __typename: string;
   type: string;
   pkg_path: string;
   func: string;

--- a/packages/adena-extension/src/repositories/transaction/transaction-history.queries.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history.queries.ts
@@ -81,7 +81,6 @@ export const makeAccountTransactionsQuery = (
           messages {
             typeUrl
             value {
-              __typename
               ... on BankMsgSend {
                 from_address
                 to_address
@@ -167,7 +166,6 @@ export const makeNativeTransactionsQuery = (
           messages {
             typeUrl
             value {
-              __typename
               ... on BankMsgSend {
                 from_address
                 to_address
@@ -237,7 +235,6 @@ export const makeGRC20TransferTransactionsQuery = (
           messages {
             typeUrl
             value {
-              __typename
               ...on MsgCall {
                 caller
                 send
@@ -281,7 +278,6 @@ export const makeGRC20ReceivedTransactionsByAddressQuery = (address: string): st
     }
     messages {
       value {
-        __typename
         ...on MsgCall {
           caller
           send
@@ -328,7 +324,6 @@ export const makeVMTransactionsByAddressQuery = (address: string): string => `
     }
     messages {
       value {
-        __typename
         ... on BankMsgSend {
           from_address
           to_address
@@ -384,7 +379,6 @@ export const makeNativeTokenSendTransactionsByAddressQuery = (address: string): 
     }
     messages {
       value {
-        __typename
         ...on BankMsgSend{
           from_address
           to_address
@@ -423,7 +417,6 @@ export const makeNativeTokenReceivedTransactionsByAddressQuery = (address: strin
     }
     messages {
       value {
-        __typename
         ...on BankMsgSend{
           from_address
           to_address
@@ -467,7 +460,6 @@ export const makeGRC20ReceivedTransactionsByAddressQueryByPackagePath = (
     }
     messages {
       value {
-        __typename
         ...on MsgCall {
           caller
           send
@@ -512,7 +504,6 @@ export const makeGRC20SendTransactionsByAddressQueryByPackagePath = (
     }
     messages {
       value {
-        __typename
         ... on MsgCall {
           caller
           send


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- fix

### What this PR does:
- When calling GraphQL, limit queries to schema and type names.
- Adena currently uses the GraphQL API from the [tx-indexer](https://github.com/gnolang/tx-indexer) open source project, and the introspection setting can be added to the project.