### PR TITLE
fix: approve transaction popup argument reverse order display error

### DIFF
--- a/packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.styles.ts
+++ b/packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.styles.ts
@@ -58,6 +58,7 @@ export const ArgumentEditBoxWrapper = styled(View)<{ marginRight?: number }>`
       direction: rtl;
       text-align: right;
       unicode-bidi: bidi-override;
+      white-space: nowrap;
       ${fonts.body2Reg};
     }
   }

--- a/packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.styles.ts
+++ b/packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.styles.ts
@@ -57,6 +57,7 @@ export const ArgumentEditBoxWrapper = styled(View)<{ marginRight?: number }>`
       text-align: end;
       direction: rtl;
       text-align: right;
+      unicode-bidi: bidi-override;
       ${fonts.body2Reg};
     }
   }

--- a/packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.tsx
+++ b/packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.tsx
@@ -23,6 +23,14 @@ const ArgumentEditBox: React.FC<ArgumentEditBoxProps> = ({
   const [editValue, setEditValue] = useState(value);
   const [editState, setEditState] = useState<EditStateType>('none');
 
+  const displayValue = useMemo(() => {
+    if (!value) {
+      return '';
+    }
+
+    return value.split('').reverse().join('');
+  }, [value]);
+
   const activateEditMode = (): void => {
     setEditable(true);
   };
@@ -128,7 +136,7 @@ const ArgumentEditBox: React.FC<ArgumentEditBoxProps> = ({
         </div>
       ) : (
         <div className='display-wrapper'>
-          <span className='display-value'>{value}</span>
+          <span className='display-value'>{displayValue}</span>
           <div className='icon-wrapper' onClick={activateEditMode}>
             <IconPencil className='edit-icon' />
           </div>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:
- Approve Transaction popup argument reverse order display error.
    - Fixes an error where a leading special character is output after a special character in an argument that contains a special character.
