### PR TITLE
fix: remove inter realm parameter when create a tx-link

### DIFF
--- a/packages/adena-extension/src/common/provider/gno/utils.ts
+++ b/packages/adena-extension/src/common/provider/gno/utils.ts
@@ -86,3 +86,7 @@ export const isHttpsProtocol = (domain: string): boolean => {
 export const isHttpProtocol = (domain: string): boolean => {
   return domain.startsWith(HTTP_PROTOCOL_PREFIX);
 };
+
+export const isInterRealmParameter = (name: string, type: string): boolean => {
+  return name === 'cur' && type === 'realm';
+};

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -2,6 +2,7 @@ import { WalletResponseFailureType, WalletResponseSuccessType } from '@adena-wal
 import { DEFAULT_GAS_WANTED } from '@common/constants/tx.constant';
 import { GnoDocumentInfo } from '@common/provider/gno';
 import { GnoProvider } from '@common/provider/gno/gno-provider';
+import { isInterRealmParameter } from '@common/provider/gno/utils';
 import { MemoryProvider } from '@common/provider/memory/memory-provider';
 import { AdenaExecutor } from '@inject/executor';
 import { ContractMessage, TransactionParams } from '@inject/types';
@@ -171,16 +172,19 @@ function makeTransactionMessage(
     throw new Error(`Function not found: ${gnoMessageInfo.functionName}`);
   }
 
-  const gnoArguments: GnoArgumentInfo[] = func.params.map((param, index) => {
-    const arg = gnoMessageInfo.args?.find((arg) => arg.key === param.name);
-    const value = arg?.value || '';
+  const gnoArguments: GnoArgumentInfo[] = func.params
+    .filter((param) => !isInterRealmParameter(param.name, param.type))
+    .map((param, index) => {
+      const messageArguments = gnoMessageInfo.args || [];
+      const arg = messageArguments.find((arg) => arg.key === param.name);
+      const value = arg?.value || '';
 
-    return {
-      index,
-      key: param.name,
-      value,
-    };
-  });
+      return {
+        index,
+        key: param.name,
+        value,
+      };
+    });
 
   const messageArguments = gnoArguments.map((arg) => {
     return arg.value;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- bug

### What this PR does:
This PR adds functionality to filter out inter-realm parameters when creating transaction links for Gno chain. This prevents unnecessary parameters from being included in transaction messages and improves the transaction creation process.

### Changes
- Added `isInterRealmParameter` utility function to identify inter-realm parameters
- Implemented filtering logic to exclude inter-realm parameters from transaction arguments
- Applied changes to transaction message creation in command handler

### Technical Details
- New utility function: `isInterRealmParameter(name: string, type: string): boolean`
  - Identifies parameters with name 'cur' and type 'realm'
- Modified `makeTransactionMessage` function to filter out inter-realm parameters
- Updated argument mapping logic to exclude filtered parameters

### Code Changes
```typescript
// New utility function
export const isInterRealmParameter = (name: string, type: string): boolean => {
  return name === 'cur' && type === 'realm';
};

// Updated transaction message creation
const gnoArguments: GnoArgumentInfo[] = func.params
  .filter((param) => !isInterRealmParameter(param.name, param.type))
  .map((param, index) => {
    // ... existing mapping logic
  });
```