### PR TITLE
feat: add a seed verification process a few words

### DIFF
--- a/packages/adena-extension/src/components/atoms/web-seed-validate-input-item/index.tsx
+++ b/packages/adena-extension/src/components/atoms/web-seed-validate-input-item/index.tsx
@@ -1,0 +1,157 @@
+import { fonts, webFonts } from '@styles/theme';
+import React, { useCallback, useMemo, useState } from 'react';
+import styled, { css, RuleSet } from 'styled-components';
+import { Row, View } from '../base';
+
+interface StyleProps {
+  hover?: boolean;
+  focus?: boolean;
+  filled?: boolean;
+  error: boolean;
+}
+
+const forwardConfig = (prop: string): boolean => {
+  return !['hover', 'focus', 'filled', 'error'].includes(prop);
+};
+
+const StyledContainer = styled(Row).withConfig({ shouldForwardProp: forwardConfig })<StyleProps>`
+  width: 100%;
+  height: 40px;
+  position: relative;
+  overflow: hidden;
+  border-radius: 10px;
+  border: 1px solid ${({ theme }): string => theme.webNeutral._800};
+  ${webFonts.body4}
+
+  ${({ theme, hover, focus, filled }): RuleSet | string =>
+    hover || focus || filled
+      ? css`
+          border-color: ${theme.webNeutral._600};
+        `
+      : ''}
+  
+  ${({ filled }): RuleSet | string =>
+    filled
+      ? css`
+          box-shadow:
+            0px 0px 0px 3px rgba(255, 255, 255, 0.04),
+            0px 1px 3px 0px rgba(0, 0, 0, 0.1),
+            0px 1px 2px 0px rgba(0, 0, 0, 0.06);
+        `
+      : ''}
+
+  ${({ theme, error }): RuleSet | string =>
+    error
+      ? css`
+          color: ${theme.webError._100};
+          background: #e0517014;
+          border-color: ${theme.webError._200};
+          box-shadow:
+            0px 0px 0px 3px rgba(235, 84, 94, 0.12),
+            0px 1px 3px 0px rgba(0, 0, 0, 0.1),
+            0px 1px 2px 0px rgba(0, 0, 0, 0.06);
+        `
+      : ''}
+`;
+
+const StyledTitle = styled(View).withConfig({
+  shouldForwardProp: (prop): boolean => !['hover', 'focus', 'filled', 'error'].includes(prop),
+})<StyleProps>`
+  width: 90px;
+  height: 100%;
+  background: ${({ theme }): string => theme.webInput._100};
+  border-right: 1px solid ${({ theme }): string => theme.webNeutral._800};
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }): string => theme.webNeutral._500};
+  ${fonts.body2Reg}
+
+  ${({ theme, hover, focus }): RuleSet | string =>
+    hover || focus
+      ? css`
+          border-color: ${theme.webNeutral._600};
+        `
+      : ''}
+
+  ${({ theme, error }): RuleSet | string =>
+    error
+      ? css`
+          color: ${({ theme }): string => theme.webNeutral._500};
+          border-color: ${theme.webError._200};
+        `
+      : ''}
+`;
+
+const StyledInput = styled.input.withConfig({
+  shouldForwardProp: (prop): boolean => !['hover', 'focus', 'filled', 'error'].includes(prop),
+})<StyleProps>`
+  flex: 1;
+  width: 100%;
+  height: 40px;
+  padding: 12px;
+  border-radius: 0;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  background: ${({ error, theme }): string =>
+    error ? theme.webError._300 : theme.webNeutral._900};
+  color: ${({ theme }): string => theme.webNeutral._100};
+`;
+
+interface WebSeedValidateInputItemProps {
+  index: number;
+  value: string;
+  error: boolean;
+  onChange: (value: string) => void;
+}
+
+export const WebSeedValidateInputItem: React.FC<WebSeedValidateInputItemProps> = ({
+  index,
+  value,
+  error,
+  onChange,
+}) => {
+  const [hover, setHover] = useState(false);
+  const [focus, setFocus] = useState(false);
+
+  const filled = useMemo(() => {
+    return value.length > 0;
+  }, [value]);
+
+  const keyName = useMemo(() => {
+    return `Word #${index + 1}`;
+  }, [index]);
+
+  const onChangeInput = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      onChange(value);
+    },
+    [onChange],
+  );
+
+  return (
+    <StyledContainer
+      hover={hover}
+      focus={focus}
+      filled={filled}
+      error={error}
+      onMouseOver={(): void => setHover(true)}
+      onMouseOut={(): void => setHover(false)}
+    >
+      <StyledTitle hover={hover} focus={focus} filled={filled} error={error}>
+        {keyName}
+      </StyledTitle>
+      <StyledInput
+        hover={hover}
+        focus={focus}
+        filled={filled}
+        value={value}
+        onFocus={(): void => setFocus(true)}
+        onBlur={(): void => setFocus(false)}
+        onChange={onChangeInput}
+        error={error}
+      />
+    </StyledContainer>
+  );
+};

--- a/packages/adena-extension/src/components/atoms/web-seed-validate-input-item/web-seed-input.stories.tsx
+++ b/packages/adena-extension/src/components/atoms/web-seed-validate-input-item/web-seed-input.stories.tsx
@@ -1,0 +1,17 @@
+import { action } from '@storybook/addon-actions';
+import { Meta, StoryObj } from '@storybook/react';
+import { WebSeedValidateInputItem } from '.';
+
+export default {
+  title: 'components/atoms/WebSeedValidateInputItem',
+  component: WebSeedValidateInputItem,
+} as Meta<typeof WebSeedValidateInputItem>;
+
+export const Default: StoryObj<typeof WebSeedValidateInputItem> = {
+  args: {
+    index: 1,
+    value: '',
+    error: false,
+    onChange: action('onChange'),
+  },
+};

--- a/packages/adena-extension/src/hooks/web/common/use-create-password-screen.ts
+++ b/packages/adena-extension/src/hooks/web/common/use-create-password-screen.ts
@@ -40,6 +40,7 @@ export type UseCreatePasswordScreenReturn = {
     disabled: boolean;
   };
   indicatorInfo: UseIndicatorStepReturn;
+  validateMatchPassword: () => boolean;
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   clearPassword: () => void;
 };
@@ -213,6 +214,7 @@ export const useCreatePasswordScreen = (): UseCreatePasswordScreenReturn => {
       onClick: onClickCreateButton,
       disabled: disabledCreateButton,
     },
+    validateMatchPassword,
     onKeyDown: onKeyDownInput,
     clearPassword,
   };

--- a/packages/adena-extension/src/hooks/web/use-wallet-create-screen.ts
+++ b/packages/adena-extension/src/hooks/web/use-wallet-create-screen.ts
@@ -20,7 +20,7 @@ export type UseWalletCreateReturn = {
   onClickNext: () => void;
 };
 
-export type WalletCreateStateType = 'INIT' | 'GET_SEED_PHRASE';
+export type WalletCreateStateType = 'INIT' | 'GET_SEED_PHRASE' | 'VALIDATE_MNEMONIC';
 
 const useWalletCreateScreen = (): UseWalletCreateReturn => {
   const { navigate, params } = useAppNavigate<RoutePath.WebWalletCreate>();
@@ -35,6 +35,7 @@ const useWalletCreateScreen = (): UseWalletCreateReturn => {
   const walletCreateStepNo = {
     INIT: 0,
     GET_SEED_PHRASE: 1,
+    VALIDATE_MNEMONIC: 2,
   };
 
   const indicatorInfo = useIndicatorStep<string>({
@@ -52,6 +53,8 @@ const useWalletCreateScreen = (): UseWalletCreateReturn => {
       navigate(RoutePath.WebAdvancedOption);
     } else if (step === 'GET_SEED_PHRASE') {
       setStep('INIT');
+    } else if (step === 'VALIDATE_MNEMONIC') {
+      setStep('GET_SEED_PHRASE');
     }
   }, [step]);
 
@@ -67,6 +70,8 @@ const useWalletCreateScreen = (): UseWalletCreateReturn => {
         });
       }
     } else if (step === 'GET_SEED_PHRASE') {
+      setStep('VALIDATE_MNEMONIC');
+    } else if (step === 'VALIDATE_MNEMONIC') {
       if (wallet) {
         let rawSeeds = stringFromBase64(seeds);
         const keyring = await HDWalletKeyring.fromMnemonic(rawSeeds);
@@ -96,7 +101,6 @@ const useWalletCreateScreen = (): UseWalletCreateReturn => {
         rawSeeds = '';
 
         const serializedWallet = await createdWallet.serialize('');
-
         navigate(RoutePath.WebCreatePassword, {
           state: { serializedWallet, stepLength: indicatorInfo.stepLength },
         });

--- a/packages/adena-extension/src/pages/web/create-password-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/create-password-screen/index.tsx
@@ -60,6 +60,7 @@ const CreatePasswordScreen = (): JSX.Element => {
     termsState,
     errorMessage,
     buttonState,
+    validateMatchPassword,
     onKeyDown,
     clearPassword,
   } = useCreatePasswordScreen();
@@ -72,6 +73,10 @@ const CreatePasswordScreen = (): JSX.Element => {
 
   const onClickNext = (): void => {
     if (buttonState.disabled) {
+      return;
+    }
+
+    if (!validateMatchPassword()) {
       return;
     }
 

--- a/packages/adena-extension/src/pages/web/wallet-create-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-create-screen/index.tsx
@@ -3,11 +3,12 @@ import { ReactElement } from 'react';
 import { WebMain } from '@components/atoms';
 import { WebMainHeader } from '@components/pages/web/main-header';
 
-import GetMnemonicStep from './get-mnemonic-step';
-import useWalletCreateScreen from '@hooks/web/use-wallet-create-screen';
-import SensitiveInfoStep from '@components/pages/web/sensitive-info-step';
 import { ADENA_DOCS_PAGE } from '@common/constants/resource.constant';
 import { WEB_TOP_SPACING, WEB_TOP_SPACING_RESPONSIVE } from '@common/constants/ui.constant';
+import SensitiveInfoStep from '@components/pages/web/sensitive-info-step';
+import useWalletCreateScreen from '@hooks/web/use-wallet-create-screen';
+import GetMnemonicStep from './get-mnemonic-step';
+import ValidateMnemonicStep from './validate-mnemonic-step';
 
 const WalletCreateScreen = (): ReactElement => {
   const useWalletCreateScreenReturn = useWalletCreateScreen();
@@ -31,6 +32,9 @@ const WalletCreateScreen = (): ReactElement => {
       )}
       {step === 'GET_SEED_PHRASE' && (
         <GetMnemonicStep useWalletCreateScreenReturn={useWalletCreateScreenReturn} />
+      )}
+      {step === 'VALIDATE_MNEMONIC' && (
+        <ValidateMnemonicStep useWalletCreateScreenReturn={useWalletCreateScreenReturn} />
       )}
     </WebMain>
   );

--- a/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.tsx
@@ -110,7 +110,7 @@ const ValidateMnemonicStep = ({
         disabled={!availableToNext}
         style={{ justifyContent: 'center' }}
       >
-        <WebText type='title4'>Reveal Seed Phrase</WebText>
+        <WebText type='title4'>Next</WebText>
       </WebButton>
     </StyledContainer>
   );

--- a/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.tsx
@@ -108,6 +108,7 @@ const ValidateMnemonicStep = ({
         size='small'
         onClick={validate}
         disabled={!availableToNext}
+        rightIcon='chevronRight'
         style={{ justifyContent: 'center' }}
       >
         <WebText type='title4'>Next</WebText>

--- a/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.tsx
@@ -1,0 +1,119 @@
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+
+import { stringFromBase64 } from '@common/utils/encoding-util';
+import { View, WebButton, WebText } from '@components/atoms';
+import { WebSeedValidateInputItem } from '@components/atoms/web-seed-validate-input-item';
+import { WebTitleWithDescription } from '@components/molecules';
+import { UseWalletCreateReturn } from '@hooks/web/use-wallet-create-screen';
+
+const StyledContainer = styled(View)`
+  width: 100%;
+  row-gap: 24px;
+`;
+
+const ValidateMnemonicStep = ({
+  useWalletCreateScreenReturn,
+}: {
+  useWalletCreateScreenReturn: UseWalletCreateReturn;
+}): ReactElement => {
+  const { seeds, onClickNext } = useWalletCreateScreenReturn;
+
+  const [firstSeed, setFirstSeed] = useState('');
+  const [secondSeed, setSecondSeed] = useState('');
+  const [firstSeedError, setFirstSeedError] = useState(false);
+  const [secondSeedError, setSecondSeedError] = useState(false);
+
+  const [validateSeedIndexes, setValidateSeedIndexes] = useState<number[]>([]);
+
+  const availableToNext = useMemo(() => {
+    return firstSeed.length > 0 && secondSeed.length > 0;
+  }, [firstSeed, secondSeed]);
+
+  const hasValidatedIndexes = useMemo(() => {
+    return validateSeedIndexes.length === 2;
+  }, [validateSeedIndexes]);
+
+  const validate = useCallback(() => {
+    if (!availableToNext || validateSeedIndexes.length !== 2) {
+      return;
+    }
+
+    let currentSeeds = stringFromBase64(seeds);
+
+    const currentSeedsArray = currentSeeds.split(' ');
+    const firstSeedIndex = currentSeedsArray.findIndex((word) => word === firstSeed);
+    const secondSeedIndex = currentSeedsArray.findIndex((word) => word === secondSeed);
+
+    currentSeeds = '';
+
+    const isValidateFirstSeed = firstSeedIndex === validateSeedIndexes[0];
+    const isValidateSecondSeed = secondSeedIndex === validateSeedIndexes[1];
+
+    if (!isValidateFirstSeed) {
+      setFirstSeedError(true);
+    }
+    if (!isValidateSecondSeed) {
+      setSecondSeedError(true);
+    }
+
+    if (isValidateFirstSeed && isValidateSecondSeed) {
+      onClickNext();
+    }
+  }, [firstSeed, secondSeed, seeds, validateSeedIndexes, availableToNext, onClickNext]);
+
+  const onChangeFirstSeed = useCallback((value: string) => {
+    setFirstSeed(value);
+    setFirstSeedError(false);
+  }, []);
+
+  const onChangeSecondSeed = useCallback((value: string) => {
+    setSecondSeed(value);
+    setSecondSeedError(false);
+  }, []);
+  useEffect(() => {
+    const randomIndexes = Array.from({ length: 2 }, () => Math.floor(Math.random() * 12)).sort(
+      (a, b) => a - b,
+    );
+    setValidateSeedIndexes(randomIndexes);
+  }, []);
+
+  return (
+    <StyledContainer>
+      <WebTitleWithDescription
+        title='Verify Your Seed Phrase'
+        description='Enter the requested words from your seed phrase in the fields below.'
+        marginBottom={-6}
+      />
+
+      {hasValidatedIndexes && (
+        <View style={{ width: '100%', gap: 16 }}>
+          <WebSeedValidateInputItem
+            index={validateSeedIndexes[0]}
+            value={firstSeed}
+            error={firstSeedError}
+            onChange={onChangeFirstSeed}
+          />
+          <WebSeedValidateInputItem
+            index={validateSeedIndexes[1]}
+            value={secondSeed}
+            error={secondSeedError}
+            onChange={onChangeSecondSeed}
+          />
+        </View>
+      )}
+
+      <WebButton
+        figure='primary'
+        size='small'
+        onClick={validate}
+        disabled={!availableToNext}
+        style={{ justifyContent: 'center' }}
+      >
+        <WebText type='title4'>Reveal Seed Phrase</WebText>
+      </WebButton>
+    </StyledContainer>
+  );
+};
+
+export default ValidateMnemonicStep;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:
This PR adds a verification step to the wallet creation flow that requires users to confirm their seed phrase by entering specific words from it. This ensures users have properly recorded their seed phrase before proceeding to wallet creation.

## Changes
- Added a new step `VALIDATE_MNEMONIC` to the wallet creation flow
- Created a new component `WebSeedValidateInputItem` for seed word input validation
- Implemented `ValidateMnemonicStep` component to handle the verification process
- Updated the wallet creation flow to include the verification step between showing the seed phrase and creating the wallet

## How it works
1. After viewing their seed phrase, users are presented with a verification screen
2. The system randomly selects two words from the seed phrase
3. Users must correctly enter these words to proceed
4. If incorrect words are entered, error states are shown
5. Only after successful verification can users proceed to wallet creation

## Screenshots
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/c4aac9dc-e3cd-4cf4-8292-9314d866b53a" />

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/9e2e1e2d-df65-4373-82ee-11037766d98c" />
