### PR TITLE
ADN-749: add Cosmos LCD provider and balance service for AtomOne

### DIFF
--- a/packages/adena-extension/src/common/provider/adena/adena-provider.tsx
+++ b/packages/adena-extension/src/common/provider/adena/adena-provider.tsx
@@ -1,4 +1,5 @@
 import { AdenaStorage } from '@common/storage';
+import { CosmosLcdProvider } from '@common/provider/cosmos/cosmos-lcd-provider';
 import { useWindowSize } from '@hooks/use-window-size';
 import { ChainRepository } from '@repositories/common';
 import { TokenRepository } from '@repositories/common/token';
@@ -23,6 +24,7 @@ import {
 } from '@services/transaction';
 import { MultisigService } from '@services/multisig';
 import {
+  CosmosBalanceService,
   WalletAccountService,
   WalletAddressBookService,
   WalletBalanceService,
@@ -30,6 +32,13 @@ import {
   WalletService,
 } from '@services/wallet';
 import { NetworkState } from '@states';
+import {
+  ALL_TOKENS,
+  ChainRegistry,
+  createChainRegistry,
+  TokenRegistry,
+  TokenRegistryImpl,
+} from 'adena-module';
 import axios from 'axios';
 import React, { createContext, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -38,6 +47,10 @@ import { GnoProvider } from '../gno/gno-provider';
 export interface AdenaContextProps {
   walletService: WalletService;
   balanceService: WalletBalanceService;
+  cosmosBalanceService: CosmosBalanceService;
+  cosmosLcdProvider: CosmosLcdProvider;
+  chainRegistry: ChainRegistry;
+  tokenRegistry: TokenRegistry;
   accountService: WalletAccountService;
   addressBookService: WalletAddressBookService;
   establishService: WalletEstablishService;
@@ -62,7 +75,29 @@ export const AdenaProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chil
     return new GnoProvider(currentNetwork.rpcUrl, currentNetwork.chainId);
   }, [currentNetwork]);
 
-  const axiosInstance = axios.create({ timeout: 20_000 });
+  const chainRegistry = useMemo(() => createChainRegistry(), []);
+
+  const tokenRegistry = useMemo(() => {
+    const registry = new TokenRegistryImpl();
+    ALL_TOKENS.forEach((t) => registry.register(t));
+    return registry;
+  }, []);
+
+  // TODO(Part 7): replace ATOMONE_CHAIN_ID with currentNetworkByChainGroup['atomone']
+  const ATOMONE_CHAIN_ID = 'atomone-1';
+  const cosmosLcdProvider = useMemo(() => {
+    const atomoneProfile = chainRegistry.get(ATOMONE_CHAIN_ID);
+    const lcdUrl =
+      atomoneProfile?.chainType === 'cosmos' ? atomoneProfile.restEndpoints[0] ?? '' : '';
+    return new CosmosLcdProvider(lcdUrl);
+  }, [chainRegistry]);
+
+  const cosmosBalanceService = useMemo(
+    () => new CosmosBalanceService(cosmosLcdProvider),
+    [cosmosLcdProvider],
+  );
+
+  const axiosInstance = useMemo(() => axios.create({ timeout: 20_000 }), []);
 
   const localStorage = AdenaStorage.local();
 
@@ -95,7 +130,7 @@ export const AdenaProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chil
 
   const tokenRepository = useMemo(
     () => new TokenRepository(localStorage, axiosInstance, currentNetwork, gnoProvider),
-    [localStorage, axiosInstance, currentNetwork],
+    [localStorage, axiosInstance, currentNetwork, gnoProvider],
   );
 
   const transactionHistoryRepository = useMemo(() => {
@@ -172,6 +207,10 @@ export const AdenaProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chil
       value={{
         walletService,
         balanceService,
+        cosmosBalanceService,
+        cosmosLcdProvider,
+        chainRegistry,
+        tokenRegistry,
         accountService,
         addressBookService,
         establishService,

--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.spec.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.spec.ts
@@ -1,0 +1,105 @@
+import axios from 'axios';
+import { CosmosLcdProvider } from './cosmos-lcd-provider';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('CosmosLcdProvider', () => {
+  const BASE_URL = 'https://atomone-api.allinbits.com';
+  let provider: CosmosLcdProvider;
+  let mockGet: jest.Mock;
+
+  beforeEach(() => {
+    mockGet = jest.fn();
+    mockedAxios.create.mockReturnValue({ get: mockGet } as any);
+    provider = new CosmosLcdProvider(BASE_URL);
+  });
+
+  describe('getBalance', () => {
+    it('returns amount for a valid denom', async () => {
+      mockGet.mockResolvedValue({
+        data: { balance: { denom: 'uatone', amount: '1000000' } },
+      });
+
+      const result = await provider.getBalance('atone1abc', 'uatone');
+
+      expect(result).toBe('1000000');
+      expect(mockGet).toHaveBeenCalledWith(
+        `${BASE_URL}/cosmos/bank/v1beta1/balances/atone1abc/by_denom`,
+        { params: { denom: 'uatone' } },
+      );
+    });
+
+    it('returns "0" when balance field has no amount', async () => {
+      mockGet.mockResolvedValue({
+        data: { balance: {} },
+      });
+
+      const result = await provider.getBalance('atone1abc', 'uatone');
+      expect(result).toBe('0');
+    });
+
+    it('returns null on network error', async () => {
+      mockGet.mockRejectedValue(new Error('Network Error'));
+
+      const result = await provider.getBalance('atone1abc', 'uatone');
+      expect(result).toBeNull();
+    });
+
+    it('returns null on timeout', async () => {
+      mockGet.mockRejectedValue(new Error('timeout of 10000ms exceeded'));
+
+      const result = await provider.getBalance('atone1abc', 'uatone');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAllBalances', () => {
+    it('returns balances array on success', async () => {
+      const balances = [
+        { denom: 'uatone', amount: '1000000' },
+        { denom: 'uphoton', amount: '500000' },
+      ];
+      mockGet.mockResolvedValue({ data: { balances } });
+
+      const result = await provider.getAllBalances('atone1abc');
+
+      expect(result).toEqual(balances);
+      expect(mockGet).toHaveBeenCalledWith(
+        `${BASE_URL}/cosmos/bank/v1beta1/balances/atone1abc`,
+      );
+    });
+
+    it('returns empty array when balances field is missing', async () => {
+      mockGet.mockResolvedValue({ data: {} });
+
+      const result = await provider.getAllBalances('atone1abc');
+      expect(result).toEqual([]);
+    });
+
+    it('returns null on network error', async () => {
+      mockGet.mockRejectedValue(new Error('Network Error'));
+
+      const result = await provider.getAllBalances('atone1abc');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setBaseUrl', () => {
+    it('updates the base URL for subsequent requests', async () => {
+      const newUrl = 'https://new-api.example.com';
+      provider.setBaseUrl(newUrl);
+
+      mockGet.mockResolvedValue({
+        data: { balance: { denom: 'uatone', amount: '999' } },
+      });
+
+      await provider.getBalance('atone1abc', 'uatone');
+
+      expect(mockGet).toHaveBeenCalledWith(
+        `${newUrl}/cosmos/bank/v1beta1/balances/atone1abc/by_denom`,
+        { params: { denom: 'uatone' } },
+      );
+    });
+  });
+});

--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.ts
@@ -1,0 +1,41 @@
+import axios, { AxiosInstance } from 'axios';
+
+export class CosmosLcdProvider {
+  private axiosInstance: AxiosInstance;
+
+  constructor(private baseUrl: string) {
+    if (!baseUrl) {
+      console.warn('CosmosLcdProvider: empty baseUrl — all queries will fail');
+    }
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.axiosInstance = axios.create({ timeout: 10_000 });
+  }
+
+  async getAllBalances(address: string): Promise<{ denom: string; amount: string }[] | null> {
+    try {
+      const response = await this.axiosInstance.get<{ balances: { denom: string; amount: string }[] }>(
+        `${this.baseUrl}/cosmos/bank/v1beta1/balances/${address}`,
+      );
+      return response.data.balances ?? [];
+    } catch {
+      return null;
+    }
+  }
+
+  async getBalance(address: string, denom: string): Promise<string | null> {
+    try {
+      const response = await this.axiosInstance.get<{ balance: { denom: string; amount: string } }>(
+        `${this.baseUrl}/cosmos/bank/v1beta1/balances/${address}/by_denom`,
+        { params: { denom } },
+      );
+      return response.data.balance?.amount ?? '0';
+    } catch {
+      return null;
+    }
+  }
+
+  // Reserved for Part 7: dynamically update endpoint when user switches AtomOne network
+  setBaseUrl(url: string): void {
+    this.baseUrl = url.replace(/\/$/, '');
+  }
+}

--- a/packages/adena-extension/src/services/resource/token.ts
+++ b/packages/adena-extension/src/services/resource/token.ts
@@ -142,7 +142,7 @@ export class TokenService {
       tokenId: string;
       networkId: string;
       display: boolean;
-      type: 'gno-native' | 'grc20' | 'ibc-native' | 'ibc-tokens';
+      type: 'gno-native' | 'grc20' | 'ibc-native' | 'ibc-tokens' | 'cosmos-native';
       name: string;
       symbol: string;
       decimals: number;

--- a/packages/adena-extension/src/services/wallet/cosmos-balance.spec.ts
+++ b/packages/adena-extension/src/services/wallet/cosmos-balance.spec.ts
@@ -1,0 +1,168 @@
+import { CosmosLcdProvider } from '@common/provider/cosmos/cosmos-lcd-provider';
+import { TokenProfile } from 'adena-module';
+import { CosmosBalanceService } from './cosmos-balance';
+
+const UATONE: TokenProfile = {
+  id: 'atomone-1:uatone',
+  chainProfileId: 'atomone-1',
+  symbol: 'ATONE',
+  name: 'AtomOne',
+  decimals: 6,
+  iconUrl: '/assets/icons/atone.svg',
+  origin: { kind: 'cosmos-native', denom: 'uatone' },
+  tags: ['native', 'staking', 'governance'],
+};
+
+const UPHOTON: TokenProfile = {
+  id: 'atomone-1:uphoton',
+  chainProfileId: 'atomone-1',
+  symbol: 'PHOTON',
+  name: 'Photon',
+  decimals: 6,
+  iconUrl: '/assets/icons/photon.svg',
+  origin: { kind: 'cosmos-native', denom: 'uphoton' },
+  tags: ['native', 'fee'],
+};
+
+const GNO_TOKEN: TokenProfile = {
+  id: 'gnoland1:ugnot',
+  chainProfileId: 'gnoland1',
+  symbol: 'GNOT',
+  name: 'Gno',
+  decimals: 6,
+  origin: { kind: 'gno-native', denom: 'ugnot' },
+  tags: ['native', 'fee', 'staking'],
+};
+
+describe('CosmosBalanceService', () => {
+  let service: CosmosBalanceService;
+  let mockGetBalance: jest.Mock;
+
+  beforeEach(() => {
+    mockGetBalance = jest.fn();
+    const mockProvider = { getBalance: mockGetBalance } as unknown as CosmosLcdProvider;
+    service = new CosmosBalanceService(mockProvider);
+  });
+
+  describe('getTokenBalance', () => {
+    it('returns TokenBalanceType for a cosmos-native token', async () => {
+      mockGetBalance.mockResolvedValue('1000000');
+
+      const result = await service.getTokenBalance('atone1abc', UATONE);
+
+      expect(result).not.toBeNull();
+      expect(result).toEqual({
+        main: true,
+        tokenId: 'atomone-1:uatone',
+        networkId: 'atomone-1',
+        display: true,
+        type: 'cosmos-native',
+        name: 'AtomOne',
+        symbol: 'ATONE',
+        decimals: 6,
+        image: '/assets/icons/atone.svg',
+        amount: { value: '1', denom: 'ATONE' },
+      });
+      expect(mockGetBalance).toHaveBeenCalledWith('atone1abc', 'uatone');
+    });
+
+    it('converts decimals correctly for non-round amounts', async () => {
+      mockGetBalance.mockResolvedValue('1234567');
+
+      const result = await service.getTokenBalance('atone1abc', UATONE);
+
+      expect(result?.amount.value).toBe('1.234567');
+    });
+
+    it('handles zero balance', async () => {
+      mockGetBalance.mockResolvedValue('0');
+
+      const result = await service.getTokenBalance('atone1abc', UATONE);
+
+      expect(result?.amount.value).toBe('0');
+    });
+
+    it('returns null when provider returns null (network error)', async () => {
+      mockGetBalance.mockResolvedValue(null);
+
+      const result = await service.getTokenBalance('atone1abc', UATONE);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for gno-native tokens', async () => {
+      const result = await service.getTokenBalance('g1abc', GNO_TOKEN);
+
+      expect(result).toBeNull();
+      expect(mockGetBalance).not.toHaveBeenCalled();
+    });
+
+    it('sets main=true for tokens with staking tag', async () => {
+      mockGetBalance.mockResolvedValue('500000');
+
+      const result = await service.getTokenBalance('atone1abc', UATONE);
+
+      expect(result?.main).toBe(true);
+    });
+
+    it('sets main=false for tokens without staking tag (e.g. fee-only tokens like PHOTON)', async () => {
+      mockGetBalance.mockResolvedValue('500000');
+
+      const result = await service.getTokenBalance('atone1abc', UPHOTON);
+
+      expect(result?.main).toBe(false);
+    });
+
+    it('uses empty string when iconUrl is undefined', async () => {
+      mockGetBalance.mockResolvedValue('100');
+      const tokenWithoutIcon: TokenProfile = {
+        ...UATONE,
+        iconUrl: undefined,
+      };
+
+      const result = await service.getTokenBalance('atone1abc', tokenWithoutIcon);
+
+      expect(result?.image).toBe('');
+    });
+  });
+
+  describe('getTokenBalances', () => {
+    it('returns balances for multiple cosmos tokens', async () => {
+      mockGetBalance
+        .mockResolvedValueOnce('1000000')
+        .mockResolvedValueOnce('2000000');
+
+      const results = await service.getTokenBalances('atone1abc', [UATONE, UPHOTON]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].symbol).toBe('ATONE');
+      expect(results[1].symbol).toBe('PHOTON');
+    });
+
+    it('filters out tokens that fail to fetch', async () => {
+      mockGetBalance
+        .mockResolvedValueOnce('1000000')
+        .mockResolvedValueOnce(null);
+
+      const results = await service.getTokenBalances('atone1abc', [UATONE, UPHOTON]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].symbol).toBe('ATONE');
+    });
+
+    it('filters out non-cosmos tokens', async () => {
+      const results = await service.getTokenBalances('g1abc', [GNO_TOKEN]);
+
+      expect(results).toHaveLength(0);
+      expect(mockGetBalance).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array when all fetches fail', async () => {
+      mockGetBalance.mockResolvedValue(null);
+
+      const results = await service.getTokenBalances('atone1abc', [UATONE, UPHOTON]);
+
+      expect(results).toHaveLength(0);
+    });
+  });
+});

--- a/packages/adena-extension/src/services/wallet/cosmos-balance.ts
+++ b/packages/adena-extension/src/services/wallet/cosmos-balance.ts
@@ -1,0 +1,47 @@
+import BigNumber from 'bignumber.js';
+
+import { CosmosLcdProvider } from '@common/provider/cosmos/cosmos-lcd-provider';
+import { TokenProfile } from 'adena-module';
+import { TokenBalanceType } from '@types';
+
+export class CosmosBalanceService {
+  constructor(private cosmosLcdProvider: CosmosLcdProvider) {}
+
+  async getTokenBalance(address: string, token: TokenProfile): Promise<TokenBalanceType | null> {
+    const origin = token.origin;
+    if (origin.kind !== 'cosmos-native' && origin.kind !== 'cosmos-ibc') {
+      return null;
+    }
+
+    const denom = origin.kind === 'cosmos-native' ? origin.denom : origin.ibcDenom;
+    const rawAmount = await this.cosmosLcdProvider.getBalance(address, denom);
+    if (rawAmount === null) {
+      return null;
+    }
+
+    const value = new BigNumber(rawAmount).shiftedBy(-token.decimals).toFixed();
+
+    return {
+      main: token.tags?.includes('staking') ?? false,
+      tokenId: token.id,
+      networkId: token.chainProfileId,
+      display: true,
+      type: 'cosmos-native',
+      name: token.name,
+      symbol: token.symbol,
+      decimals: token.decimals,
+      image: token.iconUrl ?? '',
+      amount: {
+        value,
+        denom: token.symbol,
+      },
+    };
+  }
+
+  async getTokenBalances(address: string, tokens: TokenProfile[]): Promise<TokenBalanceType[]> {
+    const results = await Promise.all(
+      tokens.map((token) => this.getTokenBalance(address, token)),
+    );
+    return results.filter((r): r is TokenBalanceType => r !== null);
+  }
+}

--- a/packages/adena-extension/src/services/wallet/index.ts
+++ b/packages/adena-extension/src/services/wallet/index.ts
@@ -3,3 +3,4 @@ export * from './wallet-account';
 export * from './wallet-establish';
 export * from './wallet-address-book';
 export * from './wallet-balance';
+export * from './cosmos-balance';

--- a/packages/adena-extension/src/types/token.ts
+++ b/packages/adena-extension/src/types/token.ts
@@ -6,7 +6,7 @@ export interface TokenModel {
   tokenId: string;
   networkId: string;
   display: boolean;
-  type: 'gno-native' | 'grc20' | 'ibc-native' | 'ibc-tokens';
+  type: 'gno-native' | 'grc20' | 'ibc-native' | 'ibc-tokens' | 'cosmos-native';
   name: string;
   symbol: string;
   decimals: number;
@@ -113,6 +113,13 @@ export interface MainToken {
     value: string;
     denom: string;
   };
+  chainIconUrl?: string;
+  /**
+   * TODO(Phase 3): Remove this flag once Cosmos transaction signing is implemented.
+   * Temporarily disables the Send button for AtomOne tokens because signing is not yet supported.
+   * Delete this field and all readOnly branches when Phase 3 Cosmos signing is added.
+   */
+  readOnly?: boolean;
 }
 
 export interface GRC721CollectionModel {


### PR DESCRIPTION
## Summary

Introduce `CosmosLcdProvider` (REST/LCD) and `CosmosBalanceService` to read AtomOne balances via Cosmos Bank module endpoints. Pure addition — existing Gno balance paths are not modified.

- `CosmosLcdProvider` with `getAllBalances` / `getBalance` using axios (project convention), 10s timeout, returns `null` on any failure; warns on empty baseUrl, normalizes trailing slash
- `CosmosBalanceService` consumes `TokenProfile` (from ADN-749-1 TokenRegistry) and returns `TokenBalanceType` aligned with `WalletBalanceService`; uses the `staking` tag to decide the main flag so only the primary staking token (ATONE) is marked main, not fee tokens (PHOTON)
- Extend `TokenModel.type` union with `'cosmos-native'`
- Wire `cosmosLcdProvider` / `cosmosBalanceService` into `AdenaProvider` context
- Unit tests — provider (8) and service (12): success, network error, timeout, zero balance, non-cosmos token filtering

## Out of scope

Endpoint is currently fixed via an `ATOMONE_CHAIN_ID` constant. Part 7 (settings > network UI) will replace this with a reactive endpoint sourced from `currentNetworkByChainGroup['atomone']`.

## Test plan

- [ ] `cd packages/adena-extension && npm test` — `cosmos-lcd-provider.spec.ts`, `cosmos-balance.spec.ts`
- [ ] `cd packages/adena-extension && npx tsc --noEmit`

## Related

Base: `feature/ADN-749-3` (resolveAddress cache)
Depends on: `feature/ADN-749-1` (ChainRegistry / TokenRegistry)