### PR TITLE
fix: adjust transfer conditions

### DIFF
--- a/packages/adena-extension/src/pages/popup/wallet/nft-transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/nft-transfer-summary/index.tsx
@@ -134,7 +134,7 @@ const NFTTransferSummaryContainer: React.FC = () => {
   }, [summaryInfo, currentAccount, currentNetwork, networkFee]);
 
   const transfer = async (): Promise<boolean> => {
-    if (isSent || !currentAccount || !hasNetworkFee) {
+    if (isSent || !currentAccount || !hasNetworkFee || useNetworkFeeReturn.isLoading) {
       return false;
     }
 

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -207,7 +207,7 @@ const TransferSummaryContainer: React.FC = () => {
   ]);
 
   const transfer = async (): Promise<boolean> => {
-    if (isSent || !currentAccount || !hasNetworkFee || !isNetworkFeeError) {
+    if (isSent || !currentAccount || !hasNetworkFee || useNetworkFeeReturn.isLoading) {
       return false;
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:

This PR improves the transfer functionality by properly handling the network fee loading state. It ensures that transfers cannot be initiated while the network fee is still being calculated.

### Changes
- Added network fee loading state check in transfer conditions
- Removed redundant network fee error check
- Applied consistent changes to both NFT and regular transfer flows

### Technical Details
- Added `useNetworkFeeReturn.isLoading` check to transfer conditions
- Removed `isNetworkFeeError` check from regular transfer flow
- Maintained consistent validation logic across transfer types
