### PR TITLE
ignore any var type realm - not just "cur"

### DIFF
--- a/packages/adena-extension/src/common/provider/gno/utils.ts
+++ b/packages/adena-extension/src/common/provider/gno/utils.ts
@@ -88,5 +88,5 @@ export const isHttpProtocol = (domain: string): boolean => {
 };
 
 export const isInterRealmParameter = (name: string, type: string): boolean => {
-  return name === 'cur' && type === 'realm';
+  return type === 'realm';
 };


### PR DESCRIPTION
### What type of PR is this?
bugfix

### What this PR does:

When calling gnoland realm functions via RPC - functions that use the 'realm' type are not intended to be populated by an RPC call.

the current wallet code correctly ignores these types but only if the var is named "cur".

This change removes the check on the var being named 'cur'

#### Added info: 

- In practice we are seeing users name this var "_" if it is unused in the gno code. 
- The current gno.land build (test6) allows realm vars to use any name.