### PR TITLE
fix: connect to unknown in add establish

### DIFF
--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -103,7 +103,8 @@ export class CommandHandler {
 
     const executor = new AdenaExecutor();
 
-    const addEstablishResponse = await executor.addEstablish();
+    const domain = new URL(window.location.href).hostname;
+    const addEstablishResponse = await executor.addEstablish(domain);
     // Not connected
     if (
       addEstablishResponse.type !== WalletResponseSuccessType.CONNECTION_SUCCESS &&


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

This pull request includes an important change to the `CommandHandler` class in the `command-handler.ts` file to improve the handling of domain-specific connections.

Key change:

* [`packages/adena-extension/src/inject/message/command-handler.ts`](diffhunk://#diff-ecd5a5447eb29ea9646cd5d50b2fceb3533a8e5554d22b2b8bb4d04bde9138b6L106-R107): Modified the `addEstablish` method to include the domain extracted from the current window's URL, enhancing domain-specific connection handling.
