### PR TITLE
fix: disable login button when empty string

### DIFF
--- a/packages/adena-extension/src/pages/popup/certify/login/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/login/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
 
@@ -46,6 +46,10 @@ export const Login = (): JSX.Element => {
   const { loadAccounts } = useLoadAccounts();
   const [existWallet, setExistWallet] = useState(false);
 
+  const availableLogin = useMemo(() => {
+    return password.length > 0;
+  }, [password]);
+
   useEffect(() => {
     walletService
       .existsWallet()
@@ -73,6 +77,10 @@ export const Login = (): JSX.Element => {
   }, [inputRef]);
 
   const login = async (): Promise<void> => {
+    if (!availableLogin) {
+      return;
+    }
+
     try {
       if (validateEmptyPassword(password)) {
         const encryptedPassword = encryptWalletPassword(password);
@@ -127,7 +135,12 @@ export const Login = (): JSX.Element => {
           Forgot Password?
         </Text>
       </ForgetPwd>
-      <Button fullWidth onClick={onClickUnLockButton} margin='auto 0px 0px'>
+      <Button
+        fullWidth
+        onClick={onClickUnLockButton}
+        margin='auto 0px 0px'
+        disabled={!availableLogin}
+      >
         <Text type='body1Bold'>Unlock</Text>
       </Button>
     </Wrapper>

--- a/packages/adena-extension/src/pages/popup/wallet/approve-login/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-login/index.tsx
@@ -1,6 +1,6 @@
 import { WalletResponseFailureType, WalletResponseType } from '@adena-wallet/sdk';
 import { isAirgapAccount } from 'adena-module';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import styled, { useTheme } from 'styled-components';
@@ -43,6 +43,10 @@ export const ApproveLogin = (): JSX.Element => {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [requestData, setRequestData] = useState<{ [key in string]: any } | undefined>(undefined);
 
+  const availableLogin = useMemo(() => {
+    return password.length > 0;
+  }, [password]);
+
   useEffect(() => {
     const data = parseParameters(location.search);
     const parsedData = decodeParameter(data['data']);
@@ -83,6 +87,10 @@ export const ApproveLogin = (): JSX.Element => {
   }, [inputRef]);
 
   const tryLoginApprove = async (password: string): Promise<void> => {
+    if (!availableLogin) {
+      return;
+    }
+
     let currentError = null;
     try {
       validateEmptyPassword(password);
@@ -178,7 +186,12 @@ export const ApproveLogin = (): JSX.Element => {
               Forgot Password?
             </Text>
           </ForgetPwd>
-          <Button fullWidth onClick={approveButtonClick} margin='auto 0px 0px'>
+          <Button
+            fullWidth
+            onClick={approveButtonClick}
+            margin='auto 0px 0px'
+            disabled={!availableLogin}
+          >
             <Text type='body1Bold'>Unlock</Text>
           </Button>
         </Wrapper>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

This PR improves the login functionality by disabling the login button when the password field is empty. This change enhances both user experience and security by preventing unnecessary login attempts.

### Changes
- Added `availableLogin` state to track password validity
- Disabled login button when password is empty
- Added additional validation check before login attempt
- Applied changes to both main login and approve login pages

### Technical Details
- Added `disabled` prop to Button component
- Implemented early return in login functions when password is empty
