### PR TITLE
fix: missing realm sub path

### DIFF
--- a/packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.tsx
+++ b/packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.tsx
@@ -137,6 +137,8 @@ const MsgCallTransactionMessage: React.FC<ApproveTransactionMessageProps> = ({
 
     const paths = pkg_path.split('/');
 
+    console.log('paths', paths);
+
     if (paths.length < 3) {
       return {
         path: pkg_path,
@@ -149,7 +151,7 @@ const MsgCallTransactionMessage: React.FC<ApproveTransactionMessageProps> = ({
 
     const domain = paths.slice(1, 2).join('/');
     const nameSpace = paths[2];
-    const namespaceSubPath = paths.length > 5 ? paths.slice(3, paths.length - 1).join('/') : '';
+    const namespaceSubPath = paths.length > 4 ? paths.slice(3, paths.length - 1).join('/') : '';
     const contract = paths[paths.length - 1];
 
     return {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

This pull request includes minor changes to the `approve-transaction-message.tsx` file, primarily focusing on debugging and correcting a logical condition.

Code debugging:

* Added a `console.log` statement to output the `paths` variable for debugging purposes. (`packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.tsx`)

Logical condition correction:

* Modified the condition to check the length of `paths` for determining `namespaceSubPath` to be more accurate. (`packages/adena-extension/src/components/molecules/approve-transaction-message/approve-transaction-message.tsx`)
