### PR TITLE
chore: bump gno libraries

### DIFF
--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -77,8 +77,8 @@
   "dependencies": {
     "@adena-wallet/sdk": "0.0.12",
     "@bufbuild/protobuf": "2.2.3",
-    "@gnolang/gno-js-client": "1.4.2",
-    "@gnolang/tm2-js-client": "1.3.1",
+    "@gnolang/gno-js-client": "1.4.4",
+    "@gnolang/tm2-js-client": "1.3.3",
     "@tanstack/react-query": "4.36.1",
     "adena-module": "*",
     "adena-torus-signin": "*",

--- a/packages/adena-extension/src/common/provider/gno/gno-provider.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.ts
@@ -47,13 +47,13 @@ export class GnoProvider extends GnoJSONRPCProvider {
   }
 
   public async getAccountNumber(address: string, height?: number | undefined): Promise<number> {
-    return this.getAccount(address, height)
+    return this.getAccountInfo(address, height)
       .then((account) => Number(account?.accountNumber ?? 0))
       .catch(() => 0);
   }
 
   public async getAccountSequence(address: string, height?: number | undefined): Promise<number> {
-    return this.getAccount(address, height)
+    return this.getAccountInfo(address, height)
       .then((account) => Number(account?.sequence ?? 0))
       .catch(() => 0);
   }
@@ -87,7 +87,7 @@ export class GnoProvider extends GnoJSONRPCProvider {
     return priceAmount / gasPrice.gas;
   }
 
-  public async getAccount(
+  public async getAccountInfo(
     address: string,
     height?: number | undefined,
   ): Promise<AccountInfo | null> {

--- a/packages/adena-extension/src/services/transaction/transaction.ts
+++ b/packages/adena-extension/src/services/transaction/transaction.ts
@@ -72,7 +72,7 @@ export class TransactionService {
   ): Promise<Document> => {
     const provider = this.getGnoProvider();
     const address = await account.getAddress(defaultAddressPrefix);
-    const accountInfo = await provider.getAccount(address).catch(() => null);
+    const accountInfo = await provider.getAccountInfo(address).catch(() => null);
     const accountNumber = accountInfo?.accountNumber ?? 0;
     const accountSequence = accountInfo?.sequence ?? 0;
     return {

--- a/packages/adena-extension/src/services/wallet/wallet-account.ts
+++ b/packages/adena-extension/src/services/wallet/wallet-account.ts
@@ -55,7 +55,7 @@ export class WalletAccountService {
     gnoProvider: GnoProvider,
   ): Promise<AccountInfo> => {
     try {
-      const account = await gnoProvider.getAccount(address);
+      const account = await gnoProvider.getAccountInfo(address);
       if (account) {
         return account;
       }

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@cosmjs/ledger-amino": "0.36.0",
-    "@gnolang/gno-js-client": "1.4.2",
-    "@gnolang/tm2-js-client": "1.3.1",
+    "@gnolang/gno-js-client": "1.4.4",
+    "@gnolang/tm2-js-client": "1.3.3",
     "@ledgerhq/hw-transport": "6.31.4",
     "@ledgerhq/hw-transport-mocker": "6.29.4",
     "@ledgerhq/hw-transport-webhid": "6.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,6 +2159,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gnolang/gno-js-client@npm:1.4.4":
+  version: 1.4.4
+  resolution: "@gnolang/gno-js-client@npm:1.4.4"
+  dependencies:
+    "@cosmjs/ledger-amino": ^0.36.0
+    "@gnolang/tm2-js-client": ^1.3.3
+    long: ^5.3.2
+    protobufjs: ^7.5.3
+  checksum: 764d52c92aceb8a4eb2ae28f834905480837b64a6b26495dec6b38138fd11aac816b8a1d66e3cab686818c7ced62c878c3e6df1a85befc4816c1d9736e545127
+  languageName: node
+  linkType: hard
+
 "@gnolang/tm2-js-client@npm:1.3.1, @gnolang/tm2-js-client@npm:^1.3.1":
   version: 1.3.1
   resolution: "@gnolang/tm2-js-client@npm:1.3.1"
@@ -2173,6 +2185,23 @@ __metadata:
     uuid: ^11.1.0
     ws: ^8.18.0
   checksum: 037e44b0cfbfa08d9d251bac18a0d288f93393876155fcf2880d40e571eb392fd8202b7b23d03dd1acd15ddbe4a304826dafb5eb4a7b9f66da3d696271732474
+  languageName: node
+  linkType: hard
+
+"@gnolang/tm2-js-client@npm:1.3.3, @gnolang/tm2-js-client@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@gnolang/tm2-js-client@npm:1.3.3"
+  dependencies:
+    "@cosmjs/amino": ^0.36.0
+    "@cosmjs/crypto": ^0.36.0
+    "@cosmjs/ledger-amino": ^0.36.0
+    "@types/uuid": ^10.0.0
+    axios: ^1.11.0
+    long: ^5.3.2
+    protobufjs: ^7.5.3
+    uuid: ^11.1.0
+    ws: ^8.18.0
+  checksum: 4a7ac6e4d560f30b1a49dc35e438266f6440f86808941c18723bc0163ab9d3ecde5e9a141874d620c3c0818d766a19c4abf35870bf1e171e681992aa48edf163
   languageName: node
   linkType: hard
 
@@ -6065,8 +6094,8 @@ __metadata:
     "@babel/preset-react": 7.23.3
     "@babel/preset-typescript": 7.23.3
     "@bufbuild/protobuf": 2.2.3
-    "@gnolang/gno-js-client": 1.4.2
-    "@gnolang/tm2-js-client": 1.3.1
+    "@gnolang/gno-js-client": 1.4.4
+    "@gnolang/tm2-js-client": 1.3.3
     "@jest/globals": 29.7.0
     "@storybook/addon-essentials": 8.5.8
     "@storybook/addon-interactions": 8.5.8
@@ -6149,8 +6178,8 @@ __metadata:
     "@babel/preset-flow": 7.23.3
     "@babel/preset-typescript": 7.23.3
     "@cosmjs/ledger-amino": 0.36.0
-    "@gnolang/gno-js-client": 1.4.2
-    "@gnolang/tm2-js-client": 1.3.1
+    "@gnolang/gno-js-client": 1.4.4
+    "@gnolang/tm2-js-client": 1.3.3
     "@ledgerhq/hw-transport": 6.31.4
     "@ledgerhq/hw-transport-mocker": 6.29.4
     "@ledgerhq/hw-transport-webhid": 6.30.0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->

- feature

### What this PR does:

Bump gno libraries to unlock `SignTransactionOptions`

I also had to rename `getAccount` to `getAccountInfo` in `GnoProvider` since it now conflicts with the new inherited `getAccount`