### PR TITLE
fix: resolve inactive account login failure

### DIFF
--- a/packages/adena-extension/src/common/provider/gno/gno-provider.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.ts
@@ -91,39 +91,46 @@ export class GnoProvider extends GnoJSONRPCProvider {
     address: string,
     height?: number | undefined,
   ): Promise<AccountInfo | null> {
+    const inActiveAccount: AccountInfo = {
+      address,
+      coins: '',
+      chainId: '',
+      status: 'IN_ACTIVE',
+      publicKey: null,
+      accountNumber: '0',
+      sequence: '0',
+    };
+
     const abciAccount = await this.getAccount(address, height).catch((e) => {
       console.info(e);
       return null;
     });
 
     if (!abciAccount || !abciAccount.BaseAccount) {
-      return {
-        address: '',
-        coins: '',
-        chainId: '',
-        status: 'IN_ACTIVE',
-        publicKey: null,
-        accountNumber: '0',
-        sequence: '0',
-      };
+      return inActiveAccount;
     }
 
-    const {
-      coins,
-      public_key: publicKey,
-      account_number: accountNumber,
-      sequence,
-    } = abciAccount.BaseAccount;
+    try {
+      const {
+        coins,
+        public_key: publicKey,
+        account_number: accountNumber,
+        sequence,
+      } = abciAccount.BaseAccount;
 
-    return {
-      address,
-      coins,
-      chainId: this.chainId ?? '',
-      status: 'ACTIVE',
-      publicKey,
-      accountNumber,
-      sequence,
-    };
+      return {
+        address,
+        coins,
+        chainId: this.chainId ?? '',
+        status: 'ACTIVE',
+        publicKey,
+        accountNumber,
+        sequence,
+      };
+    } catch (e) {
+      console.info(e);
+      return inActiveAccount;
+    }
   }
 
   public getValueByEvaluateExpression(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
- fix
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->

### What this PR does:
#### Problem
Inactive accounts (wallets with no on-chain transaction history) were unable to log in due to the `address` field being returned as an empty string (`""`), causing address validation to fail during the login process.

#### Reproduction Steps
1. Attempt to log in with a new wallet address that has no on-chain history
2. `getAccountInfo()` returns `{ address: "", status: 'IN_ACTIVE', ... }`
3. Login validation fails because `address` is empty
4. User cannot proceed with login ❌

#### Solution
##### Key Changes
1. **Return actual address parameter for inactive accounts**
   ```typescript
   // Before
   return {
     address: "",
     status: 'IN_ACTIVE',
     ...
   };
   
   // After
   return {
     address,  // ✅ Actual wallet address from parameter
     status: 'IN_ACTIVE',
     ...
   };
