### PR TITLE
fix: update account state

### DIFF
--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas-price-tiers.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas-price-tiers.ts
@@ -28,7 +28,7 @@ export const useGetEstimateGasPriceTiers = (
   gasAdjustment: string,
   options?: UseQueryOptions<NetworkFeeSettingInfo[] | null, Error>,
 ): UseQueryResult<NetworkFeeSettingInfo[] | null> => {
-  const { currentAddress } = useCurrentAccount();
+  const { currentAccount, currentAddress } = useCurrentAccount();
   const { transactionGasService, transactionService } = useAdenaContext();
   const { data: gasPrice } = useGetGasPrice();
   const { wallet } = useWalletContext();
@@ -36,10 +36,14 @@ export const useGetEstimateGasPriceTiers = (
 
   return useQuery<NetworkFeeSettingInfo[] | null, Error>({
     queryKey: [
+      wallet,
+      currentAccount?.id,
       GET_ESTIMATE_GAS_PRICE_TIERS,
       transactionGasService,
       document?.msgs,
       document?.memo,
+      document?.account_number,
+      document?.sequence,
       gasUsed,
       gasAdjustment,
       gasPrice || 0,
@@ -71,6 +75,7 @@ export const useGetEstimateGasPriceTiers = (
 
           const tx = await makeEstimateGasTransaction(
             wallet,
+            currentAccount,
             transactionService,
             document,
             Number(adjustGasUsed),

--- a/packages/adena-extension/src/pages/popup/wallet/approve-sign-transaction/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-sign-transaction/index.tsx
@@ -282,7 +282,11 @@ const ApproveSignTransactionContainer: React.FC = () => {
 
     try {
       setProcessType('PROCESSING');
-      const { signed } = await transactionService.createTransaction(wallet, document);
+      const { signed } = await transactionService.createTransaction(
+        wallet,
+        currentAccount,
+        document,
+      );
       const encodedTransaction = transactionService.encodeTransaction(signed);
       setResponse(
         InjectionMessageInstance.success(

--- a/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
@@ -351,7 +351,11 @@ const ApproveTransactionContainer: React.FC = () => {
       const walletInstance = wallet.clone();
       walletInstance.currentAccountId = currentAccount.id;
 
-      const { signed } = await transactionService.createTransaction(walletInstance, document);
+      const { signed } = await transactionService.createTransaction(
+        walletInstance,
+        currentAccount,
+        document,
+      );
 
       const hash = transactionService.createHash(signed);
 

--- a/packages/adena-extension/src/pages/popup/wallet/nft-transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/nft-transfer-summary/index.tsx
@@ -126,7 +126,11 @@ const NFTTransferSummaryContainer: React.FC = () => {
     const walletInstance = wallet.clone();
     walletInstance.currentAccountId = currentAccount.id;
 
-    const { signed } = await transactionService.createTransaction(walletInstance, document);
+    const { signed } = await transactionService.createTransaction(
+      walletInstance,
+      currentAccount,
+      document,
+    );
 
     return transactionService.sendTransaction(walletInstance, currentAccount, signed).catch((e) => {
       console.error(e);

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -192,7 +192,11 @@ const TransferSummaryContainer: React.FC = () => {
     const walletInstance = wallet.clone();
     walletInstance.currentAccountId = currentAccount.id;
 
-    const { signed } = await transactionService.createTransaction(walletInstance, document);
+    const { signed } = await transactionService.createTransaction(
+      walletInstance,
+      currentAccount,
+      document,
+    );
 
     return transactionService.sendTransaction(walletInstance, currentAccount, signed).catch((e) => {
       console.error(e);

--- a/packages/adena-extension/src/services/transaction/transaction.ts
+++ b/packages/adena-extension/src/services/transaction/transaction.ts
@@ -125,10 +125,11 @@ export class TransactionService {
    */
   public createTransaction = async (
     wallet: Wallet,
+    account: Account,
     document: Document,
   ): Promise<{ signed: Tx; signature: EncodeTxSignature[] }> => {
     const provider = this.getGnoProvider();
-    const { signed, signature } = await wallet.sign(provider, document);
+    const { signed, signature } = await wallet.signByAccountId(provider, account.id, document);
     const encodedSignature = signature.map((s) => ({
       pubKey: {
         typeUrl: s?.pub_key?.type_url,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->

- bug

### What this PR does:

This PR fixes an issue where the transaction creation process was not properly maintaining account state consistency across the application.

### Problem

The `TransactionService.createTransaction` method was using `wallet.sign()` which relies on the wallet's `currentAccount` property. This approach had several issues: