### PR TITLE
fix(cherry-pick): handle dynamic gas prices

### DIFF
--- a/packages/adena-extension/src/common/constants/gas.constant.ts
+++ b/packages/adena-extension/src/common/constants/gas.constant.ts
@@ -5,8 +5,8 @@ import { NetworkFeeSettingType } from '@types';
 export const MINIMUM_GAS_PRICE = 0.001 as const;
 
 // Adena default gas used
-// When the gas used is not set, the default value is 100,000
-export const DEFAULT_GAS_USED = 100_000 as const;
+// When the gas used is not set, the default value is 10,000,000
+export const DEFAULT_GAS_USED = 10_000_000 as const;
 
 // Default gas price step
 // Slow = 0.001, Average = 0.0025, Fast = 0.004
@@ -16,8 +16,14 @@ export const DEFAULT_GAS_PRICE_STEP: Record<NetworkFeeSettingType, number> = {
   SLOW: 0.001,
 } as const;
 
+export const DEFAULT_GAS_PRICE_RATE: Record<NetworkFeeSettingType, number> = {
+  FAST: 4,
+  AVERAGE: 2.5,
+  SLOW: 1,
+} as const;
+
 // Default gas adjustment
-export const DEFAULT_GAS_ADJUSTMENT = 1.6 as const;
+export const DEFAULT_GAS_ADJUSTMENT = 1 as const;
 
 // Gas fee safety margin
 // This is gas wanted safety margin

--- a/packages/adena-extension/src/common/provider/adena/adena-provider.tsx
+++ b/packages/adena-extension/src/common/provider/adena/adena-provider.tsx
@@ -42,7 +42,7 @@ export interface AdenaContextProps {
   transactionService: TransactionService;
   transactionHistoryService: TransactionHistoryService;
   faucetService: FaucetService;
-  transactionGasService: TransactionGasService;
+  transactionGasService: TransactionGasService | null;
 }
 
 export const AdenaContext = createContext<AdenaContextProps | null>(null);
@@ -97,10 +97,13 @@ export const AdenaProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chil
     return new TransactionHistoryRepository(axiosInstance, currentNetwork);
   }, [axiosInstance, currentNetwork]);
 
-  const transactionGasRepository = useMemo(
-    () => new TransactionGasRepository(gnoProvider, axiosInstance, currentNetwork),
-    [gnoProvider, transactionHistoryRepository, currentNetwork],
-  );
+  const transactionGasRepository = useMemo(() => {
+    if (!currentNetwork) {
+      return null;
+    }
+
+    return new TransactionGasRepository(gnoProvider, axiosInstance, currentNetwork);
+  }, [gnoProvider, transactionHistoryRepository, currentNetwork]);
 
   const chainService = useMemo(() => new ChainService(chainRepository), [chainRepository]);
 
@@ -137,10 +140,13 @@ export const AdenaProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chil
     [gnoProvider, transactionHistoryRepository],
   );
 
-  const transactionGasService = useMemo(
-    () => new TransactionGasService(transactionGasRepository),
-    [transactionGasRepository],
-  );
+  const transactionGasService = useMemo(() => {
+    if (!transactionGasRepository) {
+      return null;
+    }
+
+    return new TransactionGasService(transactionGasRepository);
+  }, [transactionGasRepository]);
 
   const faucetRepository = useMemo(() => new FaucetRepository(axios), [axiosInstance]);
 

--- a/packages/adena-extension/src/common/provider/gno/gno-provider.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.ts
@@ -175,6 +175,8 @@ export class GnoProvider extends GnoJSONRPCProvider {
     }
 
     const simulateResult = parseProto(responseValue, ResponseDeliverTx.decode);
+    console.info('simulateResult', simulateResult);
+
     if (simulateResult.responseBase?.error) {
       throw new Error(simulateResult.responseBase.error.typeUrl);
     }

--- a/packages/adena-extension/src/common/utils/fetch-utils.ts
+++ b/packages/adena-extension/src/common/utils/fetch-utils.ts
@@ -8,6 +8,13 @@ export interface RPCRequest {
   params: any[];
 }
 
+export interface IndexerRPCRequest {
+  id: number;
+  jsonrpc: string;
+  method: string;
+  params: any[];
+}
+
 export async function fetchHealth(url: string): Promise<{ url: string; healthy: boolean }> {
   const healthy = await axios
     .get(url + '/health', { timeout: 5000 })
@@ -34,4 +41,25 @@ export function makeRPCRequest({
     method: method,
     params: params || [],
   };
+}
+
+export function makeIndexerRPCRequest({
+  id,
+  method,
+  params,
+}: {
+  id?: number;
+  method: string;
+  params?: any[];
+}): IndexerRPCRequest {
+  return {
+    id: id || makeRandId(),
+    jsonrpc: '2.0',
+    method: method,
+    params: params || [],
+  };
+}
+
+function makeRandId(): number {
+  return Math.floor(Math.random() * 10 ** 16);
 }

--- a/packages/adena-extension/src/components/atoms/skeleton-box/index.tsx
+++ b/packages/adena-extension/src/components/atoms/skeleton-box/index.tsx
@@ -29,7 +29,7 @@ export const SkeletonBoxStyle = styled.div`
     right: 0;
     width: 100%;
     height: 100%;
-    z-index: 99;
+    z-index: 8;
     background: linear-gradient(
       270deg,
       rgba(82, 82, 107, 0) 0%,

--- a/packages/adena-extension/src/components/molecules/approve-transaction/approve-transaction.spec.tsx
+++ b/packages/adena-extension/src/components/molecules/approve-transaction/approve-transaction.spec.tsx
@@ -50,8 +50,10 @@ describe('ApproveTransaction Component', () => {
         return;
       },
       useNetworkFeeReturn: {
+        isLoading: false,
         isFetchedEstimateGasInfo: true,
         isFetchedPriceTiers: true,
+        isSimulateError: false,
         currentGasInfo: {
           gasFee: 0.00000048,
           gasPrice: 0.00000000048,

--- a/packages/adena-extension/src/components/molecules/approve-transaction/approve-transaction.styles.ts
+++ b/packages/adena-extension/src/components/molecules/approve-transaction/approve-transaction.styles.ts
@@ -133,7 +133,6 @@ export const ApproveTransactionWrapper = styled.div<{ isErrorNetworkFee: boolean
     padding: 0 16px;
     ${fonts.captionReg};
     height: 14px;
-    margin-top: -5px;
     margin-bottom: 10px;
     color: ${getTheme('red', '_5')};
   }

--- a/packages/adena-extension/src/components/molecules/bottom-fixed-loading-button-group/index.tsx
+++ b/packages/adena-extension/src/components/molecules/bottom-fixed-loading-button-group/index.tsx
@@ -95,7 +95,7 @@ const ButtonWrap = styled.div<{ filled?: boolean }>`
     filled && 'box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.4);'}
   ${({ filled }): false | 'align-items: center;' | undefined => filled && 'align-items: center;'}
   background-color: ${({ filled, theme }): string => (filled ? theme.neutral._8 : 'transparent')};
-  z-index: 1;
+  z-index: 9;
 
   & > button {
     margin-right: 10px;

--- a/packages/adena-extension/src/components/molecules/network-fee-custom-input/network-fee-custom-input.tsx
+++ b/packages/adena-extension/src/components/molecules/network-fee-custom-input/network-fee-custom-input.tsx
@@ -24,7 +24,7 @@ const NetworkFeeCustomInput: React.FC<NetworkFeeCustomInputProps> = ({ value, ch
 
   return (
     <NetworkFeeCustomInputContainer>
-      <span className='description'>{'Gas Adjustment'}</span>
+      <span className='description'>{'Network Fee Multiplier'}</span>
 
       <NetworkFeeCustomInputWrapper>
         <input

--- a/packages/adena-extension/src/components/molecules/network-fee/network-fee.styles.ts
+++ b/packages/adena-extension/src/components/molecules/network-fee/network-fee.styles.ts
@@ -1,3 +1,4 @@
+import { SkeletonBoxStyle } from '@components/atoms';
 import mixins from '@styles/mixins';
 import { fonts, getTheme } from '@styles/theme';
 import styled from 'styled-components';
@@ -42,4 +43,11 @@ export const NetworkFeeWrapper = styled.div<{ isError?: boolean }>`
       height: 16px;
     }
   }
+`;
+
+export const NetworkFeeItemSkeletonBox = styled(SkeletonBoxStyle)`
+  ${mixins.flex({ align: 'flex-start' })};
+  width: 55px;
+  height: 14px;
+  align-self: center;
 `;

--- a/packages/adena-extension/src/components/molecules/network-fee/network-fee.tsx
+++ b/packages/adena-extension/src/components/molecules/network-fee/network-fee.tsx
@@ -1,12 +1,17 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import IconRight from '@assets/icon-right';
 import { TokenBalance } from '@components/molecules';
-import { NetworkFeeContainer, NetworkFeeWrapper } from './network-fee.styles';
+import {
+  NetworkFeeContainer,
+  NetworkFeeItemSkeletonBox,
+  NetworkFeeWrapper,
+} from './network-fee.styles';
 
 export interface NetworkFeeProps {
   value: string;
   denom: string;
+  isLoading?: boolean;
   isError?: boolean;
   errorMessage?: string;
   onClickSetting?: () => void;
@@ -15,17 +20,22 @@ export interface NetworkFeeProps {
 const NetworkFee: React.FC<NetworkFeeProps> = ({
   value,
   denom,
+  isLoading = false,
   isError,
   errorMessage,
   onClickSetting,
 }) => {
   const hasSetting = !!onClickSetting;
 
-  const isEmptyValue = value === '' || denom === '';
+  const isEmptyValue = value === '';
 
-  const hasNetworkFee = !!Number(value) && !!denom;
+  const hasError = useMemo(() => {
+    if (isLoading) {
+      return false;
+    }
 
-  const hasError = isError || !hasNetworkFee;
+    return isError || !!errorMessage;
+  }, [isError, errorMessage]);
 
   return (
     <NetworkFeeContainer>
@@ -33,19 +43,9 @@ const NetworkFee: React.FC<NetworkFeeProps> = ({
         <span className='key'>{'Network Fee'}</span>
 
         <div className='network-fee-amount-wrapper'>
-          {hasNetworkFee ? (
-            <TokenBalance
-              value={value}
-              denom={denom}
-              fontStyleKey='body2Reg'
-              minimumFontSize='11px'
-              orientation='HORIZONTAL'
-            />
-          ) : (
-            <span className='value'>{'-'}</span>
-          )}
+          <NetworkFeeAmount value={value} denom={denom} isLoading={isLoading} />
 
-          {hasSetting && (
+          {hasSetting && !isLoading && (
             <button className='setting-button' onClick={onClickSetting}>
               <IconRight />
             </button>
@@ -55,6 +55,32 @@ const NetworkFee: React.FC<NetworkFeeProps> = ({
 
       {hasError && !isEmptyValue && <span className='error-message'>{errorMessage}</span>}
     </NetworkFeeContainer>
+  );
+};
+
+const NetworkFeeAmount: React.FC<{
+  value: string;
+  denom: string;
+  isLoading: boolean;
+}> = ({ value, denom, isLoading }) => {
+  const hasNetworkFee = !!Number(value) && !!denom;
+
+  if (isLoading) {
+    return <NetworkFeeItemSkeletonBox />;
+  }
+
+  if (!hasNetworkFee) {
+    return <span className='value'>{'-'}</span>;
+  }
+
+  return (
+    <TokenBalance
+      value={value}
+      denom={denom}
+      fontStyleKey='body2Reg'
+      minimumFontSize='11px'
+      orientation='HORIZONTAL'
+    />
   );
 };
 

--- a/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary/transfer-summary.styles.ts
+++ b/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary/transfer-summary.styles.ts
@@ -69,6 +69,12 @@ export const TransferSummaryWrapper = styled.div`
         &:hover {
           background-color: ${getTheme('primary', '_7')};
         }
+
+        &.disabled {
+          background-color: ${getTheme('primary', '_9')};
+          color: ${getTheme('neutral', '_5')};
+          cursor: default;
+        }
       }
     }
   }

--- a/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary/transfer-summary.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary/transfer-summary.tsx
@@ -20,6 +20,7 @@ export interface TransferSummaryProps {
   networkFee: NetworkFeeType | null;
   memo: string;
   isErrorNetworkFee?: boolean;
+  isLoadingNetworkFee?: boolean;
   onClickBack: () => void;
   onClickCancel: () => void;
   onClickSend: () => void;
@@ -34,6 +35,7 @@ const TransferSummary: React.FC<TransferSummaryProps> = ({
   networkFee,
   memo,
   isErrorNetworkFee,
+  isLoadingNetworkFee,
   onClickBack,
   onClickCancel,
   onClickSend,
@@ -41,9 +43,17 @@ const TransferSummary: React.FC<TransferSummaryProps> = ({
 }) => {
   const insufficientNetworkFeeError = new TransactionValidationError('INSUFFICIENT_NETWORK_FEE');
 
+  const disabledSendButton = useMemo(() => {
+    return isLoadingNetworkFee || isErrorNetworkFee;
+  }, [isLoadingNetworkFee, isErrorNetworkFee]);
+
   const errorMessage = useMemo(() => {
+    if (!isErrorNetworkFee) {
+      return '';
+    }
+
     return insufficientNetworkFeeError.message;
-  }, []);
+  }, [isErrorNetworkFee, insufficientNetworkFeeError.message]);
 
   return (
     <TransferSummaryWrapper>
@@ -74,6 +84,7 @@ const TransferSummary: React.FC<TransferSummaryProps> = ({
       <div className='network-fee-wrapper'>
         <NetworkFee
           isError={isErrorNetworkFee}
+          isLoading={isLoadingNetworkFee}
           value={networkFee?.amount || ''}
           denom={networkFee?.denom || ''}
           errorMessage={errorMessage}
@@ -85,7 +96,7 @@ const TransferSummary: React.FC<TransferSummaryProps> = ({
         <button className='cancel' onClick={onClickCancel}>
           Cancel
         </button>
-        <button className='send' onClick={onClickSend}>
+        <button className={disabledSendButton ? 'send disabled' : 'send'} onClick={onClickSend}>
           Send
         </button>
       </div>

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas-info.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas-info.ts
@@ -1,14 +1,12 @@
-import {
-  DEFAULT_GAS_USED,
-  GAS_FEE_SAFETY_MARGIN,
-  MINIMUM_GAS_PRICE,
-} from '@common/constants/gas.constant';
+import { DEFAULT_GAS_USED, GAS_FEE_SAFETY_MARGIN } from '@common/constants/gas.constant';
 import { GasToken } from '@common/constants/token.constant';
+import { DEFAULT_GAS_WANTED } from '@common/constants/tx.constant';
 import { useAdenaContext } from '@hooks/use-context';
 import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
-import { GasInfo } from '@types';
+import { GasInfo, NetworkFeeSettingType } from '@types';
 import { Document, documentToDefaultTx } from 'adena-module';
 import BigNumber from 'bignumber.js';
+import { useGetGasPriceTier } from './use-get-gas-price';
 
 export const GET_ESTIMATE_GAS_INFO_KEY = 'transactionGas/useGetSingleEstimateGas';
 
@@ -29,8 +27,11 @@ function makeGasInfoBy(
     };
   }
 
-  const gasWantedBN = BigNumber(gasUsed).multipliedBy(safetyMargin);
-  const gasFeeBN = BigNumber(gasUsed).multipliedBy(gasPrice);
+  const gasWantedBN =
+    safetyMargin > 0
+      ? BigNumber(gasUsed).multipliedBy(safetyMargin)
+      : BigNumber(DEFAULT_GAS_WANTED);
+  const gasFeeBN = gasWantedBN.multipliedBy(gasPrice);
 
   return {
     gasWanted: Number(gasWantedBN.toFixed(0, BigNumber.ROUND_DOWN)),
@@ -58,26 +59,38 @@ export const useGetDefaultEstimateGasInfo = (
   document: Document | null | undefined,
   options?: UseQueryOptions<GasInfo | null, Error>,
 ): UseQueryResult<GasInfo | null> => {
-  const emptyMargin = 1;
+  const emptyMargin = 0;
 
-  return useGetEstimateGasInfo(document, DEFAULT_GAS_USED, MINIMUM_GAS_PRICE, emptyMargin, options);
+  return useGetEstimateGasInfo(document, DEFAULT_GAS_USED, emptyMargin, options);
 };
 
 export const useGetEstimateGasInfo = (
   document: Document | null | undefined,
   gasUsed: number,
-  gasPrice: number,
   safetyMargin: number = GAS_FEE_SAFETY_MARGIN,
   options?: UseQueryOptions<GasInfo | null, Error>,
 ): UseQueryResult<GasInfo | null> => {
   const { transactionGasService } = useAdenaContext();
-
-  const { gasFee, gasWanted } = makeGasInfoBy(gasUsed, gasPrice, safetyMargin);
+  const { data: gasPriceTier } = useGetGasPriceTier(GasToken.denom);
 
   return useQuery<GasInfo | null, Error>({
-    queryKey: [GET_ESTIMATE_GAS_INFO_KEY, document?.msgs, document?.memo, gasFee, gasWanted],
+    queryKey: [
+      GET_ESTIMATE_GAS_INFO_KEY,
+      transactionGasService,
+      document?.msgs || '',
+      document?.memo || '',
+      gasUsed,
+      gasPriceTier?.[NetworkFeeSettingType.AVERAGE] || 0,
+    ],
     queryFn: async () => {
-      if (!document || !gasFee || !gasWanted) {
+      if (!document || !gasPriceTier) {
+        return null;
+      }
+
+      const gasPrice = gasPriceTier?.[NetworkFeeSettingType.AVERAGE];
+
+      const { gasFee, gasWanted } = makeGasInfoBy(gasUsed, gasPrice, safetyMargin);
+      if (!transactionGasService || !gasFee || !gasWanted) {
         return null;
       }
 
@@ -86,7 +99,7 @@ export const useGetEstimateGasInfo = (
       const result = await transactionGasService
         .estimateGas(documentToDefaultTx(modifiedDocument))
         .catch((e: Error) => {
-          if (e.message === '/std.InvalidPubKeyError') {
+          if (e?.message === '/std.InvalidPubKeyError') {
             return DEFAULT_GAS_USED;
           }
 
@@ -112,7 +125,7 @@ export const useGetEstimateGasInfo = (
     },
     refetchInterval: REFETCH_INTERVAL,
     keepPreviousData: true,
-    enabled: !!document && !!gasFee && !!gasWanted,
+    enabled: !!document && !!transactionGasService,
     ...options,
   });
 };

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-gas-price.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-gas-price.ts
@@ -1,0 +1,66 @@
+import { DEFAULT_GAS_PRICE_STEP, MINIMUM_GAS_PRICE } from '@common/constants/gas.constant';
+import { useAdenaContext } from '@hooks/use-context';
+import { useNetwork } from '@hooks/use-network';
+import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import { NetworkFeeSettingType } from '@types';
+import BigNumber from 'bignumber.js';
+
+export const GET_GAS_PRICE = 'transactionGas/useGetGasPrice';
+
+const REFETCH_INTERVAL = 5_000;
+
+export const useGetGasPriceTier = (
+  denomination: string,
+  options?: UseQueryOptions<Record<NetworkFeeSettingType, number> | null, Error>,
+): UseQueryResult<Record<NetworkFeeSettingType, number> | null> => {
+  const { currentNetwork } = useNetwork();
+  const { transactionGasService } = useAdenaContext();
+
+  return useQuery<Record<NetworkFeeSettingType, number> | null, Error>({
+    queryKey: [GET_GAS_PRICE, denomination, transactionGasService],
+    queryFn: () => {
+      if (!currentNetwork.indexerUrl || !transactionGasService) {
+        return DEFAULT_GAS_PRICE_STEP;
+      }
+
+      return transactionGasService
+        .getGasPrice(denomination)
+        .then((tierInfo) => ({
+          [NetworkFeeSettingType.FAST]: handleInsufficientGasPrice(
+            tierInfo?.low || 0,
+            DEFAULT_GAS_PRICE_STEP.FAST,
+          ),
+          [NetworkFeeSettingType.AVERAGE]: handleInsufficientGasPrice(
+            tierInfo?.high || 0,
+            DEFAULT_GAS_PRICE_STEP.AVERAGE,
+          ),
+          [NetworkFeeSettingType.SLOW]: handleInsufficientGasPrice(
+            tierInfo?.average || 0,
+            DEFAULT_GAS_PRICE_STEP.SLOW,
+          ),
+        }))
+        .catch((e) => {
+          console.error(e);
+          return null;
+        });
+    },
+    refetchInterval: REFETCH_INTERVAL,
+    enabled: !!transactionGasService,
+    keepPreviousData: true,
+    ...options,
+  });
+};
+
+function handleInsufficientGasPrice(
+  price: number,
+  defaultPrice: number,
+  overPrice = 1,
+  lowerPrice = MINIMUM_GAS_PRICE,
+): number {
+  const priceBN = BigNumber(price.toFixed(6));
+  if (priceBN.isGreaterThanOrEqualTo(overPrice) || priceBN.isLessThanOrEqualTo(lowerPrice)) {
+    return defaultPrice;
+  }
+
+  return priceBN.toNumber();
+}

--- a/packages/adena-extension/src/hooks/wallet/use-network-fee.ts
+++ b/packages/adena-extension/src/hooks/wallet/use-network-fee.ts
@@ -9,10 +9,13 @@ import {
   useGetEstimateGasInfo,
 } from './transaction-gas/use-get-estimate-gas-info';
 import { useGetEstimateGasPriceTiers } from './transaction-gas/use-get-estimate-gas-price-tiers';
+import { useGetGasPriceTier } from './transaction-gas/use-get-gas-price';
 
 export interface UseNetworkFeeReturn {
+  isLoading: boolean;
   isFetchedPriceTiers: boolean;
   isFetchedEstimateGasInfo: boolean;
+  isSimulateError: boolean;
   currentGasInfo: GasInfo | null;
   currentGasFeeRawAmount: number;
   changedGasInfo: GasInfo | null;
@@ -30,6 +33,7 @@ const defaultSettingType = NetworkFeeSettingType.AVERAGE;
 export const useNetworkFee = (
   document?: Document | null,
   isDefaultGasPrice = false,
+  gasInfo?: GasInfo | null,
 ): UseNetworkFeeReturn => {
   const [currentNetworkFeeSettingType, setCurrentNetworkFeeSettingType] =
     useState<NetworkFeeSettingType>(defaultSettingType);
@@ -39,15 +43,37 @@ export const useNetworkFee = (
   const [selectedTier, setSelectedTier] = useState(!isDefaultGasPrice);
   const [gasAdjustment, setGasAdjustment] = useState<string>(DEFAULT_GAS_ADJUSTMENT.toString());
 
-  const { data: defaultEstimatedGasInfo } = useGetDefaultEstimateGasInfo(document);
+  const { data: gasPriceTier } = useGetGasPriceTier(GasToken.denom);
+  const { data: defaultEstimatedGasInfo, isFetched: isFetchedDefaultEstimatedGasInfo } =
+    useGetDefaultEstimateGasInfo(document);
   const { data: estimatedGasInfo, isFetched: isFetchedEstimateGasInfo } = useGetEstimateGasInfo(
     document,
-    defaultEstimatedGasInfo?.gasUsed || 0,
-    defaultEstimatedGasInfo?.gasPrice || 0,
+    gasInfo?.gasUsed || defaultEstimatedGasInfo?.gasUsed || 0,
   );
 
-  const { data: gasPriceTiers = null, isFetched: isFetchedPriceTiers } =
-    useGetEstimateGasPriceTiers(document, estimatedGasInfo?.gasUsed, gasAdjustment);
+  const { data: gasPriceTiers, isFetched: isFetchedPriceTiers } = useGetEstimateGasPriceTiers(
+    document,
+    gasInfo?.gasUsed || estimatedGasInfo?.gasUsed,
+    gasAdjustment,
+  );
+
+  const isLoading = useMemo(() => {
+    if (gasPriceTier === undefined || gasPriceTiers === undefined) {
+      return true;
+    }
+
+    if (!isFetchedDefaultEstimatedGasInfo || !isFetchedEstimateGasInfo || !isFetchedPriceTiers) {
+      return true;
+    }
+
+    return false;
+  }, [
+    gasPriceTier,
+    gasPriceTiers,
+    isFetchedDefaultEstimatedGasInfo,
+    isFetchedEstimateGasInfo,
+    isFetchedPriceTiers,
+  ]);
 
   const currentSettingType = useMemo(() => {
     if (!gasPriceTiers || gasPriceTiers.length <= 0) {
@@ -71,9 +97,30 @@ export const useNetworkFee = (
     }
 
     const current = gasPriceTiers.find((setting) => setting.settingType === currentSettingType);
+    if (current?.gasInfo?.hasError) {
+      return {
+        gasFee: 0,
+        gasUsed: 0,
+        gasWanted: 0,
+        gasPrice: 0,
+        hasError: true,
+      };
+    }
 
     return current?.gasInfo || null;
   }, [gasPriceTiers, currentSettingType]);
+
+  const isSimulateError = useMemo(() => {
+    if (currentGasInfo?.hasError) {
+      return true;
+    }
+
+    if (!isFetchedDefaultEstimatedGasInfo && !defaultEstimatedGasInfo) {
+      return true;
+    }
+
+    return false;
+  }, [isFetchedDefaultEstimatedGasInfo, defaultEstimatedGasInfo, currentGasInfo]);
 
   const changedGasInfo = useMemo(() => {
     if (!gasPriceTiers) {
@@ -86,12 +133,8 @@ export const useNetworkFee = (
   }, [changedSettingType, gasPriceTiers]);
 
   const currentGasFeeRawAmount = useMemo(() => {
-    if (!selectedTier && !currentGasInfo) {
-      return BigNumber(document?.fee.amount?.[0].amount || 0).toNumber();
-    }
-
     if (!currentGasInfo) {
-      return 0;
+      return BigNumber(document?.fee.amount?.[0].amount || 0).toNumber();
     }
 
     const currentGasFeeAmount = BigNumber(currentGasInfo.gasFee).toFixed(0, BigNumber.ROUND_UP);
@@ -100,6 +143,10 @@ export const useNetworkFee = (
   }, [currentGasInfo?.gasFee, document, selectedTier]);
 
   const networkFee = useMemo(() => {
+    if (!gasPriceTier) {
+      return null;
+    }
+
     if (!currentGasInfo) {
       return null;
     }
@@ -121,7 +168,7 @@ export const useNetworkFee = (
       amount: networkFeeAmount,
       denom: GasToken.symbol,
     };
-  }, [currentGasInfo]);
+  }, [gasPriceTier, currentGasInfo]);
 
   const setNetworkFeeSetting = useCallback((settingInfo: NetworkFeeSettingInfo): void => {
     setNetworkFeeSettingType(settingInfo.settingType);
@@ -133,13 +180,15 @@ export const useNetworkFee = (
   }, [changedSettingType]);
 
   return {
+    isLoading,
     isFetchedEstimateGasInfo,
-    isFetchedPriceTiers,
+    isFetchedPriceTiers: isFetchedEstimateGasInfo && isFetchedPriceTiers,
+    isSimulateError,
     currentGasInfo,
     currentGasFeeRawAmount,
     changedGasInfo,
     networkFeeSettingType: changedSettingType,
-    networkFeeSettings: gasPriceTiers,
+    networkFeeSettings: gasPriceTiers || null,
     setNetworkFeeSetting,
     gasAdjustment,
     setGasAdjustment,

--- a/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
@@ -147,6 +147,10 @@ const ApproveTransactionContainer: React.FC = () => {
   }, [networkFee]);
 
   const isErrorNetworkFee = useMemo(() => {
+    if (!useNetworkFeeReturn.isLoading && currentBalance === 0) {
+      return true;
+    }
+
     if (!networkFee) {
       return false;
     }
@@ -154,7 +158,7 @@ const ApproveTransactionContainer: React.FC = () => {
     return BigNumber(currentBalance)
       .shiftedBy(GasToken.decimals * -1)
       .isLessThan(networkFee.amount);
-  }, [currentBalance, networkFee]);
+  }, [currentBalance, networkFee, useNetworkFeeReturn.isLoading]);
 
   const checkLockWallet = (): void => {
     walletService
@@ -330,7 +334,7 @@ const ApproveTransactionContainer: React.FC = () => {
             WalletResponseFailureType.TRANSACTION_FAILED,
             {
               hash,
-              error: response,
+              error: response?.name || response.message || '',
             },
             requestData?.key,
           ),
@@ -458,6 +462,7 @@ const ApproveTransactionContainer: React.FC = () => {
       processing={processing}
       done={done}
       logo={favicon}
+      currentBalance={currentBalance}
       isErrorNetworkFee={isErrorNetworkFee}
       networkFee={displayNetworkFee}
       useNetworkFeeReturn={useNetworkFeeReturn}

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-input/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-input/index.tsx
@@ -124,7 +124,7 @@ const TransferInputContainer: React.FC = () => {
             value: balanceInput.amount,
             denom: balanceInput.denom,
           },
-          networkFee: balanceInput.networkFee,
+          gasInfo: balanceInput.gasInfo,
           memo,
         },
       });

--- a/packages/adena-extension/src/repositories/transaction/transaction-gas.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-gas.ts
@@ -1,5 +1,5 @@
 import { GnoProvider } from '@common/provider/gno/gno-provider';
-import { makeRPCRequest } from '@common/utils/fetch-utils';
+import { makeIndexerRPCRequest } from '@common/utils/fetch-utils';
 import { Tx } from '@gnolang/tm2-js-client';
 import { NetworkMetainfo } from '@types';
 import { AxiosInstance } from 'axios';
@@ -26,15 +26,7 @@ export class TransactionGasRepository implements ITransactionGasRepository {
       return null;
     }
 
-    if (this.networkMetainfo.apiUrl) {
-      return this.networkMetainfo.apiUrl + '/v1/indexer';
-    }
-
-    if (this.networkMetainfo.indexerUrl) {
-      return this.indexerUrl;
-    }
-
-    return null;
+    return this.networkMetainfo.indexerUrl || null;
   }
 
   public async fetchGasPrices(): Promise<TransactionGasResponse[]> {
@@ -47,7 +39,7 @@ export class TransactionGasRepository implements ITransactionGasRepository {
     }>(
       this.networkInstance,
       this.indexerUrl,
-      makeRPCRequest({
+      makeIndexerRPCRequest({
         method: 'getGasPrice',
       }),
     ).then((data) => data?.result || []);

--- a/packages/adena-extension/src/services/wallet/wallet.ts
+++ b/packages/adena-extension/src/services/wallet/wallet.ts
@@ -175,8 +175,6 @@ export class WalletService {
   public equalsPassword = async (password: string): Promise<boolean> => {
     try {
       const storedPassword = await this.walletRepository.getEncryptedPassword();
-      console.log(storedPassword, password);
-      console.log('encryptSha256Password(password)', encryptSha256Password(password));
       if (storedPassword !== '') {
         const encryptedPassword = encryptSha256Password(password);
         return storedPassword === encryptedPassword;

--- a/packages/adena-extension/src/states/transfer.ts
+++ b/packages/adena-extension/src/states/transfer.ts
@@ -1,4 +1,4 @@
-import { NetworkFee, TokenModel } from '@types';
+import { GasInfo, TokenModel } from '@types';
 import { atom } from 'recoil';
 
 export interface TransferInfo {
@@ -8,7 +8,7 @@ export interface TransferInfo {
     value: string;
     denom: string;
   };
-  networkFee: NetworkFee | null;
+  gasInfo: GasInfo | null;
   memo: string;
 }
 

--- a/packages/adena-extension/src/types/router.ts
+++ b/packages/adena-extension/src/types/router.ts
@@ -2,9 +2,9 @@ import { InjectionMessage } from '@inject/message';
 import { AddressBookItem } from '@repositories/wallet';
 import {
   CreateAccountState,
+  GasInfo,
   GRC721CollectionModel,
   GRC721Model,
-  NetworkFee,
   TokenBalanceType,
   TokenModel,
   TransactionInfo,
@@ -170,7 +170,7 @@ export type RouteParams = {
       value: string;
       denom: string;
     };
-    networkFee: NetworkFee | null;
+    gasInfo: GasInfo | null;
     memo: string;
   };
   [RoutePath.NftTransferSummary]: {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:
- Handle a dynamic gas prices.
- Dynamically fetch the gas price value from indexer instead of the default gas price value.
    - This isn't the exact gas price on-chain, but it's a good estimate of the gas price at which the transaction succeeds.