### PR TITLE
ADN-749: integrate AtomOne balances into wallet UI with per-chain query lifecycle

### DIFF
--- a/packages/adena-extension/src/assets/icons/cosmos-icons.ts
+++ b/packages/adena-extension/src/assets/icons/cosmos-icons.ts
@@ -1,0 +1,19 @@
+import atoneIcon from './atone.svg';
+import photonIcon from './photon.svg';
+
+/**
+ * Maps chain profile IDs to their chain icon URLs (webpack-processed).
+ * Add new entries here when registering additional Cosmos chains.
+ */
+export const CHAIN_ICON_MAP: Record<string, string> = {
+  'atomone-1': atoneIcon,
+};
+
+/**
+ * Maps token IDs to their token icon URLs (webpack-processed).
+ * Cosmos token icons are sourced here because they are not managed by tokenService.
+ */
+export const COSMOS_TOKEN_ICON_MAP: Record<string, string> = {
+  'atomone-1:uatone': atoneIcon,
+  'atomone-1:uphoton': photonIcon,
+};

--- a/packages/adena-extension/src/components/atoms/asset-icon/asset-icon.tsx
+++ b/packages/adena-extension/src/components/atoms/asset-icon/asset-icon.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+import { getTheme } from '@styles/theme';
+
+interface AssetIconProps {
+  tokenIconUrl: string;
+  chainIconUrl?: string;
+  size?: number;
+  onLoad?: () => void;
+  onError?: () => void;
+}
+
+interface ContainerProps {
+  size: number;
+}
+
+const Container = styled.div<ContainerProps>`
+  position: relative;
+  flex-shrink: 0;
+  width: ${({ size }): string => `${size}px`};
+  height: ${({ size }): string => `${size}px`};
+`;
+
+const TokenIcon = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+`;
+
+const ChainBadge = styled.img`
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  width: 40%;
+  height: 40%;
+  border-radius: 50%;
+  border: 1.5px solid ${getTheme('neutral', '_9')};
+`;
+
+const AssetIcon: React.FC<AssetIconProps> = ({
+  tokenIconUrl,
+  chainIconUrl,
+  size = 34,
+  onLoad,
+  onError,
+}) => (
+  <Container size={size}>
+    <TokenIcon src={tokenIconUrl} onLoad={onLoad} onError={onError} alt='token icon' />
+    {chainIconUrl && <ChainBadge src={chainIconUrl} alt='chain icon' />}
+  </Container>
+);
+
+export default AssetIcon;

--- a/packages/adena-extension/src/components/pages/wallet-main/token-list-item/token-list-item.styles.ts
+++ b/packages/adena-extension/src/components/pages/wallet-main/token-list-item/token-list-item.styles.ts
@@ -26,12 +26,6 @@ export const TokenListItemWrapper = styled.div`
     width: 34px;
     height: 34px;
     margin-right: 12px;
-
-    .logo {
-      width: 100%;
-      height: 100%;
-      border-radius: 50%;
-    }
   }
 
   .name-wrapper {

--- a/packages/adena-extension/src/components/pages/wallet-main/token-list-item/token-list-item.tsx
+++ b/packages/adena-extension/src/components/pages/wallet-main/token-list-item/token-list-item.tsx
@@ -1,3 +1,4 @@
+import AssetIcon from '@components/atoms/asset-icon/asset-icon';
 import TokenListItemBalance from '@components/pages/wallet-main/token-list-item-balance/token-list-item-balance';
 import { MainToken } from '@types';
 import React from 'react';
@@ -14,7 +15,7 @@ const TokenListItem: React.FC<TokenListItemProps> = ({
   completeImageLoading,
   onClickTokenItem,
 }) => {
-  const { tokenId, logo, name, balanceAmount } = token;
+  const { tokenId, logo, name, balanceAmount, chainIconUrl } = token;
 
   const onLoadImage = (): void => {
     completeImageLoading(logo);
@@ -23,14 +24,11 @@ const TokenListItem: React.FC<TokenListItemProps> = ({
   return (
     <TokenListItemWrapper onClick={(): void => onClickTokenItem(tokenId)}>
       <div className='logo-wrapper'>
-        <img
-          className='logo'
-          src={logo}
+        <AssetIcon
+          tokenIconUrl={logo}
+          chainIconUrl={chainIconUrl}
           onLoad={onLoadImage}
           onError={onLoadImage}
-          loading='eager'
-          decoding='sync'
-          alt='token img'
         />
       </div>
 

--- a/packages/adena-extension/src/hooks/helpers/fetch-cosmos-balances.ts
+++ b/packages/adena-extension/src/hooks/helpers/fetch-cosmos-balances.ts
@@ -1,0 +1,46 @@
+import { Account, ChainRegistry, TokenRegistry } from 'adena-module';
+import { COSMOS_TOKEN_ICON_MAP } from '@assets/icons/cosmos-icons';
+import { CosmosBalanceService } from '@services/wallet';
+import { TokenBalanceType } from '@types';
+
+/**
+ * Fetch token balances for all registered Cosmos chains.
+ *
+ * Each chain is queried in parallel. If a single chain's LCD call fails,
+ * that chain returns [] so Gno balances are never affected.
+ *
+ * TODO(Phase 3): When Cosmos signing is implemented, this function may need
+ * to be aware of writable vs. read-only chains.
+ */
+export async function fetchCosmosTokenBalances(
+  account: Account,
+  cosmosBalanceService: CosmosBalanceService,
+  chainRegistry: ChainRegistry,
+  tokenRegistry: TokenRegistry,
+): Promise<TokenBalanceType[]> {
+  const cosmosChains = chainRegistry.list().filter((profile) => profile.chainType === 'cosmos');
+
+  const results = await Promise.all(
+    cosmosChains.map(async (profile) => {
+      try {
+        const chain = chainRegistry.getChain(profile.chainGroup);
+        if (!chain) return [];
+        const address = await account.getAddress(chain.bech32Prefix);
+        const tokens = tokenRegistry.list(profile.id);
+        return cosmosBalanceService.getTokenBalances(address, tokens);
+      } catch {
+        return [];
+      }
+    }),
+  );
+
+  // Resolve icon URLs through the webpack-processed map so that consumers
+  // (TokenDetails, Search, TransferInput, etc.) can use `image` directly.
+  // The iconUrl string on the TokenProfile is a domain-level hint and may
+  // not match the extension's bundler layout; the map is the source of truth
+  // for presentation. Falls back to the profile-provided string if unmapped.
+  return results.flat().map((balance) => ({
+    ...balance,
+    image: COSMOS_TOKEN_ICON_MAP[balance.tokenId] ?? balance.image,
+  }));
+}

--- a/packages/adena-extension/src/hooks/use-token-balance.ts
+++ b/packages/adena-extension/src/hooks/use-token-balance.ts
@@ -1,12 +1,13 @@
 import { QueryObserverResult, useQuery } from '@tanstack/react-query';
 import { Account } from 'adena-module';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useRecoilValueLoadable } from 'recoil';
 
 import { isGRC20TokenModel, isNativeTokenModel } from '@common/validation/validation-token';
 import { AccountState } from '@states';
 import { Amount, TokenBalanceType, TokenModel } from '@types';
 
+import { fetchCosmosTokenBalances } from './helpers/fetch-cosmos-balances';
 import { useAdenaContext, useWalletContext } from './use-context';
 import { useCurrentAccount } from './use-current-account';
 import { useGRC20Tokens } from './use-grc20-tokens';
@@ -14,7 +15,11 @@ import { useNetwork } from './use-network';
 import { useTokenMetainfo } from './use-token-metainfo';
 import { useWallet } from './use-wallet';
 
-const REFETCH_INTERVAL = 3_000;
+const GNO_REFETCH_INTERVAL = 3_000;
+// Cosmos LCD p95 latency is significantly higher than Gno RPC.
+// A relaxed interval reduces request pressure and retry noise without
+// meaningfully hurting UX — balance changes on AtomOne are less frequent.
+const COSMOS_REFETCH_INTERVAL = 10_000;
 
 export const useTokenBalance = (): {
   mainTokenBalance: Amount | null;
@@ -35,14 +40,19 @@ export const useTokenBalance = (): {
     getTokenAmount,
   } = useTokenMetainfo();
   const { wallet } = useWalletContext();
-  const { balanceService } = useAdenaContext();
+  const { balanceService, cosmosBalanceService, chainRegistry, tokenRegistry } = useAdenaContext();
   const { currentNetwork } = useNetwork();
-  const { currentAddress } = useCurrentAccount();
+  const { currentAddress, currentAccount } = useCurrentAccount();
   const { existWallet, lockedWallet } = useWallet();
 
   useEffect(() => {
     balanceService.setTokenMetainfos(tokenMetainfos);
   }, [tokenMetainfos, balanceService]);
+
+  // Declared early because it is referenced in the Gno query's `enabled` condition below.
+  const nativeToken = useMemo((): TokenModel | null => {
+    return tokenMetainfos.find((tokenModel) => tokenModel.main) || null;
+  }, [tokenMetainfos]);
 
   const availableBalanceFetching = useMemo(() => {
     if (!existWallet || lockedWallet) {
@@ -56,20 +66,27 @@ export const useTokenBalance = (): {
     return true;
   }, [existWallet, lockedWallet, tokenMetainfos, isFetchedGRC20Tokens]);
 
-  const { data: balances = [], refetch: refetchBalances } = useQuery<TokenBalanceType[]>(
-    ['balances', currentAddress, currentNetwork.chainId, isFetchedGRC20Tokens, tokenLogoMap],
+  // Gno and Cosmos are fetched in two independent queries so that each chain
+  // has its own lifecycle: separate cache, refetch interval, error state, and
+  // loading state. A slow or failing Cosmos LCD never blocks the Gno result
+  // from rendering, and either chain can be invalidated without touching the other.
+  const {
+    data: gnoBalances = [],
+    refetch: refetchGnoBalances,
+  } = useQuery<TokenBalanceType[]>(
+    // 'gno' discriminator keeps this cache entry separate from the Cosmos query
+    // even though both share the 'balances' prefix.
+    ['balances', 'gno', currentAddress, currentNetwork.chainId, isFetchedGRC20Tokens, tokenLogoMap],
     () => {
-      if (currentAddress === null || nativeToken == null) {
-        return [];
-      }
+      if (currentAddress === null || nativeToken == null) return [];
       return Promise.all(
         tokenMetainfos.map((tokenModel) => fetchBalanceBy(currentAddress, tokenModel)),
       );
     },
     {
-      refetchInterval: REFETCH_INTERVAL,
+      refetchInterval: GNO_REFETCH_INTERVAL,
       keepPreviousData: true,
-      enabled: availableBalanceFetching,
+      enabled: availableBalanceFetching && currentAddress !== null && nativeToken !== null,
     },
   );
 
@@ -81,6 +98,46 @@ export const useTokenBalance = (): {
   );
   const accountAddressesByAccountId =
     accountAddressesLoadable.state === 'hasValue' ? accountAddressesLoadable.contents : null;
+
+  const {
+    data: cosmosBalances = [],
+    refetch: refetchCosmosBalances,
+  } = useQuery<TokenBalanceType[]>(
+    // Keyed by account id (not the object reference) to avoid spurious refetches
+    // when a new Account instance is created from the same underlying data.
+    ['balances', 'cosmos', currentAccount?.id ?? null, currentNetwork.chainId],
+    () => {
+      if (currentAccount === null) return [];
+      // No .catch() here — let React Query own the error state. When this query
+      // fails, cosmosBalances defaults to [] via the fallback, so Gno balances
+      // continue rendering unaffected.
+      return fetchCosmosTokenBalances(
+        currentAccount,
+        cosmosBalanceService,
+        chainRegistry,
+        tokenRegistry,
+      );
+    },
+    {
+      refetchInterval: COSMOS_REFETCH_INTERVAL,
+      keepPreviousData: true,
+      enabled: availableBalanceFetching && currentAccount !== null,
+      // Default retry (3) causes excessive delay and traffic during LCD outages.
+      retry: 1,
+    },
+  );
+
+  const balances = useMemo<TokenBalanceType[]>(
+    () => [...gnoBalances, ...cosmosBalances],
+    [gnoBalances, cosmosBalances],
+  );
+
+  // Refetch both chains in parallel. Returns the Gno result to satisfy the
+  // existing QueryObserverResult return type; callers discard the return value.
+  const refetchBalances = useCallback(
+    () => Promise.all([refetchGnoBalances(), refetchCosmosBalances()]).then(([gno]) => gno),
+    [refetchGnoBalances, refetchCosmosBalances],
+  );
 
   const { data: accountNativeBalanceMap = {}, refetch: refetchAccountNativeBalanceMap } = useQuery<
     Record<string, TokenBalanceType>
@@ -117,7 +174,7 @@ export const useTokenBalance = (): {
       );
     },
     {
-      refetchInterval: REFETCH_INTERVAL,
+      refetchInterval: GNO_REFETCH_INTERVAL,
       enabled: availableBalanceFetching && accountAddressesByAccountId !== null,
     },
   );
@@ -126,18 +183,16 @@ export const useTokenBalance = (): {
     if (balances.length === 0) {
       return [];
     }
-    return tokenMetainfos.map((tokenMetainfo) => ({
+    const gnoTokenBalances = tokenMetainfos.map((tokenMetainfo) => ({
       ...tokenMetainfo,
       amount: balances.find((t) => t.tokenId === tokenMetainfo.tokenId)?.amount || {
         value: '',
         denom: '',
       },
     }));
+    const cosmosTokenBalances = balances.filter((b) => b.type === 'cosmos-native');
+    return [...gnoTokenBalances, ...cosmosTokenBalances];
   }, [balances, tokenMetainfos]);
-
-  const nativeToken = useMemo((): TokenModel | null => {
-    return tokenMetainfos.find((tokenModel) => tokenModel.main) || null;
-  }, [tokenMetainfos]);
 
   const mainTokenBalance = useMemo((): Amount | null => {
     if (nativeToken === null) {

--- a/packages/adena-extension/src/pages/popup/wallet/search/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/search/index.tsx
@@ -134,11 +134,18 @@ export const WalletSearch = (): JSX.Element => {
       </SearchBox>
       <DataListWrap>
         {currentBalances
-          .filter(
-            (balance) =>
+          .filter((balance) => {
+            // Hide read-only tokens (Cosmos until Phase 3 signing) from the send
+            // flow so users cannot select a token that cannot actually be sent.
+            // Deposit flow keeps them visible — receiving is always available.
+            if (params?.type === 'send' && balance.type === 'cosmos-native') {
+              return false;
+            }
+            return (
               searchTextFilter(balance.name ?? '', searchText) ||
-              searchTextFilter(balance.symbol ?? '', searchText),
-          )
+              searchTextFilter(balance.symbol ?? '', searchText)
+            );
+          })
           .map((balance, idx) => (
             <ListBox
               left={

--- a/packages/adena-extension/src/pages/popup/wallet/token-details/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/token-details/index.tsx
@@ -92,6 +92,8 @@ export const TokenDetails = (): JSX.Element => {
   const [etcClicked, setEtcClicked] = useState(false);
   const { currentAccount, currentAddress } = useCurrentAccount();
   const tokenBalance = params?.tokenBalance;
+  // TODO(Phase 3): Remove readOnly branch once Cosmos transaction signing is implemented
+  const readOnly = params?.readOnly ?? false;
   const [bodyElement, setBodyElement] = useState<HTMLBodyElement | undefined>();
   const [loadingNextFetch, setLoadingNextFetch] = useState(false);
   const { clearHistoryData } = useHistoryData();
@@ -251,6 +253,7 @@ export const TokenDetails = (): JSX.Element => {
         rightProps={{
           onClick: SendButtonClick,
           text: 'Send',
+          props: { disabled: readOnly },
         }}
       />
       {isLoading && isSupported ? (

--- a/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
@@ -5,6 +5,7 @@ import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import UnknownTokenIcon from '@assets/common-unknown-token.svg';
+import { CHAIN_ICON_MAP, COSMOS_TOKEN_ICON_MAP } from '@assets/icons/cosmos-icons';
 import { Button, Row, Text } from '@components/atoms';
 import IconThunder from '@components/atoms/icon/icon-assets/icon-thunder';
 import LoadingButton from '@components/atoms/loading-button/loading-button';
@@ -167,17 +168,24 @@ export const WalletMain = (): JSX.Element => {
       .filter((tokenBalance) => tokenBalance.display)
       .filter((tokenBalance) => !BigNumber(tokenBalance.amount.value).isNaN())
       .map((tokenBalance) => {
+        const isCosmos = tokenBalance.networkId !== currentNetwork.networkId;
         return {
           tokenId: tokenBalance.tokenId,
-          logo: getTokenImage(tokenBalance) || `${UnknownTokenIcon}`,
+          logo:
+            getTokenImage(tokenBalance) ||
+            COSMOS_TOKEN_ICON_MAP[tokenBalance.tokenId] ||
+            `${UnknownTokenIcon}`,
           name: tokenBalance.name,
           balanceAmount: {
             value: BigNumber(tokenBalance.amount.value).toFormat(),
             denom: tokenBalance.amount.denom,
           },
+          chainIconUrl: isCosmos ? CHAIN_ICON_MAP[tokenBalance.networkId] : undefined,
+          // TODO(Phase 3): Remove once Cosmos signing is implemented — Send is disabled for AtomOne tokens
+          readOnly: isCosmos || undefined,
         };
       });
-  }, [currentBalances, getTokenImage]);
+  }, [currentBalances, getTokenImage, currentNetwork]);
 
   const tokenImages = useMemo(() => {
     return tokens.map((token) => token.logo);
@@ -190,11 +198,12 @@ export const WalletMain = (): JSX.Element => {
         window.alert('Token not found');
         return;
       }
+      const token = tokens.find((t) => t.tokenId === tokenId);
       navigate(RoutePath.TokenDetails, {
-        state: { tokenBalance },
+        state: { tokenBalance, readOnly: token?.readOnly },
       });
     },
-    [navigate, tokens],
+    [navigate, tokens, currentBalances],
   );
 
   const onClickManageButton = useCallback(() => {

--- a/packages/adena-extension/src/states/network.ts
+++ b/packages/adena-extension/src/states/network.ts
@@ -16,3 +16,13 @@ export const modified = atom<boolean>({
   key: 'network/modified',
   default: false,
 });
+
+/**
+ * Stores the selected NetworkProfile id per chainGroup.
+ * Supports simultaneous multi-chain activation (one active network per chain).
+ * Example: { gno: 'gnoland1', atomone: 'atomone-1' }
+ */
+export const selectedProfileByChainGroup = atom<Record<string, string>>({
+  key: 'network/selectedProfileByChainGroup',
+  default: { gno: 'gnoland1', atomone: 'atomone-1' },
+});

--- a/packages/adena-extension/src/types/router.ts
+++ b/packages/adena-extension/src/types/router.ts
@@ -142,6 +142,7 @@ export type RouteParams = {
   [RoutePath.Send]: null;
   [RoutePath.TokenDetails]: {
     tokenBalance: TokenBalanceType;
+    readOnly?: boolean;
   };
   [RoutePath.ApproveLogin]: null;
   [RoutePath.ApproveSignFailed]: null;


### PR DESCRIPTION
## Summary

Wire `CosmosBalanceService` (ADN-749-4) into the popup UI so AtomOne tokens (ATONE, PHOTON) render alongside Gno balances. Each chain owns an independent React Query lifecycle so a slow or failing LCD cannot block Gno rendering.

- Split `useTokenBalance` into two independent `useQuery` calls — Gno (3s interval) and Cosmos (10s interval, `retry: 1`) — each with its own cache key, `enabled` condition, and error state. `refetchBalances` still reruns both in parallel to preserve the existing single-refetch signature
- `fetchCosmosTokenBalances` helper — queries every registered Cosmos chain in parallel; per-chain failures fall back to `[]` so sibling chains are unaffected
- `cosmos-icons.ts` (`CHAIN_ICON_MAP`, `COSMOS_TOKEN_ICON_MAP`) as the presentation-layer source of truth for AtomOne icons — `iconUrl` on `TokenProfile` remains a domain-level hint; the extension resolves through this webpack-processed map to tolerate bundler asset-path flattening
- `AssetIcon` atom composes a token icon with an optional chain-badge overlay; adopted in `TokenListItem`
- Tag Cosmos tokens as `readOnly` in `wallet-main` and propagate through `TokenDetails` route params; disable the Send button and filter `cosmos-native` tokens out of the Send flow search results (Deposit still shows them since receiving is always available)
- Extend `TokenDetails` `RouteParams` with an optional `readOnly` flag

## Out of scope

All `readOnly` branches (`types/token.ts`, `wallet-main`, `token-details`, `search`, `fetch-cosmos-balances`) will be removed once Phase 3 Cosmos transaction signing lands.

## Test plan

- [ ] `cd packages/adena-extension && npm test`
- [ ] `cd packages/adena-extension && npx tsc --noEmit`
- [ ] Manual: AtomOne mainnet account renders ATONE / PHOTON balances alongside Gno balances (no blocking)
- [ ] Manual: Cosmos tokens hidden in Send search, shown in Deposit

## Related

Base: `feature/ADN-749-4` (CosmosLcdProvider / CosmosBalanceService)