### PR TITLE
feat: query gas price from chain

### DIFF
--- a/packages/adena-extension/src/common/constants/gas.constant.ts
+++ b/packages/adena-extension/src/common/constants/gas.constant.ts
@@ -17,8 +17,8 @@ export const DEFAULT_GAS_PRICE_STEP: Record<NetworkFeeSettingType, number> = {
 } as const;
 
 export const DEFAULT_GAS_PRICE_RATE: Record<NetworkFeeSettingType, number> = {
-  FAST: 4,
-  AVERAGE: 2.5,
+  FAST: 1.2,
+  AVERAGE: 1.1,
   SLOW: 1,
 } as const;
 

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas-info.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas-info.ts
@@ -3,10 +3,10 @@ import { GasToken } from '@common/constants/token.constant';
 import { DEFAULT_GAS_WANTED } from '@common/constants/tx.constant';
 import { useAdenaContext } from '@hooks/use-context';
 import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
-import { GasInfo, NetworkFeeSettingType } from '@types';
+import { GasInfo } from '@types';
 import { Document, documentToDefaultTx } from 'adena-module';
 import BigNumber from 'bignumber.js';
-import { useGetGasPriceTier } from './use-get-gas-price';
+import { useGetGasPrice } from './use-get-gas-price';
 
 export const GET_ESTIMATE_GAS_INFO_KEY = 'transactionGas/useGetSingleEstimateGas';
 
@@ -62,8 +62,8 @@ export const useGetEstimateGasInfo = (
   gasUsed: number,
   options?: UseQueryOptions<GasInfo | null, Error>,
 ): UseQueryResult<GasInfo | null> => {
+  const { data: gasPrice } = useGetGasPrice();
   const { transactionGasService } = useAdenaContext();
-  const { data: gasPriceTier } = useGetGasPriceTier(GasToken.denom);
 
   return useQuery<GasInfo | null, Error>({
     queryKey: [
@@ -72,14 +72,12 @@ export const useGetEstimateGasInfo = (
       document?.msgs || '',
       document?.memo || '',
       gasUsed,
-      gasPriceTier?.[NetworkFeeSettingType.AVERAGE] || 0,
+      gasPrice || 0,
     ],
     queryFn: async () => {
-      if (!document || !gasPriceTier) {
+      if (!document || !gasPrice) {
         return null;
       }
-
-      const gasPrice = gasPriceTier?.[NetworkFeeSettingType.AVERAGE];
 
       const { gasFee, gasWanted } = makeGasInfoBy(gasUsed, gasPrice);
       if (!transactionGasService || !gasFee || !gasWanted) {

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-gas-price.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-gas-price.ts
@@ -1,48 +1,23 @@
-import { DEFAULT_GAS_PRICE_STEP, MINIMUM_GAS_PRICE } from '@common/constants/gas.constant';
 import { useAdenaContext } from '@hooks/use-context';
-import { useNetwork } from '@hooks/use-network';
 import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
-import { NetworkFeeSettingType } from '@types';
-import BigNumber from 'bignumber.js';
 
 export const GET_GAS_PRICE = 'transactionGas/useGetGasPrice';
 
 const REFETCH_INTERVAL = 5_000;
 
-export const useGetGasPriceTier = (
-  denomination: string,
-  options?: UseQueryOptions<Record<NetworkFeeSettingType, number> | null, Error>,
-): UseQueryResult<Record<NetworkFeeSettingType, number> | null> => {
-  const { currentNetwork } = useNetwork();
+export const useGetGasPrice = (
+  options?: UseQueryOptions<number | null, Error>,
+): UseQueryResult<number | null> => {
   const { transactionGasService } = useAdenaContext();
 
-  return useQuery<Record<NetworkFeeSettingType, number> | null, Error>({
-    queryKey: [GET_GAS_PRICE, denomination, transactionGasService],
+  return useQuery<number | null, Error>({
+    queryKey: [GET_GAS_PRICE, transactionGasService],
     queryFn: () => {
-      if (!currentNetwork.indexerUrl || !transactionGasService) {
-        return DEFAULT_GAS_PRICE_STEP;
+      if (!transactionGasService) {
+        return null;
       }
 
-      return transactionGasService
-        .getGasPrice(denomination)
-        .then((tierInfo) => ({
-          [NetworkFeeSettingType.FAST]: handleInsufficientGasPrice(
-            tierInfo?.low || 0,
-            DEFAULT_GAS_PRICE_STEP.FAST,
-          ),
-          [NetworkFeeSettingType.AVERAGE]: handleInsufficientGasPrice(
-            tierInfo?.high || 0,
-            DEFAULT_GAS_PRICE_STEP.AVERAGE,
-          ),
-          [NetworkFeeSettingType.SLOW]: handleInsufficientGasPrice(
-            tierInfo?.average || 0,
-            DEFAULT_GAS_PRICE_STEP.SLOW,
-          ),
-        }))
-        .catch((e) => {
-          console.error(e);
-          return null;
-        });
+      return transactionGasService.getGasPrice();
     },
     refetchInterval: REFETCH_INTERVAL,
     enabled: !!transactionGasService,
@@ -50,17 +25,3 @@ export const useGetGasPriceTier = (
     ...options,
   });
 };
-
-function handleInsufficientGasPrice(
-  price: number,
-  defaultPrice: number,
-  overPrice = 1,
-  lowerPrice = MINIMUM_GAS_PRICE,
-): number {
-  const priceBN = BigNumber(price.toFixed(6));
-  if (priceBN.isGreaterThanOrEqualTo(overPrice) || priceBN.isLessThanOrEqualTo(lowerPrice)) {
-    return defaultPrice;
-  }
-
-  return priceBN.toNumber();
-}

--- a/packages/adena-extension/src/hooks/wallet/use-network-fee.ts
+++ b/packages/adena-extension/src/hooks/wallet/use-network-fee.ts
@@ -9,7 +9,6 @@ import {
   useGetEstimateGasInfo,
 } from './transaction-gas/use-get-estimate-gas-info';
 import { useGetEstimateGasPriceTiers } from './transaction-gas/use-get-estimate-gas-price-tiers';
-import { useGetGasPriceTier } from './transaction-gas/use-get-gas-price';
 
 export interface UseNetworkFeeReturn {
   isLoading: boolean;
@@ -43,7 +42,6 @@ export const useNetworkFee = (
   const [selectedTier, setSelectedTier] = useState(!isDefaultGasPrice);
   const [gasAdjustment, setGasAdjustment] = useState<string>(DEFAULT_GAS_ADJUSTMENT.toString());
 
-  const { data: gasPriceTier } = useGetGasPriceTier(GasToken.denom);
   const { data: defaultEstimatedGasInfo, isFetched: isFetchedDefaultEstimatedGasInfo } =
     useGetDefaultEstimateGasInfo(document);
   const { data: estimatedGasInfo, isFetched: isFetchedEstimateGasInfo } = useGetEstimateGasInfo(
@@ -59,7 +57,7 @@ export const useNetworkFee = (
   );
 
   const isLoading = useMemo(() => {
-    if (gasPriceTier === undefined || gasPriceTiers === undefined) {
+    if (gasPriceTiers === undefined) {
       return true;
     }
 
@@ -69,7 +67,6 @@ export const useNetworkFee = (
 
     return false;
   }, [
-    gasPriceTier,
     gasPriceTiers,
     isFetchedDefaultEstimatedGasInfo,
     isFetchedEstimateGasInfo,
@@ -145,10 +142,6 @@ export const useNetworkFee = (
   }, [currentGasInfo?.gasFee, document, selectedTier]);
 
   const networkFee = useMemo(() => {
-    if (!gasPriceTier) {
-      return null;
-    }
-
     if (!currentGasInfo) {
       return null;
     }
@@ -163,7 +156,7 @@ export const useNetworkFee = (
       amount: networkFeeAmount,
       denom: GasToken.symbol,
     };
-  }, [gasPriceTier, currentGasInfo]);
+  }, [currentGasInfo]);
 
   const setNetworkFeeSetting = useCallback((settingInfo: NetworkFeeSettingInfo): void => {
     setNetworkFeeSettingType(settingInfo.settingType);

--- a/packages/adena-extension/src/repositories/transaction/types.ts
+++ b/packages/adena-extension/src/repositories/transaction/types.ts
@@ -1,9 +1,8 @@
 import { ResponseDeliverTx } from '@common/provider/gno/proto/tm2/abci';
 import { Tx } from '@gnolang/tm2-js-client';
-import { TransactionGasResponse } from './response/transaction-gas-response';
 
 export interface ITransactionGasRepository {
-  fetchGasPrices: () => Promise<TransactionGasResponse[]>;
+  fetchGasPrices: () => Promise<number | null>;
   simulateTx: (tx: Tx) => Promise<ResponseDeliverTx>;
   estimateGasByTx: (tx: Tx) => Promise<number>;
 }

--- a/packages/adena-extension/src/services/transaction/transaction-gas.ts
+++ b/packages/adena-extension/src/services/transaction/transaction-gas.ts
@@ -1,7 +1,6 @@
 import { ResponseDeliverTx } from '@common/provider/gno/proto/tm2/abci';
 import { Tx } from '@gnolang/tm2-js-client';
 import { ITransactionGasRepository } from '@repositories/transaction/types';
-import { GasPriceTierInfo } from '@types';
 import { ITransactionGasService } from '..';
 
 export class TransactionGasService implements ITransactionGasService {
@@ -11,15 +10,8 @@ export class TransactionGasService implements ITransactionGasService {
     this.gasRepository = gasRepository;
   }
 
-  public async getGasPrice(denomination: string): Promise<GasPriceTierInfo | null> {
-    const gasPrices = await this.gasRepository.fetchGasPrices();
-
-    const gasPrice = gasPrices.find((gasPrice) => gasPrice.denom === denomination);
-    if (!gasPrice) {
-      return null;
-    }
-
-    return gasPrice;
+  public async getGasPrice(): Promise<number | null> {
+    return this.gasRepository.fetchGasPrices();
   }
 
   public async simulateTx(tx: Tx): Promise<ResponseDeliverTx> {

--- a/packages/adena-extension/src/services/transaction/types.ts
+++ b/packages/adena-extension/src/services/transaction/types.ts
@@ -1,9 +1,8 @@
 import { ResponseDeliverTx } from '@common/provider/gno/proto/tm2/abci';
 import { Tx } from '@gnolang/tm2-js-client';
-import { GasPriceTierInfo } from '@types';
 
 export interface ITransactionGasService {
-  getGasPrice: (denomination: string) => Promise<GasPriceTierInfo | null>;
+  getGasPrice: () => Promise<number | null>;
   simulateTx(tx: Tx): Promise<ResponseDeliverTx>;
   estimateGas(tx: Tx): Promise<number>;
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:
This PR implements direct gas price querying from the chain instead of using the indexer. The changes include updating the gas price calculation logic and simplifying the related interfaces.

## Changes
- Implement `getGasPrice` method in `GnoProvider` to query gas price directly from chain
- Update gas price constants and calculation logic
- Simplify gas price related interfaces and remove unnecessary complexity
- Remove indexer-based gas price fetching

## Technical Details
### Gas Price Query
- Added new ABCI query endpoint for gas price
- Implemented gas price parsing from chain response
- Updated gas price calculation with new base values

### Interface Changes
- Simplified `ITransactionGasRepository` interface
- Removed `GasPriceTierInfo` type