### PR TITLE
fix: invalid gas wanted in grc20 transfer

### DIFF
--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -40,7 +40,7 @@ const TransferSummaryContainer: React.FC = () => {
   const [openedNetworkFeeSetting, setOpenedNetworkFeeSetting] = useState(false);
   const [document, setDocument] = useState<Document | null>(null);
 
-  const useNetworkFeeReturn = useNetworkFee(document, false, summaryInfo.gasInfo);
+  const useNetworkFeeReturn = useNetworkFee(document, false);
   const networkFee = useNetworkFeeReturn.networkFee;
 
   const { data: currentBalance } = useGetGnotBalance();
@@ -131,7 +131,8 @@ const TransferSummaryContainer: React.FC = () => {
       return null;
     }
 
-    const { tokenMetainfo, memo, gasInfo } = summaryInfo;
+    const { tokenMetainfo, memo } = summaryInfo;
+    const gasWanted = useNetworkFeeReturn.currentGasInfo?.gasWanted || 0;
     const message =
       tokenMetainfo.type === 'gno-native' ? getNativeTransferMessage() : getGRC20TransferMessage();
 
@@ -139,7 +140,7 @@ const TransferSummaryContainer: React.FC = () => {
       currentAccount,
       currentNetwork.networkId,
       [message],
-      gasInfo?.gasWanted || 0,
+      gasWanted,
       BigNumber(networkFee?.amount || 0)
         .shiftedBy(GasToken.decimals)
         .toNumber(),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

Fix an error that caused transactions to fail with an incorrect gas wanted value when transferring GRC20 balances.
On the Token Transfer page, change to use the calculated gas wanted value.
