### PR TITLE
fix: handle gnoconnect rpc protocol

### DIFF
--- a/packages/adena-extension/src/common/provider/gno/gno-provider.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.ts
@@ -20,7 +20,13 @@ import {
 import axios from 'axios';
 import { ResponseDeliverTx } from './proto/tm2/abci';
 import { ABCIAccount, AccountInfo, GnoDocumentInfo, VMQueryType } from './types';
-import { fetchABCIResponse, makeRequestQueryPath, parseProto, postABCIResponse } from './utils';
+import {
+  fetchABCIResponse,
+  isHttpsAvailable,
+  makeRequestQueryPath,
+  parseProto,
+  postABCIResponse,
+} from './utils';
 
 export class GnoProvider extends GnoJSONRPCProvider {
   private chainId?: string;
@@ -182,7 +188,7 @@ export class GnoProvider extends GnoJSONRPCProvider {
   public async getRealmDocument(packagePath: string): Promise<GnoDocumentInfo | null> {
     const query = VMQueryType.QUERY_DOCUMENT;
     const base64PackagePath = stringToBase64(packagePath);
-    const requestQuery = this.makeRequestQueryPath(query, base64PackagePath);
+    const requestQuery = await this.getRequestQueryPath(query, base64PackagePath);
 
     try {
       const abciResponse = await fetchABCIResponse(requestQuery, false);
@@ -199,7 +205,8 @@ export class GnoProvider extends GnoJSONRPCProvider {
     return null;
   }
 
-  private makeRequestQueryPath(path: string, data: string): string {
-    return makeRequestQueryPath(this.baseURL, path, data);
+  private async getRequestQueryPath(path: string, data: string): Promise<string> {
+    const ssl = await isHttpsAvailable(this.baseURL);
+    return makeRequestQueryPath(this.baseURL, path, data, ssl);
   }
 }

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -138,7 +138,7 @@ export class CommandHandler {
         realmDocument,
       );
 
-      executor.doContract(transactionParams).then(console.info);
+      executor.doContract(transactionParams).then(console.info).catch(console.info);
     } catch (error) {
       console.info(error);
     }

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.ts
@@ -4,6 +4,7 @@ import {
   GNO_PACKAGE_PREFIX,
   GNO_RPC_META_TAG,
 } from '@common/constants/metatag.constant';
+import { hasHttpProtocol } from '@common/provider/gno/utils';
 
 export interface GnoConnectInfo {
   rpc: string;
@@ -54,7 +55,7 @@ export function parseGnoConnectInfo(): GnoConnectInfo | null {
 
     switch (name) {
       case GNO_RPC_META_TAG:
-        gnoConnectInfo.rpc = content;
+        gnoConnectInfo.rpc = getUrlPathWithoutProtocol(content);
         break;
       case GNO_CHAIN_ID_META_TAG:
         gnoConnectInfo.chainId = content;
@@ -171,4 +172,14 @@ export function shouldRegisterAnchorIntercept(): boolean {
   }
 
   return true;
+}
+
+export function getUrlPathWithoutProtocol(url: string): string {
+  const trimmedUrl = url.trim();
+
+  if (hasHttpProtocol(trimmedUrl)) {
+    return trimmedUrl;
+  }
+
+  return trimmedUrl.replace(/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//, '');
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:
This pull request to the `packages/adena-extension` includes several changes to enhance the functionality and improve the robustness of the `GnoProvider` and related utilities. The most important changes include the addition of HTTPS protocol checking, refactoring of query path creation, and improvements to error handling.

Enhancements to protocol handling:

* [`packages/adena-extension/src/common/provider/gno/gno-provider.ts`](diffhunk://#diff-54090f0e7847331a6714c67a0c314e6d701b25327828565c0840d5700e8e8d8aL23-R29): Added `isHttpsAvailable` to check for HTTPS support and modified `makeRequestQueryPath` to `getRequestQueryPath` to use this check. [[1]](diffhunk://#diff-54090f0e7847331a6714c67a0c314e6d701b25327828565c0840d5700e8e8d8aL23-R29) [[2]](diffhunk://#diff-54090f0e7847331a6714c67a0c314e6d701b25327828565c0840d5700e8e8d8aL185-R191) [[3]](diffhunk://#diff-54090f0e7847331a6714c67a0c314e6d701b25327828565c0840d5700e8e8d8aL202-R210)
* [`packages/adena-extension/src/common/provider/gno/utils.ts`](diffhunk://#diff-c5356ab4a931c1ccd73a199d08c868c318b69dc2fb3baa1d9bea618f84c67708R4-R8): Introduced constants and functions for handling HTTP and HTTPS protocols, including `isHttpsAvailable`, `hasHttpProtocol`, `isHttpsProtocol`, and `isHttpProtocol`. [[1]](diffhunk://#diff-c5356ab4a931c1ccd73a199d08c868c318b69dc2fb3baa1d9bea618f84c67708R4-R8) [[2]](diffhunk://#diff-c5356ab4a931c1ccd73a199d08c868c318b69dc2fb3baa1d9bea618f84c67708L40-R88)

Refactoring and utility improvements:

* [`packages/adena-extension/src/inject/message/methods/gno-connect.ts`](diffhunk://#diff-e7d777cb1f61519a85112473f76e6846868a8b841af9d6c368d00ff18e046d5cR7): Added `hasHttpProtocol` import and created `getUrlPathWithoutProtocol` to strip protocol from URLs. [[1]](diffhunk://#diff-e7d777cb1f61519a85112473f76e6846868a8b841af9d6c368d00ff18e046d5cR7) [[2]](diffhunk://#diff-e7d777cb1f61519a85112473f76e6846868a8b841af9d6c368d00ff18e046d5cR176-R185)
* [`packages/adena-extension/src/inject/message/methods/gno-connect.ts`](diffhunk://#diff-e7d777cb1f61519a85112473f76e6846868a8b841af9d6c368d00ff18e046d5cL57-R58): Updated `parseGnoConnectInfo` to use `getUrlPathWithoutProtocol` for cleaner URL handling.

Error handling improvements:

* [`packages/adena-extension/src/inject/message/command-handler.ts`](diffhunk://#diff-ecd5a5447eb29ea9646cd5d50b2fceb3533a8e5554d22b2b8bb4d04bde9138b6L141-R141): Enhanced error handling in `CommandHandler` by adding a catch block to log errors.
