### PR TITLE
fix: realm path direction in approve transaction

### DIFF
--- a/packages/adena-extension/src/common/utils/string-utils.ts
+++ b/packages/adena-extension/src/common/utils/string-utils.ts
@@ -46,3 +46,7 @@ export function calculateByteSize(str: string): number {
   const encodedStr = encoder.encode(str);
   return encodedStr.length;
 }
+
+export function reverseString(str: string): string {
+  return str.split('').reverse().join('');
+}

--- a/packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.styles.ts
+++ b/packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.styles.ts
@@ -113,11 +113,13 @@ export const ApproveTransactionMessageArgumentsOpenerWrapper = styled(View)`
 export const RealmPathInfoWrapper = styled.span`
   display: block;
   max-width: 191px;
-  text-align: right;
   text-overflow: ellipsis;
   overflow: hidden;
-  ${fonts.body2Reg};
   direction: rtl;
+  text-align: right;
+  unicode-bidi: bidi-override;
+  ${fonts.body2Reg};
+
   & .domain-path {
     color: ${getTheme('neutral', 'a')};
     font-weight: 400;

--- a/packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.tsx
+++ b/packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 
 import { formatAddress } from '@common/utils/client-utils';
-import { isBech32Address } from '@common/utils/string-utils';
+import { isBech32Address, reverseString } from '@common/utils/string-utils';
 import ArgumentEditBox from '@components/molecules/argument-edit-box/argument-edit-box';
 import { ContractMessage } from '@inject/types';
 import { MsgCallValue } from '@repositories/transaction/response/transaction-history-query-response';
@@ -278,15 +278,23 @@ const RealmPathInfo: React.FC<{
   namespaceSubPath: string;
   contract: string;
 }> = ({ domain, nameSpace, namespaceSubPath, contract }) => {
+  const displayDomain = useMemo(() => {
+    return reverseString(domain);
+  }, [domain]);
+
   const displayNamespacePath = useMemo(() => {
     const displayNamespace = isBech32Address(nameSpace) ? formatAddress(nameSpace, 4) : nameSpace;
 
     if (namespaceSubPath.length > 0) {
-      return `${displayNamespace}/${namespaceSubPath}/`;
+      return reverseString(`${displayNamespace}/${namespaceSubPath}`);
     }
 
-    return displayNamespace;
+    return reverseString(displayNamespace);
   }, [nameSpace, namespaceSubPath]);
+
+  const displayContractPath = useMemo(() => {
+    return reverseString(contract);
+  }, [contract]);
 
   if (!domain && !displayNamespacePath && !contract) {
     return <RealmPathInfoWrapper />;
@@ -294,11 +302,11 @@ const RealmPathInfo: React.FC<{
 
   return (
     <RealmPathInfoWrapper>
-      {domain && <span className='domain-path'>{domain}</span>}
-      {displayNamespacePath && <span className='namespace-path'>/</span>}
+      {displayContractPath && <span className='contract-path'>{displayContractPath}</span>}
+      {displayContractPath && <span className='contract-path'>/</span>}
       {displayNamespacePath && <span className='namespace-path'>{displayNamespacePath}</span>}
-      {contract && <span className='contract-path'>/</span>}
-      {contract && <span className='contract-path'>{contract}</span>}
+      {displayNamespacePath && <span className='namespace-path'>/</span>}
+      {displayDomain && <span className='domain-path'>{displayDomain}</span>}
     </RealmPathInfoWrapper>
   );
 };

--- a/packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.tsx
+++ b/packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.tsx
@@ -5,6 +5,7 @@ import { ArgumentEditBoxWrapper } from './argument-edit-box.styles';
 import IconEditCancel from '@assets/icon-edit-cancel';
 import IconEditConfirm from '@assets/icon-edit-confirm';
 import IconPencil from '@assets/icon-pencil';
+import { reverseString } from '@common/utils/string-utils';
 
 export interface ArgumentEditBoxProps {
   editRightMargin?: number;
@@ -28,7 +29,7 @@ const ArgumentEditBox: React.FC<ArgumentEditBoxProps> = ({
       return '';
     }
 
-    return value.split('').reverse().join('');
+    return reverseString(value);
   }, [value]);
 
   const activateEditMode = (): void => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

This pull request introduces a new utility function and updates several components to utilize this function for string manipulation. The most significant changes include the addition of the `reverseString` function and its integration into various components.

New utility function:

* [`packages/adena-extension/src/common/utils/string-utils.ts`](diffhunk://#diff-a8dfa8ca5f6992dc8f6e88c2376ea95960947833672343480780ec7feaac4a6bR49-R52): Added `reverseString` function to reverse a given string.

Component updates:

* [`packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.tsx`](diffhunk://#diff-7af33d19ac48074e9c6260a7cd474e8595efa816ca5be2971192fb9a82b266c9L4-R4): Integrated `reverseString` function to reverse domain, namespace, and contract strings before displaying them. [[1]](diffhunk://#diff-7af33d19ac48074e9c6260a7cd474e8595efa816ca5be2971192fb9a82b266c9L4-R4) [[2]](diffhunk://#diff-7af33d19ac48074e9c6260a7cd474e8595efa816ca5be2971192fb9a82b266c9R281-R309)
* [`packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.styles.ts`](diffhunk://#diff-c207d8a4a5d870b7f1e635cbd0fe57abfbc359edd2f686017d769a303af99793L116-R122): Updated `RealmPathInfoWrapper` styles to include `unicode-bidi: bidi-override` and adjusted text alignment.
* [`packages/adena-extension/src/components/molecules/argument-edit-box/argument-edit-box.tsx`](diffhunk://#diff-3416e5674e93a32f1d5a914ad1aa6b09a805d8d40d472578f5a97944b0524ce0R8): Imported and used `reverseString` function to reverse the value string. [[1]](diffhunk://#diff-3416e5674e93a32f1d5a914ad1aa6b09a805d8d40d472578f5a97944b0524ce0R8) [[2]](diffhunk://#diff-3416e5674e93a32f1d5a914ad1aa6b09a805d8d40d472578f5a97944b0524ce0L31-R32)