### PR TITLE
ADN-749: parameterize bech32 address prefix across wallet paths

### DIFF
--- a/packages/adena-extension/src/common/validation/validation-address-book.ts
+++ b/packages/adena-extension/src/common/validation/validation-address-book.ts
@@ -36,9 +36,10 @@ export const validateAlreadyAddressByAccounts = async (
   currData: AddressBookItem,
   accounts: Account[],
   isAdd: boolean,
+  addressPrefix: string,
 ): Promise<boolean> => {
   let check: boolean;
-  const addresses = await Promise.all(accounts.map((account) => account.getAddress('g')));
+  const addresses = await Promise.all(accounts.map((account) => account.getAddress(addressPrefix)));
   if (isAdd) {
     check = addresses.some((address) => address === currData.address);
   } else {

--- a/packages/adena-extension/src/components/pages/web/main-account-header/index.tsx
+++ b/packages/adena-extension/src/components/pages/web/main-account-header/index.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 import { Account } from 'adena-module';
+import { useNetwork } from '@hooks/use-network';
 
 import { CopyIconButton, Pressable, Row, WebImg, WebText } from '@components/atoms';
 import { formatAddress } from '@common/utils/client-utils';
@@ -29,6 +30,7 @@ export const WebMainAccountHeader = ({
   onClickGoBack,
 }: WebMainAccountHeaderProps): ReactElement => {
   const theme = useTheme();
+  const { currentNetwork } = useNetwork();
   const [address, setAddress] = useState<string>('');
 
   const addressStr = useMemo(() => {
@@ -40,7 +42,7 @@ export const WebMainAccountHeader = ({
 
   useEffect(() => {
     if (account) {
-      account.getAddress('g').then(setAddress);
+      account.getAddress(currentNetwork.addressPrefix).then(setAddress);
     }
   }, [account]);
 

--- a/packages/adena-extension/src/hooks/use-address-book-input.ts
+++ b/packages/adena-extension/src/hooks/use-address-book-input.ts
@@ -66,7 +66,7 @@ export const useAddressBookInput = (): UseAddressBookInputHookReturn => {
 
   const getAddressBookInfos = useCallback(async () => {
     const currentAccountInfos = [];
-    const addressPrefix = currentNetwork?.addressPrefix || 'g';
+    const addressPrefix = currentNetwork.addressPrefix;
     const currentAddress = await getCurrentAddress(addressPrefix);
     for (const account of wallet?.accounts || []) {
       const address = await account.getAddress(addressPrefix);
@@ -156,7 +156,7 @@ export const useAddressBookInput = (): UseAddressBookInputHookReturn => {
         clearError();
         setOpened(false);
         setSelected(true);
-        const address = await selectedAccount.getAddress(currentNetwork?.addressPrefix || 'g');
+        const address = await selectedAccount.getAddress(currentNetwork.addressPrefix);
         setSelectedAddressBook({
           id: selectedAccount.id,
           name: selectedAccount.name,

--- a/packages/adena-extension/src/hooks/use-current-account.tsx
+++ b/packages/adena-extension/src/hooks/use-current-account.tsx
@@ -25,7 +25,7 @@ export const useCurrentAccount = (): {
       if (!currentAccount) {
         return null;
       }
-      return await currentAccount.getAddress(prefix ?? 'g');
+      return await currentAccount.getAddress(prefix ?? currentNetwork.addressPrefix);
     },
     [currentAccount],
   );
@@ -55,7 +55,7 @@ export const useCurrentAccount = (): {
       if (!currentAccount) {
         return null;
       }
-      const address = await currentAccount.getAddress(currentNetwork.addressPrefix ?? 'g');
+      const address = await currentAccount.getAddress(currentNetwork.addressPrefix);
       return address;
     },
     {

--- a/packages/adena-extension/src/hooks/wallet/sign-transaction/use-sign-multisig-transaction-screen.ts
+++ b/packages/adena-extension/src/hooks/wallet/sign-transaction/use-sign-multisig-transaction-screen.ts
@@ -1,5 +1,6 @@
 import { useAdenaContext, useMultisigTransactionContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
+import { useNetwork } from '@hooks/use-network';
 import { useCallback, useState } from 'react';
 
 export type SignTransactionState = 'IDLE' | 'SIGNING' | 'SUCCESS' | 'FAILED';
@@ -17,6 +18,7 @@ const useSignMultisigTransactionScreen = (): UseSignMultisigTransactionScreenRet
 
   const { multisigService } = useAdenaContext();
   const { currentAccount, currentAddress } = useCurrentAccount();
+  const { currentNetwork } = useNetwork();
   const {
     transaction,
     chainId,
@@ -40,6 +42,7 @@ const useSignMultisigTransactionScreen = (): UseSignMultisigTransactionScreenRet
         transaction,
         accountNumber,
         sequence,
+        currentNetwork.addressPrefix,
       );
 
       const fileSaved = await multisigService.saveSignatureToFile(newSignature);

--- a/packages/adena-extension/src/hooks/web/setup-airgap/use-setup-airgap-screen.ts
+++ b/packages/adena-extension/src/hooks/web/setup-airgap/use-setup-airgap-screen.ts
@@ -1,5 +1,4 @@
 import { useCallback, useState } from 'react';
-import { defaultAddressPrefix } from '@gnolang/tm2-js-client';
 import {
   AirgapAccount,
   AddressKeyring,
@@ -11,6 +10,7 @@ import {
 import useAppNavigate from '@hooks/use-app-navigate';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
+import { useNetwork } from '@hooks/use-network';
 import { RoutePath } from '@types';
 import { useLoadAccounts } from '@hooks/use-load-accounts';
 import { waitForRun } from '@common/utils/timeout-utils';
@@ -51,6 +51,7 @@ const useSetupAirgapScreen = (): UseSetupAirgapScreenReturn => {
   const { navigate } = useAppNavigate();
   const { updateWallet } = useWalletContext();
   const { walletService } = useAdenaContext();
+  const { currentNetwork } = useNetwork();
   const { accounts } = useLoadAccounts();
   const [setupAirgapState, setSetupAirgapState] = useState<SetupAirgapStateType>('INIT');
   const [address, setAddress] = useState<string>('');
@@ -76,7 +77,7 @@ const useSetupAirgapScreen = (): UseSetupAirgapScreenReturn => {
   const _validateAddress = useCallback(() => {
     try {
       const { prefix } = fromBech32(address);
-      if (address && prefix === defaultAddressPrefix) {
+      if (address && prefix === currentNetwork.addressPrefix) {
         return true;
       }
     } catch (e) {
@@ -88,7 +89,7 @@ const useSetupAirgapScreen = (): UseSetupAirgapScreenReturn => {
   const _existsAddress = useCallback(async () => {
     const checkAccounts = accounts.filter((account) => isAirgapAccount(account));
     return Promise.all(
-      checkAccounts.map((account) => account.getAddress(defaultAddressPrefix)),
+      checkAccounts.map((account) => account.getAddress(currentNetwork.addressPrefix)),
     ).then((addresses) => addresses.includes(address));
   }, [accounts, address]);
 

--- a/packages/adena-extension/src/hooks/web/setup-multisig/use-setup-multisig-screen.ts
+++ b/packages/adena-extension/src/hooks/web/setup-multisig/use-setup-multisig-screen.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { defaultAddressPrefix } from '@gnolang/tm2-js-client';
 
 import { MultisigConfig, fromBech32, validateAddress } from 'adena-module';
 import useIndicatorStep, {
@@ -7,6 +6,7 @@ import useIndicatorStep, {
 } from '@hooks/wallet/broadcast-transaction/use-indicator-step';
 import { useAdenaContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
+import { useNetwork } from '@hooks/use-network';
 
 export type UseSetupMultisigScreenReturn = {
   setupMultisigState: SetupMultisigStateType;
@@ -58,6 +58,7 @@ export const MAX_SIGNERS = 7;
 const useSetupMultisigScreen = (): UseSetupMultisigScreenReturn => {
   const { multisigService, walletService } = useAdenaContext();
   const { changeCurrentAccount, currentAddress } = useCurrentAccount();
+  const { currentNetwork } = useNetwork();
 
   const [setupMultisigState, setSetupMultisigState] =
     React.useState<SetupMultisigStateType>('INIT');
@@ -158,7 +159,7 @@ const useSetupMultisigScreen = (): UseSetupMultisigScreenReturn => {
     for (const signer of validSigners) {
       try {
         const { prefix } = fromBech32(signer);
-        if (prefix !== defaultAddressPrefix) {
+        if (prefix !== currentNetwork.addressPrefix) {
           setMultisigConfigError('Invalid address format.');
           return false;
         }
@@ -193,7 +194,7 @@ const useSetupMultisigScreen = (): UseSetupMultisigScreenReturn => {
       }
 
       const { multisigAddress, multisigAddressBytes, multisigPubKey, signerPublicKeys } =
-        await multisigService.createMultisigAccount(multisigConfig);
+        await multisigService.createMultisigAccount(multisigConfig, currentNetwork.addressPrefix);
 
       const publicKeyBytesArray = Uint8Array.from(Object.values(multisigPubKey));
       const addressBytesArray = Uint8Array.from(Object.values(multisigAddressBytes));

--- a/packages/adena-extension/src/hooks/web/use-account-import-screen.ts
+++ b/packages/adena-extension/src/hooks/web/use-account-import-screen.ts
@@ -14,10 +14,10 @@ import {
 import { useCallback, useMemo, useState } from 'react';
 
 import { waitForRun } from '@common/utils/timeout-utils';
-import { defaultAddressPrefix } from '@gnolang/tm2-js-client';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
+import { useNetwork } from '@hooks/use-network';
 import { useWallet } from '@hooks/use-wallet';
 import useIndicatorStep, {
   UseIndicatorStepReturn,
@@ -66,6 +66,7 @@ const useAccountImportScreen = ({ wallet }: { wallet: Wallet }): UseAccountImpor
   const { updateWallet } = useWalletContext();
   const { changeCurrentAccount } = useCurrentAccount();
   const { hasHDWallet } = useWallet();
+  const { currentNetwork } = useNetwork();
 
   const [inputType, setInputType] = useState<ImportWalletType>('12seeds');
   const [step, setStep] = useState<AccountImportStateType>(
@@ -136,10 +137,10 @@ const useAccountImportScreen = ({ wallet }: { wallet: Wallet }): UseAccountImpor
     }
 
     const account = await SingleAccount.createBy(keyring, wallet.nextAccountName);
-    const address = await account.getAddress(defaultAddressPrefix);
+    const address = await account.getAddress(currentNetwork.addressPrefix);
     const checkAccounts = wallet.accounts.filter((account) => !isAirgapAccount(account));
     const storedAddresses = await Promise.all(
-      checkAccounts.map((account) => account.getAddress(defaultAddressPrefix)),
+      checkAccounts.map((account) => account.getAddress(currentNetwork.addressPrefix)),
     );
     const existAddress = storedAddresses.includes(address);
     if (existAddress) {
@@ -218,7 +219,7 @@ const useAccountImportScreen = ({ wallet }: { wallet: Wallet }): UseAccountImpor
       const keyring = storedKeyring || (await HDWalletKeyring.fromMnemonic(inputValue));
 
       for (const account of loadedAccounts) {
-        const address = await account.getAddress('g');
+        const address = await account.getAddress(currentNetwork.addressPrefix);
         if (selectedAddresses.includes(address)) {
           resultWallet = await addAccountWith(resultWallet, keyring, account);
         }

--- a/packages/adena-extension/src/inject/message/methods/core.ts
+++ b/packages/adena-extension/src/inject/message/methods/core.ts
@@ -125,7 +125,11 @@ export class InjectCore {
     if (!currentAccount) {
       return null;
     }
-    return currentAccount.getAddress('g');
+    const network = await this.getCurrentNetwork();
+    if (!network) {
+      return null;
+    }
+    return currentAccount.getAddress(network.addressPrefix);
   }
 
   public async isLockedBy(inMemoryKey: CryptoKey | null): Promise<boolean> {

--- a/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@services/index';
 import { AddressBookValidationError } from '@common/errors/validation/address-book-validation-error';
 import { useWalletContext } from '@hooks/use-context';
+import { useNetwork } from '@hooks/use-network';
 import mixins from '@styles/mixins';
 import { AddressBookItem } from '@repositories/wallet';
 import useAppNavigate from '@hooks/use-app-navigate';
@@ -26,6 +27,7 @@ const ACCOUNT_NAME_LENGTH_LIMIT = 23;
 const AddAddress = (): JSX.Element => {
   const theme = useTheme();
   const { wallet } = useWalletContext();
+  const { currentNetwork } = useNetwork();
   const { params, goBack } = useAppNavigate<RoutePath.AddAddress>();
   const isAdd = params.status === 'add';
 
@@ -85,7 +87,7 @@ const AddAddress = (): JSX.Element => {
     }
 
     try {
-      await validateAlreadyAddressByAccounts(currData, wallet?.accounts ?? [], isAdd);
+      await validateAlreadyAddressByAccounts(currData, wallet?.accounts ?? [], isAdd, currentNetwork.addressPrefix);
     } catch (error) {
       isValid = false;
       if (error instanceof AddressBookValidationError) {

--- a/packages/adena-extension/src/pages/popup/wallet/approve-sign-transaction/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-sign-transaction/index.tsx
@@ -18,7 +18,6 @@ import {
 } from '@common/utils/client-utils';
 import { validateInjectionDataWithAddress } from '@common/validation/validation-transaction';
 import { ApproveTransaction } from '@components/molecules';
-import { defaultAddressPrefix } from '@gnolang/tm2-js-client';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
@@ -186,7 +185,7 @@ const ApproveSignTransactionContainer: React.FC = () => {
   ): Promise<boolean> => {
     const validationMessage = validateInjectionDataWithAddress(
       requestData,
-      await currentAccount.getAddress(defaultAddressPrefix),
+      await currentAccount.getAddress(currentNetwork.addressPrefix),
     );
     if (validationMessage) {
       chrome.runtime.sendMessage(validationMessage);
@@ -211,6 +210,7 @@ const ApproveSignTransactionContainer: React.FC = () => {
         currentAccount,
         currentNetwork.networkId,
         requestData?.data?.messages,
+        currentNetwork.addressPrefix,
         requestData?.data?.gasWanted,
         requestData?.data?.gasFee,
         requestData?.data?.memo,

--- a/packages/adena-extension/src/pages/popup/wallet/approve-sign/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-sign/index.tsx
@@ -185,7 +185,7 @@ const ApproveSignContainer: React.FC = () => {
   ): Promise<boolean> => {
     const validationMessage = validateInjectionDataWithAddress(
       requestData,
-      await currentAccount.getAddress('g'),
+      await currentAccount.getAddress(currentNetwork.addressPrefix),
     );
     if (validationMessage) {
       chrome.runtime.sendMessage(validationMessage);
@@ -210,6 +210,7 @@ const ApproveSignContainer: React.FC = () => {
         currentAccount,
         currentNetwork.networkId,
         requestData?.data?.messages,
+        currentNetwork.addressPrefix,
         requestData?.data?.gasWanted,
         requestData?.data?.gasFee,
         requestData?.data?.memo,

--- a/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
@@ -2,7 +2,6 @@
 import {
   BroadcastTxCommitResult,
   BroadcastTxSyncResult,
-  defaultAddressPrefix,
   TM2Error,
 } from '@gnolang/tm2-js-client';
 import { Account, Document, isAirgapAccount, isLedgerAccount } from 'adena-module';
@@ -51,9 +50,9 @@ interface TransactionData {
   document: Document;
 }
 
-function makeDefaultNetworkInfo(chainId: string, rpcUrl: string): NetworkMetainfo {
+function makeDefaultNetworkInfo(chainId: string, rpcUrl: string, addressPrefix: string): NetworkMetainfo {
   return {
-    addressPrefix: defaultAddressPrefix,
+    addressPrefix,
     chainId,
     rpcUrl,
     networkId: chainId,
@@ -124,7 +123,7 @@ const ApproveTransactionContainer: React.FC = () => {
   const currentNetwork: NetworkMetainfo = useMemo(() => {
     const networkInfo = requestData?.data?.networkInfo;
     if (!!networkInfo?.chainId && !!networkInfo?.rpcUrl) {
-      return makeDefaultNetworkInfo(networkInfo.chainId, networkInfo.rpcUrl);
+      return makeDefaultNetworkInfo(networkInfo.chainId, networkInfo.rpcUrl, currentWalletNetwork.addressPrefix);
     }
 
     return currentWalletNetwork;
@@ -311,7 +310,7 @@ const ApproveTransactionContainer: React.FC = () => {
     currentAccount: Account,
     requestData: InjectionMessage,
   ): Promise<boolean> => {
-    const address = await currentAccount.getAddress('g');
+    const address = await currentAccount.getAddress(currentNetwork.addressPrefix);
     const validationMessage = validateInjectionDataWithAddress(requestData, address);
     if (validationMessage) {
       chrome.runtime.sendMessage(validationMessage);
@@ -351,6 +350,7 @@ const ApproveTransactionContainer: React.FC = () => {
         currentAccount,
         currentNetwork.networkId,
         requestData?.data?.messages,
+        currentNetwork.addressPrefix,
         requestData?.data?.gasWanted,
         requestData?.data?.gasFee,
         requestData?.data?.memo,

--- a/packages/adena-extension/src/pages/popup/wallet/broadcast-multisig-transaction/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/broadcast-multisig-transaction/index.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { defaultAddressPrefix } from '@gnolang/tm2-js-client';
 import { Account, isMultisigAccount, MultisigConfig, RawTx } from 'adena-module';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -46,9 +45,9 @@ interface TransactionData {
   memo: string;
 }
 
-function makeDefaultNetworkInfo(chainId: string, rpcUrl: string): NetworkMetainfo {
+function makeDefaultNetworkInfo(chainId: string, rpcUrl: string, addressPrefix: string): NetworkMetainfo {
   return {
-    addressPrefix: defaultAddressPrefix,
+    addressPrefix,
     chainId,
     rpcUrl,
     networkId: chainId,
@@ -123,7 +122,7 @@ const BroadcastMultisigTransactionContainer: React.FC = () => {
   const currentNetwork: NetworkMetainfo = useMemo(() => {
     const networkInfo = requestData?.data?.networkInfo;
     if (!!networkInfo?.chainId && !!networkInfo?.rpcUrl) {
-      return makeDefaultNetworkInfo(networkInfo.chainId, networkInfo.rpcUrl);
+      return makeDefaultNetworkInfo(networkInfo.chainId, networkInfo.rpcUrl, currentWalletNetwork.addressPrefix);
     }
 
     return currentWalletNetwork;
@@ -306,7 +305,7 @@ const BroadcastMultisigTransactionContainer: React.FC = () => {
 
     const validationMessage = validateInjectionDataWithAddress(
       requestData,
-      await currentAccount.getAddress(defaultAddressPrefix),
+      await currentAccount.getAddress(currentNetwork.addressPrefix),
       false,
     );
     if (validationMessage) {

--- a/packages/adena-extension/src/pages/popup/wallet/create-multisig-account/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/create-multisig-account/index.tsx
@@ -15,6 +15,7 @@ import {
 import { CreateMultisigAccount } from '@components/molecules/create-multisig-account';
 import { useAdenaContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
+import { useNetwork } from '@hooks/use-network';
 import { InjectionMessage, InjectionMessageInstance } from '@inject/message';
 import { RoutePath } from '@types';
 
@@ -22,6 +23,7 @@ const CreateMultisigAccountContainer: React.FC = () => {
   const normalNavigate = useNavigate();
   const { walletService, multisigService } = useAdenaContext();
   const { currentAccount, changeCurrentAccount } = useCurrentAccount();
+  const { currentNetwork } = useNetwork();
   const location = useLocation();
 
   const [hostname, setHostname] = useState('');
@@ -100,7 +102,7 @@ const CreateMultisigAccountContainer: React.FC = () => {
       setProcessType('PROCESSING');
 
       const { multisigAddress, multisigAddressBytes, multisigPubKey, signerPublicKeys } =
-        await multisigService.createMultisigAccount(multisigConfig);
+        await multisigService.createMultisigAccount(multisigConfig, currentNetwork.addressPrefix);
 
       const publicKeyBytesArray = Uint8Array.from(Object.values(multisigPubKey));
       const addressBytesArray = Uint8Array.from(Object.values(multisigAddressBytes));

--- a/packages/adena-extension/src/pages/popup/wallet/create-multisig-transaction/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/create-multisig-transaction/index.tsx
@@ -229,7 +229,7 @@ const CreateMultisigTransactionContainer: React.FC = () => {
     const validationMessage = validateInjectionDataForMultisig(
       requestData,
       currentAccount,
-      await currentAccount.getAddress('g'),
+      await currentAccount.getAddress(currentNetwork.addressPrefix),
     );
 
     if (validationMessage) {

--- a/packages/adena-extension/src/pages/popup/wallet/nft-transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/nft-transfer-summary/index.tsx
@@ -118,6 +118,7 @@ const NFTTransferSummaryContainer: React.FC = () => {
       currentAccount,
       currentNetwork.networkId,
       [message],
+      currentNetwork.addressPrefix,
       useNetworkFeeReturn.currentGasInfo?.gasWanted || 0,
       useNetworkFeeReturn.currentGasFeeRawAmount,
       memo,

--- a/packages/adena-extension/src/pages/popup/wallet/sign-multisig-transaction/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/sign-multisig-transaction/index.tsx
@@ -203,7 +203,7 @@ const SignMultisigTransactionContainer: React.FC = () => {
   ): Promise<boolean> => {
     const validationMessage = validateInjectionDataWithAddress(
       requestData,
-      await currentAccount.getAddress('g'),
+      await currentAccount.getAddress(currentNetwork.addressPrefix),
       true,
     );
     if (validationMessage) {
@@ -275,6 +275,7 @@ const SignMultisigTransactionContainer: React.FC = () => {
         multisigDocument.tx,
         multisigDocument.accountNumber,
         multisigDocument.sequence,
+        currentNetwork.addressPrefix,
       );
 
       // Save signature to file if enabled

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -187,6 +187,7 @@ const TransferSummaryContainer: React.FC = () => {
       currentAccount,
       currentNetwork.networkId,
       [message],
+      currentNetwork.addressPrefix,
       gasWanted,
       BigNumber(networkFee?.amount || 0)
         .shiftedBy(GasToken.decimals)

--- a/packages/adena-extension/src/pages/web/account-import-screen/select-account-step.tsx
+++ b/packages/adena-extension/src/pages/web/account-import-screen/select-account-step.tsx
@@ -7,7 +7,7 @@ import { View, WebButton, WebImg } from '@components/atoms';
 import { WebTitleWithDescription } from '@components/molecules';
 import { AccountInfo } from '@components/molecules/select-account-box';
 import SelectAccountBox from '@components/molecules/select-account-box/select-account-box';
-import { defaultAddressPrefix } from '@gnolang/tm2-js-client';
+import { useNetwork } from '@hooks/use-network';
 import { UseAccountImportReturn } from '@hooks/web/use-account-import-screen';
 import { useQuery } from '@tanstack/react-query';
 
@@ -21,6 +21,7 @@ const SelectAccountStep = ({
 }: {
   useAccountImportScreenReturn: UseAccountImportReturn;
 }): JSX.Element => {
+  const { currentNetwork } = useNetwork();
   const {
     isLoadingAccounts,
     loadedAccounts,
@@ -36,7 +37,7 @@ const SelectAccountStep = ({
     async () => {
       const accountInfos: AccountInfo[] = [];
       for (const account of loadedAccounts) {
-        const address = await account.getAddress(defaultAddressPrefix);
+        const address = await account.getAddress(currentNetwork.addressPrefix);
         const accountInfo: AccountInfo = {
           hdPath: account.index,
           index: account.index,

--- a/packages/adena-extension/src/services/multisig/multisig.ts
+++ b/packages/adena-extension/src/services/multisig/multisig.ts
@@ -2,7 +2,6 @@ import {
   BroadcastTransactionMap,
   BroadcastTxCommitResult,
   BroadcastTxSyncResult,
-  defaultAddressPrefix,
   Tx,
   uint8ArrayToBase64,
 } from '@gnolang/tm2-js-client';
@@ -73,7 +72,10 @@ export class MultisigService {
    * @param config - Multisig configuration (signers and threshold)
    * @returns Multisig account address, addressBytes, and publicKey
    */
-  public createMultisigAccount = async (config: MultisigConfig): Promise<MultisigAccountResult> => {
+  public createMultisigAccount = async (
+    config: MultisigConfig,
+    addressPrefix: string,
+  ): Promise<MultisigAccountResult> => {
     const { signers, threshold, noSort = true } = config;
 
     const signerInfos: SignerInfo[] = await this.fetchSignerInfos(signers);
@@ -86,7 +88,7 @@ export class MultisigService {
         '@type': info.publicKey['@type'],
         value: info.bytes,
       })),
-      defaultAddressPrefix,
+      addressPrefix,
     );
 
     // Extract address bytes from bech32 address
@@ -244,9 +246,10 @@ export class MultisigService {
   public createSignature = async (
     account: Account,
     document: Document,
+    addressPrefix: string,
   ): Promise<EncodeTxSignature> => {
     const provider = this.getGnoProvider();
-    const address = await account.getAddress(defaultAddressPrefix);
+    const address = await account.getAddress(addressPrefix);
     const accountInfo = await provider.getAccountInfo(address);
     const wallet = await this.walletService.loadWallet();
     const { signature } = await wallet.signByAccountId(provider, account.id, document);
@@ -273,6 +276,7 @@ export class MultisigService {
     transaction: RawTx,
     accountNumber: string,
     sequence: string,
+    addressPrefix: string,
   ): Promise<Signature> => {
     try {
       await this.validatePublicKeyExists(address);
@@ -283,7 +287,7 @@ export class MultisigService {
         sequence,
         chainId,
       );
-      const encodedSignature = await this.createSignature(account, aminoDocument);
+      const encodedSignature = await this.createSignature(account, aminoDocument, addressPrefix);
       return {
         pub_key: {
           '@type': '/tm.PubKeySecp256k1',

--- a/packages/adena-extension/src/services/transaction/transaction.ts
+++ b/packages/adena-extension/src/services/transaction/transaction.ts
@@ -1,7 +1,6 @@
 import {
   BroadcastTxCommitResult,
   BroadcastTxSyncResult,
-  defaultAddressPrefix,
   Tx,
   uint8ArrayToBase64,
 } from '@gnolang/tm2-js-client';
@@ -66,12 +65,13 @@ export class TransactionService {
     chainId: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     messages: any[],
+    addressPrefix: string,
     gasWanted?: number,
     gasFee?: number,
     memo?: string | undefined,
   ): Promise<Document> => {
     const provider = this.getGnoProvider();
-    const address = await account.getAddress(defaultAddressPrefix);
+    const address = await account.getAddress(addressPrefix);
     const accountInfo = await provider.getAccountInfo(address).catch(() => null);
     const accountNumber = accountInfo?.accountNumber ?? 0;
     const accountSequence = accountInfo?.sequence ?? 0;

--- a/packages/adena-module/src/utils/address.spec.ts
+++ b/packages/adena-module/src/utils/address.spec.ts
@@ -1,0 +1,51 @@
+import { fromBech32 } from '../encoding';
+import { publicKeyToAddress, secp256k1PubKeyToAddress, secp256k1PubKeyToAddressBytes } from './address';
+
+// A known secp256k1 compressed public key (33 bytes) used as a stable test fixture
+const TEST_PUBLIC_KEY = new Uint8Array([
+  0x02, 0xc6, 0x04, 0x7f, 0x94, 0x41, 0xed, 0x7d,
+  0x6d, 0x30, 0x45, 0x40, 0x6e, 0x95, 0xc0, 0x7c,
+  0xd8, 0x5c, 0x77, 0x8e, 0x4b, 0x8c, 0xef, 0x3c,
+  0xa7, 0xab, 0xac, 0x09, 0xb9, 0x5c, 0x70, 0x9e,
+  0xe5,
+]);
+
+describe('publicKeyToAddress', () => {
+  it('produces a g1... address with g prefix', async () => {
+    const address = await publicKeyToAddress(TEST_PUBLIC_KEY, 'g');
+    expect(address).toMatch(/^g1/);
+  });
+});
+
+describe('secp256k1PubKeyToAddress', () => {
+  it('produces a g1... address with g prefix', () => {
+    const address = secp256k1PubKeyToAddress(TEST_PUBLIC_KEY, 'g');
+    expect(address).toMatch(/^g1/);
+  });
+
+  it('produces an atone1... address with atone prefix', () => {
+    const address = secp256k1PubKeyToAddress(TEST_PUBLIC_KEY, 'atone');
+    expect(address).toMatch(/^atone1/);
+  });
+
+  it('same public key produces different address strings for different prefixes', () => {
+    const gnoAddress = secp256k1PubKeyToAddress(TEST_PUBLIC_KEY, 'g');
+    const atoneAddress = secp256k1PubKeyToAddress(TEST_PUBLIC_KEY, 'atone');
+    expect(gnoAddress).not.toBe(atoneAddress);
+  });
+
+  it('20-byte address data is identical regardless of prefix', () => {
+    const gnoAddress = secp256k1PubKeyToAddress(TEST_PUBLIC_KEY, 'g');
+    const atoneAddress = secp256k1PubKeyToAddress(TEST_PUBLIC_KEY, 'atone');
+    const gnoBytes = fromBech32(gnoAddress).data;
+    const atoneBytes = fromBech32(atoneAddress).data;
+    expect(gnoBytes).toEqual(atoneBytes);
+  });
+
+  it('decoded bech32 data matches secp256k1PubKeyToAddressBytes output', () => {
+    const rawBytes = secp256k1PubKeyToAddressBytes(TEST_PUBLIC_KEY);
+    const address = secp256k1PubKeyToAddress(TEST_PUBLIC_KEY, 'g');
+    const decodedBytes = fromBech32(address).data;
+    expect(rawBytes).toEqual(decodedBytes);
+  });
+});

--- a/packages/adena-module/src/utils/address.ts
+++ b/packages/adena-module/src/utils/address.ts
@@ -4,7 +4,7 @@ import { fromBech32, toBech32 } from '../encoding';
 
 export async function publicKeyToAddress(
   publicKey: Uint8Array,
-  addressPrefix: string = 'g',
+  addressPrefix: string,
 ): Promise<string> {
   return new KeySigner(new Uint8Array(), publicKey, addressPrefix).getAddress();
 }
@@ -32,7 +32,7 @@ export function secp256k1PubKeyToAddressBytes(publicKey: Uint8Array): Uint8Array
  */
 export function secp256k1PubKeyToAddress(
   publicKey: Uint8Array,
-  addressPrefix: string = 'g',
+  addressPrefix: string,
 ): string {
   const addressBytes = secp256k1PubKeyToAddressBytes(publicKey);
   return toBech32(addressPrefix, addressBytes);

--- a/packages/adena-module/src/utils/multisig.ts
+++ b/packages/adena-module/src/utils/multisig.ts
@@ -1,4 +1,4 @@
-import { Any, defaultAddressPrefix, PubKeySecp256k1 } from '@gnolang/tm2-js-client';
+import { Any, PubKeySecp256k1 } from '@gnolang/tm2-js-client';
 import { PubKeyMultisig } from '@gnolang/tm2-js-client/bin/proto/tm2/multisig';
 import Long from 'long';
 import { sha256 } from '../crypto';
@@ -18,7 +18,7 @@ export interface Pubkey {
 export function createMultisigPublicKey(
   threshold: number,
   publicKeys: Pubkey[],
-  addressPrefix: string = defaultAddressPrefix,
+  addressPrefix: string,
 ): { address: string; publicKey: Uint8Array } {
   const publicKeysAny = publicKeys.map((pk) => {
     return Any.create({

--- a/packages/adena-module/src/wallet/account/multisig-account.ts
+++ b/packages/adena-module/src/wallet/account/multisig-account.ts
@@ -1,4 +1,3 @@
-import { defaultAddressPrefix } from '@gnolang/tm2-js-client';
 import { v4 as uuidv4 } from 'uuid';
 
 import { toBech32 } from '../../encoding';
@@ -104,7 +103,7 @@ export class MultisigAccount implements Account {
    * Get the multisig address
    * Converts addressBytes to bech32 format (like AirgapAccount)
    */
-  async getAddress(prefix: string = defaultAddressPrefix): Promise<string> {
+  async getAddress(prefix: string): Promise<string> {
     return toBech32(prefix, this.addressBytes);
   }
 

--- a/packages/adena-module/src/wallet/wallet.ts
+++ b/packages/adena-module/src/wallet/wallet.ts
@@ -2,13 +2,13 @@ import { LedgerConnector } from '@cosmjs/ledger-amino';
 import {
   BroadcastTxCommitResult,
   BroadcastTxSyncResult,
-  defaultAddressPrefix,
   Provider,
   Tx,
   TxSignature,
 } from '@gnolang/tm2-js-client';
 
 import { Bip39, Random } from '../crypto';
+import { fromBech32 } from '../encoding';
 import { arrayContentEquals, arrayToHex, hexToArray } from '../utils';
 import { Document } from './..';
 import {
@@ -392,8 +392,9 @@ export class AdenaWallet implements Wallet {
    * @returns true if duplicate exists
    */
   async hasAddress(address: string): Promise<boolean> {
+    const { prefix } = fromBech32(address);
     const addresses = await Promise.all(
-      this._accounts.map((account) => account.getAddress(defaultAddressPrefix)),
+      this._accounts.map((account) => account.getAddress(prefix)),
     );
     return addresses.includes(address);
   }


### PR DESCRIPTION
## Summary

Remove `'g'` prefix hardcoding and default values from address derivation paths to prepare for multichain (AtomOne) support. Runtime address prefix is still `'g'` for all active networks, so no behavioral change — this only establishes the plumbing.

**adena-module**
- Remove `= 'g'` default from `publicKeyToAddress` / `secp256k1PubKeyToAddress` (now required)
- Remove `= defaultAddressPrefix` defaults from `createMultisigPublicKey` / `MultisigAccount.getAddress`
- Replace `defaultAddressPrefix` hardcoding in `wallet.hasAddress` with `fromBech32(address).prefix` extraction
- Add multi-prefix tests (`g` / `atone`) with 20-byte address-data equality verification

**adena-extension**
- Replace literal `'g'` / `defaultAddressPrefix` call sites with `currentNetwork.addressPrefix` (23 files)
- Remove `?? 'g'` fallback in `core.ts` `getCurrentAddress` (return `null` when network is absent)
- Remove `?? 'g'` fallback in `sign-multisig-transaction`
- Add `addressPrefix` parameter to `makeDefaultNetworkInfo` helpers in `approve-transaction-main` / `broadcast-multisig-transaction`

## Out of scope

`services/resource/chain.ts` `addNetwork()` still uses `'g'` — deferred to Part 7 (settings > network UI).

## Test plan

- [ ] `cd packages/adena-module && npm test` — including new `address.spec.ts`
- [ ] `cd packages/adena-extension && npm test`
- [ ] `npx tsc --noEmit` in both packages
- [ ] Manual: Gno testnet signing flows (approve-sign, sign-multisig, broadcast-multisig)

## Related

Base: `feature/ADN-749-1` (ChainRegistry + TokenRegistry foundation)