### PR TITLE
fix: handle broadcast transaction before calculating gas fee

### DIFF
--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -207,11 +207,7 @@ const TransferSummaryContainer: React.FC = () => {
   ]);
 
   const transfer = async (): Promise<boolean> => {
-    if (isSent || !currentAccount) {
-      return false;
-    }
-
-    if (isNetworkFeeError) {
+    if (isSent || !currentAccount || !hasNetworkFee || !isNetworkFeeError) {
       return false;
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

This PR addresses an issue where transactions could be broadcasted before properly calculating and validating gas fees. The changes improve the gas fee calculation logic and prevent transaction broadcasting when there are insufficient funds.

### Key Changes
- Added proper balance validation before transaction broadcasting
- Improved error handling for network fee validation