### PR TITLE
chore: change the portal-loop to staging

### DIFF
--- a/packages/adena-extension/src/resources/chains/chains.json
+++ b/packages/adena-extension/src/resources/chains/chains.json
@@ -15,13 +15,13 @@
     "linkUrl": "https://gnoscan.io"
   },
   {
-    "id": "portal-loop",
+    "id": "staging",
     "default": true,
     "main": false,
-    "chainId": "portal-loop",
+    "chainId": "staging",
     "chainName": "Gno.land",
-    "networkId": "portal-loop",
-    "networkName": "Portal Loop",
+    "networkId": "staging",
+    "networkName": "Staging",
     "addressPrefix": "g",
     "rpcUrl": "https://rpc.gno.land:443",
     "indexerUrl": "https://indexer.onbloc.xyz",

--- a/packages/adena-extension/src/resources/faucet/faucet-api.json
+++ b/packages/adena-extension/src/resources/faucet/faucet-api.json
@@ -1,4 +1,4 @@
 {
-  "portal-loop": "https://faucet.adena.app",
+  "staging": "https://faucet.adena.app",
   "test6": "https://test6.faucet.adena.app"
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- chore

### What this PR does:
This PR updates the network configuration to use the staging environment instead of portal-loop. This change affects both the chain configuration and faucet API endpoints.

### Changes
- Updated chain configuration in `chains.json`:
  - Changed chain ID from `portal-loop` to `staging`
  - Updated network ID and name
  - Maintained other chain parameters (RPC URL, indexer URL, etc.)
- Updated faucet API configuration in `faucet-api.json`:
  - Changed faucet endpoint mapping from `portal-loop` to `staging`

### Technical Details
- Chain Configuration Changes:
  - `id`: portal-loop → staging
  - `chainId`: portal-loop → staging
  - `networkId`: portal-loop → staging
  - `networkName`: Portal Loop → Staging
- Faucet API Changes:
  - Updated endpoint mapping for staging environment