### PR TITLE
fix: visible network fee when error

### DIFF
--- a/packages/adena-extension/src/hooks/wallet/use-network-fee.ts
+++ b/packages/adena-extension/src/hooks/wallet/use-network-fee.ts
@@ -152,13 +152,6 @@ export const useNetworkFee = (
       return null;
     }
 
-    if (currentGasInfo.hasError) {
-      return {
-        amount: '0',
-        denom: '',
-      };
-    }
-
     const networkFeeAmount = BigNumber(currentGasInfo.gasFee)
       .shiftedBy(-GasToken.decimals)
       .toFixed(GasToken.decimals)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:
- Even if simulate fails, it shows the selected network fee.
