### PR TITLE
fix: prevent approval popup from being force-closed by dapp polling (ADN-757)

### DIFF
--- a/packages/adena-extension/src/inject/message/message-handler.ts
+++ b/packages/adena-extension/src/inject/message/message-handler.ts
@@ -6,6 +6,8 @@ import { InjectionMessage, InjectionMessageInstance } from './message';
 import { existsPopups, removePopups } from './methods';
 import { InjectCore } from './methods/core';
 
+const NON_POPUP_REQUEST_TYPES: ReadonlySet<string> = new Set(['GET_ACCOUNT', 'GET_NETWORK']);
+
 export class MessageHandler {
   public static createHandler = (
     inMemoryProvider: MemoryProvider,
@@ -63,9 +65,15 @@ export class MessageHandler {
       return;
     }
 
-    const isPopup = await existsPopups();
-    if (isPopup) {
-      await removePopups();
+    // Data-only queries must not tear down an open approval popup. DApps such
+    // as Gnoswap poll GET_ACCOUNT in the background; calling removePopups for
+    // those requests force-closes the in-flight approval popup and the user
+    // sees a spurious TRANSACTION_REJECTED.
+    if (!NON_POPUP_REQUEST_TYPES.has(message.type)) {
+      const isPopup = await existsPopups();
+      if (isPopup) {
+        await removePopups();
+      }
     }
 
     switch (message.type) {

--- a/packages/adena-extension/src/inject/message/methods/common.ts
+++ b/packages/adena-extension/src/inject/message/methods/common.ts
@@ -29,17 +29,34 @@ export const createPopup = async (
       return;
     }
 
-    chrome.windows.onRemoved.addListener((removeWindowId) => {
-      if (windowResponse.id === removeWindowId) {
-        sendResponse(closeMessage);
-      }
-    });
-
-    const onMessageListener = (popupMessage: InjectionMessage): void => {
-      popupMessageListener(windowResponse.id, message, popupMessage, sendResponse);
+    // Guard: ensure sendResponse fires at most once. Without this, a successful
+    // popup response and the subsequent window removal both try to reply to the
+    // dapp, and whichever the background dispatches first wins — producing a
+    // TRANSACTION_REJECTED even though the popup returned success.
+    let responseSent = false;
+    const sendResponseOnce = (msg: any): void => {
+      if (responseSent) return;
+      responseSent = true;
+      sendResponse(msg);
     };
 
-    chrome.tabs.onUpdated.addListener((tabId, info) => {
+    const cleanup = (): void => {
+      chrome.windows.onRemoved.removeListener(onRemovedListener);
+      chrome.runtime.onMessage.removeListener(onMessageListener);
+      chrome.tabs.onUpdated.removeListener(onTabsUpdatedListener);
+    };
+
+    const onRemovedListener = (removeWindowId: number): void => {
+      if (windowResponse.id !== removeWindowId) return;
+      sendResponseOnce(closeMessage);
+      cleanup();
+    };
+
+    const onMessageListener = (popupMessage: InjectionMessage): void => {
+      popupMessageListener(windowResponse.id, message, popupMessage, sendResponseOnce, cleanup);
+    };
+
+    const onTabsUpdatedListener = (tabId: number, info: chrome.tabs.TabChangeInfo): void => {
       if (info.status === 'complete' && windowResponse.tabs) {
         chrome.runtime.onMessage.removeListener(onMessageListener);
         chrome.runtime.onMessage.addListener(onMessageListener);
@@ -52,7 +69,10 @@ export const createPopup = async (
           })
           .catch(() => undefined);
       }
-    });
+    };
+
+    chrome.windows.onRemoved.addListener(onRemovedListener);
+    chrome.tabs.onUpdated.addListener(onTabsUpdatedListener);
   });
 };
 
@@ -96,14 +116,17 @@ const popupMessageListener = (
   popupId: number | undefined,
   requestData: InjectionMessage,
   popupMessage: InjectionMessage,
-  sendResponse: (message: any) => void,
+  sendResponseOnce: (message: any) => void,
+  cleanup: () => void,
 ): boolean => {
-  new Promise((resolve) => {
-    if (requestData.key === popupMessage.key) {
-      resolve(popupMessage);
-    }
-  })
-    .then(sendResponse)
-    .finally(() => popupId && chrome.windows.remove(popupId));
+  if (requestData.key !== popupMessage.key) return true;
+
+  // Reply to the dapp first, then clean up listeners so the subsequent window
+  // removal cannot fire another sendResponse after the success path.
+  sendResponseOnce(popupMessage);
+  cleanup();
+  if (popupId) {
+    chrome.windows.remove(popupId).catch(() => undefined);
+  }
   return true;
 };

--- a/packages/adena-extension/src/inject/message/methods/common.ts
+++ b/packages/adena-extension/src/inject/message/methods/common.ts
@@ -3,6 +3,12 @@ import { encodeParameter, getSiteName } from '@common/utils/client-utils';
 import { InjectionMessage, InjectionMessageInstance } from '../message';
 import { InjectCore } from './core';
 
+// Tracks popup window ids that were closed programmatically (by the extension
+// itself — removePopups, popupMessageListener cleanup, etc.) so that the
+// onRemoved listener can distinguish "force-closed" from "user closed via X"
+// and respond with UNEXPECTED_ERROR instead of a user-rejection message.
+const programmaticallyClosedPopups = new Set<number>();
+
 export const createPopup = async (
   popupPath: string,
   message: InjectionMessage,
@@ -48,7 +54,20 @@ export const createPopup = async (
 
     const onRemovedListener = (removeWindowId: number): void => {
       if (windowResponse.id !== removeWindowId) return;
-      sendResponseOnce(closeMessage);
+      const wasProgrammatic = programmaticallyClosedPopups.has(removeWindowId);
+      if (wasProgrammatic) {
+        programmaticallyClosedPopups.delete(removeWindowId);
+      }
+      // If the popup was force-closed by the extension itself, the dapp should
+      // not be told "user rejected" — surface an unexpected error instead.
+      const responseMsg = wasProgrammatic
+        ? InjectionMessageInstance.failure(
+            WalletResponseFailureType.UNEXPECTED_ERROR,
+            {},
+            message.key,
+          )
+        : closeMessage;
+      sendResponseOnce(responseMsg);
       cleanup();
     };
 
@@ -85,6 +104,7 @@ export const removePopups = async (): Promise<void> => {
   const windows = await chrome.windows.getAll();
   windows.forEach((window) => {
     if (window.type === 'popup' && window.id) {
+      programmaticallyClosedPopups.add(window.id);
       chrome.windows.remove(window.id);
     }
   });

--- a/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx
@@ -660,9 +660,17 @@ const ApproveTransactionContainer: React.FC = () => {
     openScannerLink('/transactions/details', { txhash: txHash });
   }, [response, openScannerLink]);
 
-  const onClickCloseResult = useCallback(() => {
+  const onClickCloseResult = useCallback(async () => {
     if (response) {
-      chrome.runtime.sendMessage(response);
+      // Await delivery before closing — otherwise window.close() can sever the
+      // message channel mid-flight, and the background's onRemoved listener
+      // replies to the dapp with TRANSACTION_REJECTED even though the tx
+      // succeeded.
+      try {
+        await chrome.runtime.sendMessage(response);
+      } catch {
+        // Best-effort: if the channel is already gone, nothing to do.
+      }
     } else {
       onTimeoutSendTransaction();
     }


### PR DESCRIPTION
## Summary
Three related fixes for approval-popup teardown that caused dapps to see `TRANSACTION_REJECTED` when the user had actually approved (or had not acted at all).

1. **Primary** — `message-handler.ts` no longer tears down open popups for read-only requests (`GET_ACCOUNT`, `GET_NETWORK`). The dapp's background polling was force-closing in-flight approval popups.
2. **Race guard** — `common.ts` now ensures `sendResponse` fires at most once and cleans up all popup listeners together, plus the popup awaits `chrome.runtime.sendMessage` before `window.close()`. Prevents the earlier race where a successful popup response could be overridden by the `onRemoved` fallback.
3. **Forced-close disambiguation** — When a popup is closed by the extension itself (not by the user), the dapp now receives `UNEXPECTED_ERROR` instead of the user-rejection message. This keeps the rejection signal truthful for future force-close paths (e.g. consecutive `DO_CONTRACT` requests).

## Root cause
While a `DO_CONTRACT` popup was open, the dapp (e.g. Gnoswap) kept polling `GET_ACCOUNT` every few seconds. On each poll, `MessageHandler.requestHandler` ran `removePopups()` before dispatching the handler, which closed the approval popup. The popup's `onRemoved` listener in `common.ts` then sent the default `closeMessage` (`TRANSACTION_REJECTED`) back to the dapp — producing a "user rejected" result even though the user had done nothing, or had actually approved.

Timing evidence from instrumentation:
- Failing key `51fd0e5b…`: dapp `GET_ACCOUNT` at t=50997ms → popup `onRemoved` at t=51017ms (~20ms gap)
- Failing key `2c108cd1…`: dapp `GET_ACCOUNT` at t=124156ms → popup `onRemoved` at t=124173ms (~17ms gap)

## Changes
### `packages/adena-extension/src/inject/message/message-handler.ts`
- Introduce `NON_POPUP_REQUEST_TYPES = { GET_ACCOUNT, GET_NETWORK }`.
- Skip `existsPopups()` / `removePopups()` for these read-only requests. Popup-opening requests (`DO_CONTRACT`, `SIGN_*`, `ADD_ESTABLISH`, etc.) preserve the existing behavior.

### `packages/adena-extension/src/inject/message/methods/common.ts`
- Replace anonymous listeners with named `onRemovedListener` / `onMessageListener` / `onTabsUpdatedListener` and add a `cleanup()` that removes all three. Prevents listener leaks across popup sessions.
- Add a `sendResponseOnce` guard so `sendResponse` can never fire twice for the same request (defends against races between popup success message and `onRemoved` fallback).
- Add a module-scoped `programmaticallyClosedPopups: Set<number>`. `removePopups()` records each window id it is about to close. When `onRemovedListener` fires, if the id is in the set, respond with `UNEXPECTED_ERROR` instead of the default `closeMessage`. This prevents future forced-close paths (e.g. consecutive `DO_CONTRACT` requests) from being reported as user rejections.

### `packages/adena-extension/src/pages/popup/wallet/approve-transaction-main/index.tsx`
- `onClickCloseResult`: `await chrome.runtime.sendMessage(response)` before `window.close()` so the success response actually reaches the background before the popup tears down.

## Test plan
- [ ] Build the extension and load unpacked.
- [ ] On Gnoswap, open a swap approval popup and wait >5s before confirming (to let background `GET_ACCOUNT` polling fire). Confirm the popup stays open and the transaction succeeds. Dapp should receive `TRANSACTION_SUCCESS`.
- [ ] Repeat with multiple swaps in succession — each should yield its own `TRANSACTION_SUCCESS`.
- [ ] Close the popup with the X button mid-review — dapp should receive `TRANSACTION_REJECTED` (unchanged behavior).
- [ ] Fire a second `DO_CONTRACT` while a first popup is still open — previous request should now receive `UNEXPECTED_ERROR` (not a user rejection).
- [ ] `SIGN_AMINO` / `SIGN_TX` popups behave the same way (same `createPopup` path).
- [ ] `GET_ACCOUNT` / `GET_NETWORK` continue to respond normally.

Closes ADN-757