### PR TITLE
ADN-751: add Cosmos AMINO send flow for AtomOne (Phase 3)

### DIFF
--- a/packages/adena-extension/src/common/provider/adena/adena-provider.tsx
+++ b/packages/adena-extension/src/common/provider/adena/adena-provider.tsx
@@ -175,9 +175,9 @@ export const AdenaProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chil
   );
 
   const transactionService = useMemo(() => {
-    const transactionService = new TransactionService(walletService, gnoProvider);
+    const transactionService = new TransactionService(walletService, gnoProvider, chainRegistry);
     return transactionService;
-  }, [walletService, gnoProvider]);
+  }, [walletService, gnoProvider, chainRegistry]);
 
   const transactionHistoryService = useMemo(
     () => new TransactionHistoryService(gnoProvider, transactionHistoryRepository),

--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.spec.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.spec.ts
@@ -8,10 +8,12 @@ describe('CosmosLcdProvider', () => {
   const BASE_URL = 'https://atomone-api.allinbits.com';
   let provider: CosmosLcdProvider;
   let mockGet: jest.Mock;
+  let mockPost: jest.Mock;
 
   beforeEach(() => {
     mockGet = jest.fn();
-    mockedAxios.create.mockReturnValue({ get: mockGet } as any);
+    mockPost = jest.fn();
+    mockedAxios.create.mockReturnValue({ get: mockGet, post: mockPost } as any);
     provider = new CosmosLcdProvider(BASE_URL);
   });
 
@@ -31,9 +33,7 @@ describe('CosmosLcdProvider', () => {
     });
 
     it('returns "0" when balance field has no amount', async () => {
-      mockGet.mockResolvedValue({
-        data: { balance: {} },
-      });
+      mockGet.mockResolvedValue({ data: { balance: {} } });
 
       const result = await provider.getBalance('atone1abc', 'uatone');
       expect(result).toBe('0');
@@ -41,13 +41,6 @@ describe('CosmosLcdProvider', () => {
 
     it('returns null on network error', async () => {
       mockGet.mockRejectedValue(new Error('Network Error'));
-
-      const result = await provider.getBalance('atone1abc', 'uatone');
-      expect(result).toBeNull();
-    });
-
-    it('returns null on timeout', async () => {
-      mockGet.mockRejectedValue(new Error('timeout of 10000ms exceeded'));
 
       const result = await provider.getBalance('atone1abc', 'uatone');
       expect(result).toBeNull();
@@ -99,6 +92,135 @@ describe('CosmosLcdProvider', () => {
       expect(mockGet).toHaveBeenCalledWith(
         `${newUrl}/cosmos/bank/v1beta1/balances/atone1abc/by_denom`,
         { params: { denom: 'uatone' } },
+      );
+    });
+  });
+
+  describe('getAccount', () => {
+    it('returns BaseAccount fields', async () => {
+      mockGet.mockResolvedValue({
+        data: {
+          account: {
+            '@type': '/cosmos.auth.v1beta1.BaseAccount',
+            address: 'atone1abc',
+            account_number: '42',
+            sequence: '7',
+          },
+        },
+      });
+
+      const result = await provider.getAccount('atone1abc');
+
+      expect(result).toEqual({
+        address: 'atone1abc',
+        accountNumber: '42',
+        sequence: '7',
+      });
+      expect(mockGet).toHaveBeenCalledWith(
+        `${BASE_URL}/cosmos/auth/v1beta1/accounts/atone1abc`,
+      );
+    });
+
+    it('unwraps base_account for wrapped account types (e.g. vesting)', async () => {
+      mockGet.mockResolvedValue({
+        data: {
+          account: {
+            '@type': '/cosmos.vesting.v1beta1.PeriodicVestingAccount',
+            base_account: {
+              address: 'atone1vest',
+              account_number: '99',
+              sequence: '3',
+            },
+          },
+        },
+      });
+
+      const result = await provider.getAccount('atone1vest');
+
+      expect(result).toEqual({
+        address: 'atone1vest',
+        accountNumber: '99',
+        sequence: '3',
+      });
+    });
+
+    it('falls back to 0/0 when fields are missing (fresh account)', async () => {
+      mockGet.mockResolvedValue({
+        data: {
+          account: {
+            '@type': '/cosmos.auth.v1beta1.BaseAccount',
+          },
+        },
+      });
+
+      const result = await provider.getAccount('atone1fresh');
+
+      expect(result).toEqual({
+        address: 'atone1fresh',
+        accountNumber: '0',
+        sequence: '0',
+      });
+    });
+  });
+
+  describe('broadcastTx', () => {
+    it('posts base64-encoded tx_bytes and returns response on success', async () => {
+      mockPost.mockResolvedValue({
+        data: {
+          tx_response: {
+            txhash: 'ABCDEF',
+            code: 0,
+            raw_log: '',
+            height: '100',
+          },
+        },
+      });
+
+      const txBytes = new Uint8Array([1, 2, 3, 4]);
+      const result = await provider.broadcastTx(txBytes);
+
+      expect(result).toEqual({
+        txhash: 'ABCDEF',
+        code: 0,
+        rawLog: '',
+        height: '100',
+      });
+      expect(mockPost).toHaveBeenCalledWith(
+        `${BASE_URL}/cosmos/tx/v1beta1/txs`,
+        {
+          tx_bytes: Buffer.from(txBytes).toString('base64'),
+          mode: 'BROADCAST_MODE_SYNC',
+        },
+      );
+    });
+
+    it('uses the provided broadcast mode', async () => {
+      mockPost.mockResolvedValue({
+        data: { tx_response: { txhash: 'XYZ', code: 0, raw_log: '', height: '1' } },
+      });
+
+      await provider.broadcastTx(new Uint8Array([9]), 'BROADCAST_MODE_ASYNC');
+
+      expect(mockPost).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ mode: 'BROADCAST_MODE_ASYNC' }),
+      );
+    });
+
+    it('throws with raw_log when code is non-zero', async () => {
+      mockPost.mockResolvedValue({
+        data: {
+          tx_response: {
+            txhash: 'FAILHASH',
+            code: 32,
+            raw_log: 'account sequence mismatch',
+            height: '0',
+          },
+        },
+      });
+
+      await expect(provider.broadcastTx(new Uint8Array([1]))).rejects.toThrow(
+        /code=32.*account sequence mismatch/,
       );
     });
   });

--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.spec.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.spec.ts
@@ -207,6 +207,16 @@ describe('CosmosLcdProvider', () => {
       );
     });
 
+    it('throws a clear error when tx_response is missing from LCD response', async () => {
+      // Regression: prior code accessed r.code without null-checking r,
+      // producing a cryptic "Cannot read properties of undefined" crash.
+      mockPost.mockResolvedValue({ data: {} });
+
+      await expect(provider.broadcastTx(new Uint8Array([1]))).rejects.toThrow(
+        /no tx_response/,
+      );
+    });
+
     it('throws with raw_log when code is non-zero', async () => {
       mockPost.mockResolvedValue({
         data: {

--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.ts
@@ -1,6 +1,29 @@
+import {
+  CosmosAccount,
+  CosmosBroadcastMode,
+  CosmosProvider,
+  CosmosTxBroadcastResponse,
+} from 'adena-module';
 import axios, { AxiosInstance } from 'axios';
 
-export class CosmosLcdProvider {
+// Re-export the module-side types so existing extension import sites keep
+// working against `@common/provider/cosmos/cosmos-lcd-provider`.
+export type {
+  CosmosAccount,
+  CosmosBroadcastMode,
+  CosmosTxBroadcastResponse,
+} from 'adena-module';
+
+/**
+ * REST LCD implementation of {@link CosmosProvider}. Lives in adena-extension
+ * because axios pulls in Node built-ins when bundled via adena-module's rollup
+ * config (causes `Z_SYNC_FLUSH` crash in the browser). Extension's webpack
+ * correctly picks axios's browser build.
+ *
+ * Injected into AdenaWallet cosmos methods via the TransactionService, mirroring
+ * how GnoProvider is injected for the Gno path.
+ */
+export class CosmosLcdProvider implements CosmosProvider {
   private axiosInstance: AxiosInstance;
 
   constructor(private baseUrl: string) {
@@ -11,11 +34,18 @@ export class CosmosLcdProvider {
     this.axiosInstance = axios.create({ timeout: 10_000 });
   }
 
-  async getAllBalances(address: string): Promise<{ denom: string; amount: string }[] | null> {
+  // Reserved for future network switching (Phase 7+).
+  setBaseUrl(url: string): void {
+    this.baseUrl = url.replace(/\/$/, '');
+  }
+
+  async getAllBalances(
+    address: string,
+  ): Promise<{ denom: string; amount: string }[] | null> {
     try {
-      const response = await this.axiosInstance.get<{ balances: { denom: string; amount: string }[] }>(
-        `${this.baseUrl}/cosmos/bank/v1beta1/balances/${address}`,
-      );
+      const response = await this.axiosInstance.get<{
+        balances: { denom: string; amount: string }[];
+      }>(`${this.baseUrl}/cosmos/bank/v1beta1/balances/${address}`);
       return response.data.balances ?? [];
     } catch {
       return null;
@@ -24,18 +54,69 @@ export class CosmosLcdProvider {
 
   async getBalance(address: string, denom: string): Promise<string | null> {
     try {
-      const response = await this.axiosInstance.get<{ balance: { denom: string; amount: string } }>(
-        `${this.baseUrl}/cosmos/bank/v1beta1/balances/${address}/by_denom`,
-        { params: { denom } },
-      );
+      const response = await this.axiosInstance.get<{
+        balance: { denom: string; amount: string };
+      }>(`${this.baseUrl}/cosmos/bank/v1beta1/balances/${address}/by_denom`, {
+        params: { denom },
+      });
       return response.data.balance?.amount ?? '0';
     } catch {
       return null;
     }
   }
 
-  // Reserved for Part 7: dynamically update endpoint when user switches AtomOne network
-  setBaseUrl(url: string): void {
-    this.baseUrl = url.replace(/\/$/, '');
+  async getAccount(address: string): Promise<CosmosAccount> {
+    const response = await this.axiosInstance.get<{
+      account: {
+        '@type': string;
+        address?: string;
+        account_number?: string;
+        sequence?: string;
+        base_account?: {
+          address?: string;
+          account_number?: string;
+          sequence?: string;
+        };
+      };
+    }>(`${this.baseUrl}/cosmos/auth/v1beta1/accounts/${address}`);
+
+    const raw = response.data.account;
+    const inner = raw.base_account ?? raw;
+
+    return {
+      address: inner.address ?? address,
+      accountNumber: inner.account_number ?? '0',
+      sequence: inner.sequence ?? '0',
+    };
+  }
+
+  async broadcastTx(
+    txBytes: Uint8Array,
+    mode: CosmosBroadcastMode = 'BROADCAST_MODE_SYNC',
+  ): Promise<CosmosTxBroadcastResponse> {
+    const body = {
+      tx_bytes: Buffer.from(txBytes).toString('base64'),
+      mode,
+    };
+
+    const response = await this.axiosInstance.post<{
+      tx_response: {
+        txhash: string;
+        code: number;
+        raw_log: string;
+        height: string;
+      };
+    }>(`${this.baseUrl}/cosmos/tx/v1beta1/txs`, body);
+
+    const r = response.data.tx_response;
+    if (r.code !== 0) {
+      throw new Error(`Cosmos broadcast failed (code=${r.code}): ${r.raw_log}`);
+    }
+    return {
+      txhash: r.txhash,
+      code: r.code,
+      rawLog: r.raw_log,
+      height: r.height,
+    };
   }
 }

--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.ts
@@ -109,6 +109,9 @@ export class CosmosLcdProvider implements CosmosProvider {
     }>(`${this.baseUrl}/cosmos/tx/v1beta1/txs`, body);
 
     const r = response.data.tx_response;
+    if (!r) {
+      throw new Error('Cosmos broadcast returned no tx_response');
+    }
     if (r.code !== 0) {
       throw new Error(`Cosmos broadcast failed (code=${r.code}): ${r.raw_log}`);
     }

--- a/packages/adena-extension/src/components/pages/transfer-input/address-input/address-input.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-input/address-input/address-input.tsx
@@ -20,6 +20,10 @@ export interface AddressInputProps {
   onClickInputIcon: (selected: boolean) => void;
   onChangeAddress: (address: string) => void;
   onClickAddressBook: (addressBookId: string) => void;
+  // Cosmos atone1 addresses are 44 chars vs Gno g1 addresses at 40.
+  // Leaving these optional preserves the Gno-only behavior for existing callers.
+  maxLength?: number;
+  placeholder?: string;
 }
 
 const AddressInput: React.FC<AddressInputProps> = ({
@@ -34,6 +38,8 @@ const AddressInput: React.FC<AddressInputProps> = ({
   onClickInputIcon,
   onChangeAddress,
   onClickAddressBook,
+  maxLength = 40,
+  placeholder = 'Recipient’s Gno.land Address',
 }) => {
   const addressInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -58,9 +64,9 @@ const AddressInput: React.FC<AddressInputProps> = ({
             className='address-input'
             value={address}
             onChange={(event): void => onChangeAddress(event.target.value)}
-            placeholder='Recipient’s Gno.land Address'
+            placeholder={placeholder}
             autoComplete='off'
-            maxLength={40}
+            maxLength={maxLength}
             rows={1}
           />
         )}

--- a/packages/adena-extension/src/components/pages/transfer-input/transfer-input/transfer-input.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-input/transfer-input/transfer-input.tsx
@@ -79,7 +79,15 @@ const TransferInput: React.FC<TransferInputProps> = ({
         <img className='logo' src={tokenMetainfo?.image || UnknownTokenIcon} alt='token image' />
       </div>
       <div className='address-input-wrapper'>
-        <AddressInput {...addressInput} />
+        <AddressInput
+          {...addressInput}
+          maxLength={tokenMetainfo?.type === 'cosmos-native' ? 48 : 40}
+          placeholder={
+            tokenMetainfo?.type === 'cosmos-native'
+              ? 'Recipient’s AtomOne Address'
+              : 'Recipient’s Gno.land Address'
+          }
+        />
       </div>
       <div className='balance-input-wrapper'>
         <BalanceInput {...balanceInput} />

--- a/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary/transfer-summary.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary/transfer-summary.tsx
@@ -40,25 +40,42 @@ const TransferSummary: React.FC<TransferSummaryProps> = ({
   memo,
   useNetworkFeeReturn,
   isErrorNetworkFee,
+  isLoadingNetworkFee,
   simulateErrorBannerMessage,
   onClickBack,
   onClickCancel,
   onClickSend,
   onClickNetworkFeeSetting,
 }) => {
+  // TEMP (Phase 3 MVP): when the container supplies an explicit loading override
+  // it is also telling us "I'm providing the fee externally — don't rely on any
+  // of the Gno useNetworkFee hook state (loading, simulate error, etc.)". The
+  // Cosmos path uses this with a hardcoded fee.
+  // TODO(Phase 6): replace with a unified network-fee abstraction once feemarket
+  //                estimation lands.
+  const hasExternalFee = isLoadingNetworkFee !== undefined;
+  const effectiveIsLoading = hasExternalFee
+    ? (isLoadingNetworkFee as boolean)
+    : useNetworkFeeReturn.isLoading;
+
   const disabledSendButton = useMemo(() => {
-    if (useNetworkFeeReturn.isLoading) {
+    if (effectiveIsLoading) {
       return true;
     }
 
-    if (isErrorNetworkFee || useNetworkFeeReturn.isSimulateError) {
+    if (isErrorNetworkFee) {
+      return true;
+    }
+
+    if (!hasExternalFee && useNetworkFeeReturn.isSimulateError) {
       return true;
     }
 
     return Number(networkFee?.amount || 0) <= 0;
   }, [
+    hasExternalFee,
     isErrorNetworkFee,
-    useNetworkFeeReturn.isLoading,
+    effectiveIsLoading,
     useNetworkFeeReturn.isSimulateError,
     networkFee,
   ]);
@@ -102,7 +119,7 @@ const TransferSummary: React.FC<TransferSummaryProps> = ({
           value={networkFee?.amount || ''}
           denom={networkFee?.denom || ''}
           isError={isErrorNetworkFee}
-          isLoading={useNetworkFeeReturn.isLoading}
+          isLoading={effectiveIsLoading}
           errorMessage={networkFeeErrorMessage}
           onClickSetting={onClickNetworkFeeSetting}
         />

--- a/packages/adena-extension/src/hooks/helpers/fetch-cosmos-balances.ts
+++ b/packages/adena-extension/src/hooks/helpers/fetch-cosmos-balances.ts
@@ -8,9 +8,6 @@ import { TokenBalanceType } from '@types';
  *
  * Each chain is queried in parallel. If a single chain's LCD call fails,
  * that chain returns [] so Gno balances are never affected.
- *
- * TODO(Phase 3): When Cosmos signing is implemented, this function may need
- * to be aware of writable vs. read-only chains.
  */
 export async function fetchCosmosTokenBalances(
   account: Account,

--- a/packages/adena-extension/src/hooks/use-address-book-input.ts
+++ b/packages/adena-extension/src/hooks/use-address-book-input.ts
@@ -33,7 +33,13 @@ export type UseAddressBookInputHookReturn = {
   validateEqualAddress: () => Promise<boolean>;
 };
 
-export const useAddressBookInput = (): UseAddressBookInputHookReturn => {
+// addressPrefixOverride: when the caller is sending to a non-Gno chain (e.g.
+// AtomOne), the default currentNetwork.addressPrefix ('g') would resolve
+// account/address-book entries as Gno addresses. Pass the target chain's
+// bech32 prefix to have the hook list and return chain-matched addresses.
+export const useAddressBookInput = (
+  addressPrefixOverride?: string,
+): UseAddressBookInputHookReturn => {
   const { addressBookService } = useAdenaContext();
   const { wallet } = useWalletContext();
   const { getCurrentAddress } = useCurrentAccount();
@@ -66,7 +72,7 @@ export const useAddressBookInput = (): UseAddressBookInputHookReturn => {
 
   const getAddressBookInfos = useCallback(async () => {
     const currentAccountInfos = [];
-    const addressPrefix = currentNetwork.addressPrefix;
+    const addressPrefix = addressPrefixOverride ?? currentNetwork.addressPrefix;
     const currentAddress = await getCurrentAddress(addressPrefix);
     for (const account of wallet?.accounts || []) {
       const address = await account.getAddress(addressPrefix);
@@ -89,7 +95,7 @@ export const useAddressBookInput = (): UseAddressBookInputHookReturn => {
       });
 
     return [...currentAccountInfos, ...addressBookInfos];
-  }, [addressBooks, wallet?.accounts]);
+  }, [addressBooks, wallet?.accounts, addressPrefixOverride, currentNetwork.addressPrefix]);
 
   const getSelectedAddressBookInfos = useCallback(() => {
     if (selectedAddressBook === null) {
@@ -156,7 +162,9 @@ export const useAddressBookInput = (): UseAddressBookInputHookReturn => {
         clearError();
         setOpened(false);
         setSelected(true);
-        const address = await selectedAccount.getAddress(currentNetwork.addressPrefix);
+        const address = await selectedAccount.getAddress(
+          addressPrefixOverride ?? currentNetwork.addressPrefix,
+        );
         setSelectedAddressBook({
           id: selectedAccount.id,
           name: selectedAccount.name,
@@ -182,7 +190,9 @@ export const useAddressBookInput = (): UseAddressBookInputHookReturn => {
 
   const validateEqualAddress = useCallback(async () => {
     const address = getResultAddress();
-    const currentAddress = await getCurrentAddress(currentNetwork?.addressPrefix);
+    const currentAddress = await getCurrentAddress(
+      addressPrefixOverride ?? currentNetwork?.addressPrefix,
+    );
     if (address === currentAddress) {
       setHasError(true);
       setErrorMessage('You can’t send GRC20 tokens to your own address');

--- a/packages/adena-extension/src/hooks/use-token-balance.ts
+++ b/packages/adena-extension/src/hooks/use-token-balance.ts
@@ -225,6 +225,30 @@ export const useTokenBalance = (): {
   }
 
   async function fetchBalanceBy(address: string, token: TokenModel): Promise<TokenBalanceType> {
+    // Cosmos branch: the `address` arg is the current (Gno-prefixed) address,
+    // which does not apply to Cosmos chains. Resolve the chain-specific address
+    // from currentAccount + chain.bech32Prefix and query the Cosmos LCD.
+    // Without this branch Send would read 0 for ATONE/PHOTON even when the
+    // wallet-main screen shows a non-zero balance (uses fetchCosmosTokenBalances).
+    if (token.type === 'cosmos-native') {
+      const zeroBalance: TokenBalanceType = {
+        ...token,
+        amount: getTokenAmount({ value: '0', denom: token.symbol }),
+      };
+
+      if (!currentAccount) return zeroBalance;
+
+      const chain = chainRegistry.getChainByChainId(token.networkId);
+      if (!chain || chain.chainType !== 'cosmos') return zeroBalance;
+
+      const cosmosAddress = await currentAccount.resolveAddress(chain.bech32Prefix);
+      const profile = tokenRegistry.get(token.tokenId);
+      if (!profile) return zeroBalance;
+
+      const balance = await cosmosBalanceService.getTokenBalance(cosmosAddress, profile);
+      return balance ?? zeroBalance;
+    }
+
     const balanceAmount = isNativeTokenModel(token)
       ? await balanceService.getGnotTokenBalance(address)
       : isGRC20TokenModel(token)

--- a/packages/adena-extension/src/hooks/use-token-balance.ts
+++ b/packages/adena-extension/src/hooks/use-token-balance.ts
@@ -241,7 +241,7 @@ export const useTokenBalance = (): {
       const chain = chainRegistry.getChainByChainId(token.networkId);
       if (!chain || chain.chainType !== 'cosmos') return zeroBalance;
 
-      const cosmosAddress = await currentAccount.resolveAddress(chain.bech32Prefix);
+      const cosmosAddress = await currentAccount.getAddress(chain.bech32Prefix);
       const profile = tokenRegistry.get(token.tokenId);
       if (!profile) return zeroBalance;
 

--- a/packages/adena-extension/src/pages/popup/wallet/search/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/search/index.tsx
@@ -135,12 +135,6 @@ export const WalletSearch = (): JSX.Element => {
       <DataListWrap>
         {currentBalances
           .filter((balance) => {
-            // Hide read-only tokens (Cosmos until Phase 3 signing) from the send
-            // flow so users cannot select a token that cannot actually be sent.
-            // Deposit flow keeps them visible — receiving is always available.
-            if (params?.type === 'send' && balance.type === 'cosmos-native') {
-              return false;
-            }
             return (
               searchTextFilter(balance.name ?? '', searchText) ||
               searchTextFilter(balance.symbol ?? '', searchText)

--- a/packages/adena-extension/src/pages/popup/wallet/token-details/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/token-details/index.tsx
@@ -1,4 +1,4 @@
-import { isAirgapAccount } from 'adena-module';
+import { isAirgapAccount, isMultisigAccount } from 'adena-module';
 import BigNumber from 'bignumber.js';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
@@ -92,14 +92,20 @@ export const TokenDetails = (): JSX.Element => {
   const [etcClicked, setEtcClicked] = useState(false);
   const { currentAccount, currentAddress } = useCurrentAccount();
   const tokenBalance = params?.tokenBalance;
-  // TODO(Phase 3): Remove readOnly branch once Cosmos transaction signing is implemented
-  const readOnly = params?.readOnly ?? false;
   const [bodyElement, setBodyElement] = useState<HTMLBodyElement | undefined>();
   const [loadingNextFetch, setLoadingNextFetch] = useState(false);
   const { clearHistoryData } = useHistoryData();
   const { currentBalances } = useTokenBalance();
 
   const isNative = tokenBalance && !isGRC20TokenModel(tokenBalance);
+
+  // Multisig × Cosmos = permanent non-support (keyrings are Gno-only).
+  // Disable the Send button with a tooltip instead of hiding the token so
+  // users can still see balances but immediately understand they can't send.
+  const isMultisigCosmosBlocked =
+    tokenBalance?.type === 'cosmos-native' &&
+    !!currentAccount &&
+    isMultisigAccount(currentAccount);
 
   const tokenPath = useMemo(() => {
     if (!tokenBalance || !isGRC20TokenModel(tokenBalance)) {
@@ -253,7 +259,12 @@ export const TokenDetails = (): JSX.Element => {
         rightProps={{
           onClick: SendButtonClick,
           text: 'Send',
-          props: { disabled: readOnly },
+          props: {
+            disabled: isMultisigCosmosBlocked,
+            title: isMultisigCosmosBlocked
+              ? "Multisig accounts don't support Cosmos chains"
+              : undefined,
+          },
         }}
       />
       {isLoading && isSupported ? (

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-input/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-input/index.tsx
@@ -1,3 +1,4 @@
+import { validateCosmosAddress } from 'adena-module';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -5,6 +6,7 @@ import { isNativeTokenModel } from '@common/validation/validation-token';
 import TransferInput from '@components/pages/transfer-input/transfer-input/transfer-input';
 import { useAddressBookInput } from '@hooks/use-address-book-input';
 import { useBalanceInput } from '@hooks/use-balance-input';
+import { useAdenaContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import useHistoryData from '@hooks/use-history-data';
 import { RoutePath } from '@types';
@@ -44,7 +46,15 @@ const TransferInputContainer: React.FC = () => {
   } = useSessionParams<RoutePath.TransferInput>();
   const [isTokenSearch, setIsTokenSearch] = useState(params?.isTokenSearch === true);
   const [tokenMetainfo, setTokenMetainfo] = useState<TokenModel | undefined>(params?.tokenBalance);
-  const addressBookInput = useAddressBookInput();
+  const { chainRegistry } = useAdenaContext();
+  // For Cosmos-native tokens the recipient/address-book must use the target
+  // chain's bech32 prefix (e.g. 'atone') instead of the current Gno network's.
+  const addressPrefixOverride = useMemo(() => {
+    if (tokenMetainfo?.type !== 'cosmos-native') return undefined;
+    const chain = chainRegistry.getChainByChainId(tokenMetainfo.networkId);
+    return chain?.chainType === 'cosmos' ? chain.bech32Prefix : undefined;
+  }, [tokenMetainfo, chainRegistry]);
+  const addressBookInput = useAddressBookInput(addressPrefixOverride);
   const balanceInput = useBalanceInput(tokenMetainfo);
   const { currentAccount } = useCurrentAccount();
   const { getHistoryData, setHistoryData } = useHistoryData<HistoryData>();
@@ -102,6 +112,22 @@ const TransferInputContainer: React.FC = () => {
     goBack();
   }, [isTokenSearch]);
 
+  const validateCosmosPrefixIfNeeded = useCallback((): boolean => {
+    if (!tokenMetainfo || tokenMetainfo.type !== 'cosmos-native') {
+      return true;
+    }
+    const chain = chainRegistry.getChainByChainId(tokenMetainfo.networkId);
+    if (!chain || chain.chainType !== 'cosmos') {
+      return true;
+    }
+    const ok = validateCosmosAddress(addressBookInput.resultAddress, chain.bech32Prefix);
+    if (!ok) {
+      // Reuse the generic "Invalid Address" UI state from addressBookInput.
+      addressBookInput.validateAddressBookInput();
+    }
+    return ok;
+  }, [tokenMetainfo, chainRegistry, addressBookInput]);
+
   const onClickNext = useCallback(async () => {
     if (!isNext) {
       return;
@@ -111,6 +137,7 @@ const TransferInputContainer: React.FC = () => {
     }
     const validAddress =
       addressBookInput.validateAddressBookInput() &&
+      validateCosmosPrefixIfNeeded() &&
       (isNativeTokenModel(tokenMetainfo) || (await addressBookInput.validateEqualAddress()));
     const validBalance = balanceInput.validateBalanceInput();
     if (validAddress && validBalance) {
@@ -129,7 +156,7 @@ const TransferInputContainer: React.FC = () => {
         },
       });
     }
-  }, [addressBookInput, balanceInput, isNext]);
+  }, [addressBookInput, balanceInput, isNext, validateCosmosPrefixIfNeeded]);
 
   useEffect(() => {
     if (isLoadingSessionState) {

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -314,15 +314,13 @@ const TransferSummaryContainer: React.FC = () => {
     }
 
     // Cosmos AMINO path (Phase 3) — skips Gno createDocument/gas-simulate flow.
+    // Let errors propagate so transferByCommon's catch surfaces the real
+    // message (broadcast code/raw_log, LCD error, etc.) instead of the
+    // generic "could not be submitted" fallback.
     if (summaryInfo.tokenMetainfo.type === 'cosmos-native') {
-      try {
-        const result = await createCosmosTransaction();
-        if (!result) return null;
-        return { hash: result.txhash };
-      } catch (e) {
-        console.error(e);
-        return null;
-      }
+      const result = await createCosmosTransaction();
+      if (!result) return null;
+      return { hash: result.txhash };
     }
 
     const document = await createDocument();

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -282,7 +282,7 @@ const TransferSummaryContainer: React.FC = () => {
       throw new Error(`Cosmos chain not found for ${cosmosChainId}`);
     }
 
-    const fromAddress = await currentAccount.resolveAddress(chain.bech32Prefix);
+    const fromAddress = await currentAccount.getAddress(chain.bech32Prefix);
     const rawAmount = BigNumber(transferAmount.value)
       .shiftedBy(tokenMetainfo.decimals)
       .toFixed(0);

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -1,4 +1,9 @@
-import { Document, isLedgerAccount } from 'adena-module';
+import {
+  CosmosDocument,
+  Document,
+  MSG_SEND_AMINO_TYPE,
+  isLedgerAccount,
+} from 'adena-module';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -18,7 +23,10 @@ import { useNetwork } from '@hooks/use-network';
 import { useTransferInfo } from '@hooks/use-transfer-info';
 import { useGetGnotBalance } from '@hooks/wallet/use-get-gnot-balance';
 import { useNetworkFee } from '@hooks/wallet/use-network-fee';
-import { createNotificationSendMessage } from '@inject/message/methods/transaction-event';
+import {
+  createNotificationSendMessage,
+  createNotificationSendMessageByHash,
+} from '@inject/message/methods/transaction-event';
 import BroadcastTransactionLoading from '@pages/popup/wallet/broadcast-transaction-screen/loading';
 import { TransactionMessage } from '@services/index';
 import mixins from '@styles/mixins';
@@ -40,7 +48,7 @@ const TransferSummaryContainer: React.FC = () => {
   const { navigate, goBack, params } = useAppNavigate<RoutePath.TransferSummary>();
   const summaryInfo = params;
   const { wallet } = useWalletContext();
-  const { transactionService } = useAdenaContext();
+  const { transactionService, chainRegistry } = useAdenaContext();
   const { currentAccount, currentAddress } = useCurrentAccount();
   const { currentNetwork } = useNetwork();
   const { openScannerLink } = useLink();
@@ -61,7 +69,17 @@ const TransferSummaryContainer: React.FC = () => {
 
   const { data: currentBalance } = useGetGnotBalance();
 
+  const isCosmosToken = summaryInfo.tokenMetainfo.type === 'cosmos-native';
+
   const hasNetworkFee = useMemo(() => {
+    // Cosmos fee is hardcoded (2000uphoton/gas 200000) for Phase 3 MVP.
+    // Node rejects with a clear error if PHOTON balance is insufficient, so we
+    // defer that check to the broadcast path instead of gating the UI here.
+    // TODO(Phase 6): replace hardcoded fee gate with feemarket dynamic estimation.
+    if (isCosmosToken) {
+      return true;
+    }
+
     if (!currentBalance || currentBalance === 0) {
       return false;
     }
@@ -85,6 +103,11 @@ const TransferSummaryContainer: React.FC = () => {
   }, [currentBalance, networkFee?.amount, summaryInfo]);
 
   const isNetworkFeeError = useMemo(() => {
+    // Cosmos path skips the Gno gas-simulate / balance check entirely.
+    if (isCosmosToken) {
+      return false;
+    }
+
     if (useNetworkFeeReturn.isLoading) {
       return false;
     }
@@ -103,6 +126,7 @@ const TransferSummaryContainer: React.FC = () => {
 
     return !hasNetworkFee;
   }, [
+    isCosmosToken,
     currentBalance,
     networkFee?.amount,
     useNetworkFeeReturn.isLoading,
@@ -221,9 +245,84 @@ const TransferSummaryContainer: React.FC = () => {
     });
   };
 
+  // Cosmos (Phase 3): MVP hardcodes fee at 2000uphoton / gas 200000.
+  // Node's minGasPrice is 0.01 uphoton/gas → 0.01 * 200000 = 2000uphoton required.
+  // TODO(Phase 6): replace with feemarket dynamic estimation; move constant to
+  //                common/constants/tx.constant.ts and read denom from chain profile.
+  const COSMOS_DEFAULT_FEE = {
+    amount: [{ denom: 'uphoton', amount: '2000' }],
+    gas: '200000',
+  };
+
+  const createCosmosTransaction = useCallback(async () => {
+    if (!currentAccount) {
+      return null;
+    }
+
+    const { tokenMetainfo, toAddress, transferAmount, memo } = summaryInfo;
+    if (tokenMetainfo.type !== 'cosmos-native') {
+      return null;
+    }
+
+    const denom = (tokenMetainfo as { denom?: string }).denom;
+    if (!denom) {
+      throw new Error('Cosmos native token is missing denom metadata');
+    }
+
+    // Resolve the Cosmos chain via ChainRegistry (not currentNetwork — that
+    // is still the Gno network while the wallet shows cross-chain balances).
+    // tokenMetainfo.networkId matches chainProfileId which equals chainId.
+    const cosmosChainId = tokenMetainfo.networkId;
+    const profile = chainRegistry.getNetworkProfileByChainId(cosmosChainId);
+    if (!profile || profile.chainType !== 'cosmos') {
+      throw new Error(`Cosmos profile not found for ${cosmosChainId}`);
+    }
+    const chain = chainRegistry.getChainByChainId(cosmosChainId);
+    if (!chain || chain.chainType !== 'cosmos') {
+      throw new Error(`Cosmos chain not found for ${cosmosChainId}`);
+    }
+
+    const fromAddress = await currentAccount.resolveAddress(chain.bech32Prefix);
+    const rawAmount = BigNumber(transferAmount.value)
+      .shiftedBy(tokenMetainfo.decimals)
+      .toFixed(0);
+
+    const document: CosmosDocument = {
+      chainId: cosmosChainId,
+      fromAddress,
+      msgs: [
+        {
+          type: MSG_SEND_AMINO_TYPE,
+          value: {
+            from_address: fromAddress,
+            to_address: toAddress,
+            amount: [{ denom, amount: rawAmount }],
+          },
+        },
+      ],
+      fee: COSMOS_DEFAULT_FEE,
+      memo: memo ?? '',
+    };
+
+    const signed = await transactionService.signCosmos(currentAccount.id, document);
+    return transactionService.broadcastCosmos(signed, cosmosChainId);
+  }, [summaryInfo, currentAccount, chainRegistry, transactionService]);
+
   const createTransaction = useCallback(async () => {
     if (!currentNetwork || !currentAccount || !wallet) {
       return null;
+    }
+
+    // Cosmos AMINO path (Phase 3) — skips Gno createDocument/gas-simulate flow.
+    if (summaryInfo.tokenMetainfo.type === 'cosmos-native') {
+      try {
+        const result = await createCosmosTransaction();
+        if (!result) return null;
+        return { hash: result.txhash };
+      } catch (e) {
+        console.error(e);
+        return null;
+      }
     }
 
     const document = await createDocument();
@@ -251,10 +350,15 @@ const TransferSummaryContainer: React.FC = () => {
     networkFee,
     useNetworkFeeReturn.currentGasFeeRawAmount,
     useNetworkFeeReturn.currentGasInfo,
+    createCosmosTransaction,
   ]);
 
   const transfer = async (): Promise<boolean> => {
-    if (isSent || !currentAccount || !hasNetworkFee || useNetworkFeeReturn.isLoading) {
+    if (isSent || !currentAccount) {
+      return false;
+    }
+    // Cosmos path skips Gno-only preconditions (hasNetworkFee, gas simulate).
+    if (!isCosmosToken && (!hasNetworkFee || useNetworkFeeReturn.isLoading)) {
       return false;
     }
 
@@ -270,9 +374,16 @@ const TransferSummaryContainer: React.FC = () => {
     try {
       setScreenState('LOADING');
       const response = await createTransaction();
-      createNotificationSendMessage(response);
-
       const txHash = response?.hash || null;
+      if (isCosmosToken) {
+        if (txHash) createNotificationSendMessageByHash(txHash);
+      } else {
+        // Type-narrow: non-cosmos path returns TM2 broadcast result.
+        createNotificationSendMessage(
+          response as Awaited<ReturnType<typeof transactionService.sendTransaction>> | null,
+        );
+      }
+
       if (txHash) {
         setTransferResult({
           status: 'SUCCESS',
@@ -346,8 +457,27 @@ const TransferSummaryContainer: React.FC = () => {
       return;
     }
 
+    // Cosmos tx → Mintscan (path-style: /atomone/tx/{hash}).
+    // Gno tx → existing gnoscan (query-string: /transactions/details?txhash=...).
+    if (isCosmosToken) {
+      const chainId = summaryInfo.tokenMetainfo.networkId;
+      const profile = chainRegistry.getNetworkProfileByChainId(chainId);
+      if (profile?.linkUrl) {
+        window.open(`${profile.linkUrl}/tx/${transferResult.hash}`, '_blank');
+        return;
+      }
+      // Fallback: no linkUrl registered (e.g. AtomOne testnet). Nothing to open.
+      return;
+    }
+
     openScannerLink('/transactions/details', { txhash: transferResult.hash });
-  }, [transferResult?.hash, openScannerLink]);
+  }, [
+    transferResult?.hash,
+    openScannerLink,
+    isCosmosToken,
+    summaryInfo.tokenMetainfo.networkId,
+    chainRegistry,
+  ]);
 
   useEffect(() => {
     if (simulateErrorMessage) {
@@ -361,6 +491,11 @@ const TransferSummaryContainer: React.FC = () => {
   }, [simulateErrorMessage]);
 
   useEffect(() => {
+    // Cosmos path builds its document inline at broadcast time — skip the
+    // Gno-only createDocument pre-warm which calls GnoProvider.getAccountInfo.
+    if (isCosmosToken) {
+      return;
+    }
     if (!document) {
       createDocument().then((doc) => {
         if (!doc) {
@@ -378,6 +513,7 @@ const TransferSummaryContainer: React.FC = () => {
     currentAccount,
     currentNetwork,
     useNetworkFeeReturn.currentGasFeeRawAmount,
+    isCosmosToken,
   ]);
 
   return (
@@ -407,8 +543,15 @@ const TransferSummaryContainer: React.FC = () => {
           toAddress={summaryInfo.toAddress}
           transferBalance={getTransferBalance()}
           isErrorNetworkFee={isNetworkFeeError}
-          isLoadingNetworkFee={useNetworkFeeReturn.isLoading}
-          networkFee={networkFee}
+          // TEMP (Phase 3 MVP): Cosmos fee is hardcoded so the Gno gas-simulate
+          // hook stays in its loading state forever (enabled=false when document
+          // is null). Force loading=false and inject the fixed fee here to unblock
+          // the Send button.
+          // TODO(Phase 6): remove this override once feemarket estimation lands.
+          isLoadingNetworkFee={isCosmosToken ? false : useNetworkFeeReturn.isLoading}
+          networkFee={
+            isCosmosToken ? { amount: '0.002', denom: 'PHOTON' } : networkFee
+          }
           memo={summaryInfo.memo}
           currentBalance={currentBalance}
           useNetworkFeeReturn={useNetworkFeeReturn}

--- a/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
@@ -181,8 +181,6 @@ export const WalletMain = (): JSX.Element => {
             denom: tokenBalance.amount.denom,
           },
           chainIconUrl: isCosmos ? CHAIN_ICON_MAP[tokenBalance.networkId] : undefined,
-          // TODO(Phase 3): Remove once Cosmos signing is implemented — Send is disabled for AtomOne tokens
-          readOnly: isCosmos || undefined,
         };
       });
   }, [currentBalances, getTokenImage, currentNetwork]);
@@ -198,12 +196,11 @@ export const WalletMain = (): JSX.Element => {
         window.alert('Token not found');
         return;
       }
-      const token = tokens.find((t) => t.tokenId === tokenId);
       navigate(RoutePath.TokenDetails, {
-        state: { tokenBalance, readOnly: token?.readOnly },
+        state: { tokenBalance },
       });
     },
-    [navigate, tokens, currentBalances],
+    [navigate, currentBalances],
   );
 
   const onClickManageButton = useCallback(() => {

--- a/packages/adena-extension/src/services/transaction/transaction.ts
+++ b/packages/adena-extension/src/services/transaction/transaction.ts
@@ -7,9 +7,14 @@ import {
 import {
   Account,
   AdenaLedgerConnector,
+  ChainRegistry,
+  CosmosDocument,
+  CosmosNetworkProfile,
+  CosmosTxBroadcastResponse,
   Document,
   LedgerAccount,
   LedgerKeyring,
+  SignedCosmosTx,
   sha256,
   Wallet,
 } from 'adena-module';
@@ -17,6 +22,7 @@ import {
 import { GasToken } from '@common/constants/token.constant';
 import { DEFAULT_GAS_FEE, DEFAULT_GAS_WANTED } from '@common/constants/tx.constant';
 import { mappedDocumentMessagesWithCaller } from '@common/mapper/transaction-mapper';
+import { CosmosLcdProvider } from '@common/provider/cosmos/cosmos-lcd-provider';
 import { GnoProvider } from '@common/provider/gno/gno-provider';
 import { WalletService } from '..';
 
@@ -33,9 +39,18 @@ export class TransactionService {
 
   private gnoProvider: GnoProvider | null;
 
-  constructor(walletService: WalletService, gnoProvider: GnoProvider | null) {
+  // ChainRegistry is optional so older construction sites (inject/message/methods)
+  // keep working while the DI container in adena-provider wires it up.
+  private chainRegistry: ChainRegistry | null;
+
+  constructor(
+    walletService: WalletService,
+    gnoProvider: GnoProvider | null,
+    chainRegistry: ChainRegistry | null = null,
+  ) {
     this.walletService = walletService;
     this.gnoProvider = gnoProvider;
+    this.chainRegistry = chainRegistry;
   }
 
   public getGnoProvider(): GnoProvider {
@@ -47,6 +62,26 @@ export class TransactionService {
 
   public setGnoProvider(gnoProvider: GnoProvider): void {
     this.gnoProvider = gnoProvider;
+  }
+
+  public setChainRegistry(chainRegistry: ChainRegistry): void {
+    this.chainRegistry = chainRegistry;
+  }
+
+  private resolveCosmosProfile(chainId: string): CosmosNetworkProfile {
+    if (!this.chainRegistry) {
+      throw new Error('ChainRegistry not initialized for Cosmos operations');
+    }
+    const profile = this.chainRegistry.getNetworkProfileByChainId(chainId);
+    if (!profile || profile.chainType !== 'cosmos') {
+      throw new Error(`Cosmos network profile not found for chainId: ${chainId}`);
+    }
+    return profile as CosmosNetworkProfile;
+  }
+
+  private makeCosmosProvider(chainId: string): CosmosLcdProvider {
+    const profile = this.resolveCosmosProfile(chainId);
+    return new CosmosLcdProvider(profile.restEndpoints[0]);
   }
 
   /**
@@ -213,6 +248,28 @@ export class TransactionService {
 
     const result = await broadcastTx(provider, transaction, account.hdPath);
     return result;
+  };
+
+  // ─── Cosmos AMINO (Phase 3) ─────────────────────────────────────────
+  // Thin passthrough to AdenaWallet's Cosmos methods. Gno methods above
+  // remain untouched so Gno flows have zero regression risk.
+
+  public signCosmos = async (
+    accountId: string,
+    document: CosmosDocument,
+  ): Promise<SignedCosmosTx> => {
+    const wallet = await this.walletService.loadWallet();
+    const cosmosProvider = this.makeCosmosProvider(document.chainId);
+    return wallet.signCosmosByAccountId(accountId, document, cosmosProvider);
+  };
+
+  public broadcastCosmos = async (
+    signedTx: SignedCosmosTx,
+    chainId: string,
+  ): Promise<CosmosTxBroadcastResponse> => {
+    const wallet = await this.walletService.loadWallet();
+    const cosmosProvider = this.makeCosmosProvider(chainId);
+    return wallet.broadcastCosmosTx(signedTx, cosmosProvider);
   };
 
   /**

--- a/packages/adena-extension/src/services/wallet/cosmos-balance.spec.ts
+++ b/packages/adena-extension/src/services/wallet/cosmos-balance.spec.ts
@@ -61,6 +61,7 @@ describe('CosmosBalanceService', () => {
         symbol: 'ATONE',
         decimals: 6,
         image: '/assets/icons/atone.svg',
+        denom: 'uatone',
         amount: { value: '1', denom: 'ATONE' },
       });
       expect(mockGetBalance).toHaveBeenCalledWith('atone1abc', 'uatone');

--- a/packages/adena-extension/src/services/wallet/cosmos-balance.ts
+++ b/packages/adena-extension/src/services/wallet/cosmos-balance.ts
@@ -31,6 +31,10 @@ export class CosmosBalanceService {
       symbol: token.symbol,
       decimals: token.decimals,
       image: token.iconUrl ?? '',
+      // Raw on-chain denom (e.g. uatone / uphoton) required by
+      // createCosmosTransaction to build the MsgSend amount. The amount.denom
+      // below is the display symbol (e.g. ATONE) and cannot be used on-chain.
+      denom,
       amount: {
         value,
         denom: token.symbol,

--- a/packages/adena-extension/src/types/router.ts
+++ b/packages/adena-extension/src/types/router.ts
@@ -142,7 +142,6 @@ export type RouteParams = {
   [RoutePath.Send]: null;
   [RoutePath.TokenDetails]: {
     tokenBalance: TokenBalanceType;
-    readOnly?: boolean;
   };
   [RoutePath.ApproveLogin]: null;
   [RoutePath.ApproveSignFailed]: null;

--- a/packages/adena-extension/src/types/states.ts
+++ b/packages/adena-extension/src/types/states.ts
@@ -2,6 +2,9 @@ import { TokenModel } from './';
 
 export interface TokenBalanceType extends TokenModel {
   amount: Amount;
+  // Present on 'gno-native' / 'cosmos-native' rows — the raw on-chain denom
+  // (e.g. ugnot, uatone, uphoton) used to construct transactions.
+  denom?: string;
 }
 
 export interface Amount {

--- a/packages/adena-extension/src/types/token.ts
+++ b/packages/adena-extension/src/types/token.ts
@@ -114,12 +114,6 @@ export interface MainToken {
     denom: string;
   };
   chainIconUrl?: string;
-  /**
-   * TODO(Phase 3): Remove this flag once Cosmos transaction signing is implemented.
-   * Temporarily disables the Send button for AtomOne tokens because signing is not yet supported.
-   * Delete this field and all readOnly branches when Phase 3 Cosmos signing is added.
-   */
-  readOnly?: boolean;
 }
 
 export interface GRC721CollectionModel {

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -38,7 +38,9 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
+    "@cosmjs/amino": "0.36.0",
     "@cosmjs/ledger-amino": "0.36.0",
+    "@cosmjs/proto-signing": "0.36.0",
     "@gnolang/gno-js-client": "1.4.5",
     "@gnolang/tm2-js-client": "1.3.3",
     "@ledgerhq/hw-transport": "6.31.4",

--- a/packages/adena-module/src/cosmos/amino/index.ts
+++ b/packages/adena-module/src/cosmos/amino/index.ts
@@ -1,0 +1,3 @@
+export * from './make-std-sign-doc';
+export * from './serialize-sign-doc';
+export * from './sign-cosmos-amino';

--- a/packages/adena-module/src/cosmos/amino/make-std-sign-doc.ts
+++ b/packages/adena-module/src/cosmos/amino/make-std-sign-doc.ts
@@ -1,0 +1,27 @@
+import { AminoMsg, makeSignDoc, StdFee, StdSignDoc } from '@cosmjs/amino';
+
+export interface MakeStdSignDocParams {
+  chainId: string;
+  accountNumber: string;
+  sequence: string;
+  msgs: AminoMsg[];
+  fee: StdFee;
+  memo?: string;
+}
+
+/**
+ * Thin wrapper over @cosmjs/amino's `makeSignDoc` — normalizes defaults
+ * (empty memo) and keeps the shape of optional callers consistent.
+ *
+ * @cosmjs/amino reference: node_modules/@cosmjs/amino/build/signdoc.js:30-39
+ */
+export function makeStdSignDoc(params: MakeStdSignDocParams): StdSignDoc {
+  return makeSignDoc(
+    params.msgs,
+    params.fee,
+    params.chainId,
+    params.memo ?? '',
+    params.accountNumber,
+    params.sequence,
+  );
+}

--- a/packages/adena-module/src/cosmos/amino/serialize-sign-doc.ts
+++ b/packages/adena-module/src/cosmos/amino/serialize-sign-doc.ts
@@ -1,0 +1,7 @@
+// Thin re-export so Cosmos callers depend on this module (not @cosmjs/amino
+// directly). Gives a single hook point for future regression tests around
+// the escape / sortedJsonStringify contract.
+//
+// serializeSignDoc = sortedJsonStringify + escapeCharacters(<,>,&) + UTF-8.
+// Reference: node_modules/@cosmjs/amino/build/signdoc.js:61-64
+export { serializeSignDoc } from '@cosmjs/amino';

--- a/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.spec.ts
+++ b/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.spec.ts
@@ -1,0 +1,204 @@
+import { Secp256k1Wallet } from '@cosmjs/amino';
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
+
+import { HDWalletKeyring } from '../../wallet/keyring/hd-wallet-keyring';
+import { LedgerKeyring } from '../../wallet/keyring/ledger-keyring';
+import { MultisigKeyring } from '../../wallet/keyring/multisig-keyring';
+import { AddressKeyring } from '../../wallet/keyring/address-keyring';
+import { MSG_SEND_AMINO_TYPE } from '../codec/msg-send';
+import { CosmosProvider } from '../providers/cosmos-provider';
+import { CosmosDocument } from '../types';
+
+import { signCosmosAmino } from './sign-cosmos-amino';
+
+const MNEMONIC =
+  'source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast';
+
+function makeMockProvider(
+  overrides: Partial<CosmosProvider> = {},
+): CosmosProvider & { getAccount: jest.Mock; broadcastTx: jest.Mock } {
+  return {
+    getAccount: jest.fn().mockResolvedValue({
+      address: '',
+      accountNumber: '42',
+      sequence: '7',
+    }),
+    broadcastTx: jest.fn().mockResolvedValue({
+      txhash: 'HASH',
+      code: 0,
+      rawLog: '',
+      height: '100',
+    }),
+    ...overrides,
+  } as CosmosProvider & { getAccount: jest.Mock; broadcastTx: jest.Mock };
+}
+
+function makeDocument(overrides: Partial<CosmosDocument> = {}): CosmosDocument {
+  return {
+    chainId: 'atomone-1',
+    fromAddress: 'atone1qqqsyqcyq5rqwzqfpg9scrgwpugpzysndkda8p',
+    msgs: [
+      {
+        type: MSG_SEND_AMINO_TYPE,
+        value: {
+          from_address: 'atone1qqqsyqcyq5rqwzqfpg9scrgwpugpzysndkda8p',
+          to_address: 'atone1qyqszqgpqyqszqgpqyqszqgpqyqszqgpwc2vge',
+          amount: [{ denom: 'uphoton', amount: '1000' }],
+        },
+      },
+    ],
+    fee: {
+      amount: [{ denom: 'uphoton', amount: '1000' }],
+      gas: '200000',
+    },
+    memo: '',
+    accountNumber: '42',
+    sequence: '7',
+    ...overrides,
+  };
+}
+
+describe('signCosmosAmino', () => {
+  it('matches @cosmjs/amino Secp256k1Wallet signature bit-equal', async () => {
+    const keyring = await HDWalletKeyring.fromMnemonic(MNEMONIC);
+    const privKey = await keyring.getPrivateKey(0);
+
+    const cosmjsWallet = await Secp256k1Wallet.fromKey(privKey, 'atone');
+    const [{ address: cosmjsAddress }] = await cosmjsWallet.getAccounts();
+
+    const document = makeDocument({ fromAddress: cosmjsAddress });
+    document.msgs[0].value.from_address = cosmjsAddress;
+
+    const ours = await signCosmosAmino({
+      document,
+      keyring,
+      cosmosProvider: makeMockProvider(),
+    });
+
+    const { signature: cosmjsSig } = await cosmjsWallet.signAmino(
+      cosmjsAddress,
+      ours.signDoc,
+    );
+    const cosmjsRawSig = Buffer.from(cosmjsSig.signature, 'base64');
+
+    const ourTxRaw = TxRaw.decode(ours.txBytes);
+    const ourSig = Buffer.from(ourTxRaw.signatures[0]);
+
+    expect(ourSig.length).toBe(64);
+    expect(ourSig.equals(cosmjsRawSig)).toBe(true);
+  });
+
+  it('GOLDEN: fixed mnemonic + document yields known TxRaw bytes', async () => {
+    const keyring = await HDWalletKeyring.fromMnemonic(MNEMONIC);
+    const cosmjsWallet = await Secp256k1Wallet.fromKey(
+      await keyring.getPrivateKey(0),
+      'atone',
+    );
+    const [{ address }] = await cosmjsWallet.getAccounts();
+
+    const document = makeDocument({ fromAddress: address });
+    document.msgs[0].value.from_address = address;
+
+    const { txBytes } = await signCosmosAmino({
+      document,
+      keyring,
+      cosmosProvider: makeMockProvider(),
+    });
+
+    expect(Buffer.from(txBytes).toString('base64')).toBe(
+      'CpABCo0BChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEm0KLGF0b25lMWpnOG10dXR1OWtoaGZ3YzRueG11aGNwZnRmMHBhamRoNXNzeTdnEixhdG9uZTFxeXFzenFncHF5cXN6cWdwcXlxc3pxZ3BxeXFzenFncHdjMnZnZRoPCgd1cGhvdG9uEgQxMDAwEmkKUApGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQPhYTbbFx4y30iZNZQfBW4i+Jhj43OdCrfNSexCg5ydshIECgIIfxgHEhUKDwoHdXBob3RvbhIEMTAwMBDAmgwaQEB7POL2vYZ6A/Qumjxm0HxNAPrCoZ1NjBTqzhZ1Qod1eAChaKDeEHhHXeSdJmSSRNo4UwihxNZs76whBBD3G0c=',
+    );
+  });
+
+  it('fetches accountNumber and sequence from provider when missing from document', async () => {
+    const keyring = await HDWalletKeyring.fromMnemonic(MNEMONIC);
+    const cosmjsWallet = await Secp256k1Wallet.fromKey(
+      await keyring.getPrivateKey(0),
+      'atone',
+    );
+    const [{ address }] = await cosmjsWallet.getAccounts();
+
+    const document: CosmosDocument = {
+      chainId: 'atomone-1',
+      fromAddress: address,
+      msgs: [
+        {
+          type: MSG_SEND_AMINO_TYPE,
+          value: {
+            from_address: address,
+            to_address: 'atone1qyqszqgpqyqszqgpqyqszqgpqyqszqgpwc2vge',
+            amount: [{ denom: 'uphoton', amount: '1000' }],
+          },
+        },
+      ],
+      fee: { amount: [{ denom: 'uphoton', amount: '1000' }], gas: '200000' },
+      memo: '',
+    };
+
+    const provider = makeMockProvider();
+    provider.getAccount.mockResolvedValue({
+      address,
+      accountNumber: '99',
+      sequence: '3',
+    });
+
+    const signed = await signCosmosAmino({
+      document,
+      keyring,
+      cosmosProvider: provider,
+    });
+
+    expect(provider.getAccount).toHaveBeenCalledWith(address);
+    expect(signed.signDoc.account_number).toBe('99');
+    expect(signed.signDoc.sequence).toBe('3');
+  });
+
+  it('throws forward-looking message for Ledger keyring', async () => {
+    const keyring = new LedgerKeyring({});
+    await expect(
+      signCosmosAmino({
+        document: makeDocument(),
+        keyring,
+        cosmosProvider: makeMockProvider(),
+      }),
+    ).rejects.toThrow(/Phase 7/);
+  });
+
+  it('throws permanent-unsupport message for Multisig keyring', async () => {
+    const keyring = new MultisigKeyring({
+      addressBytes: [
+        146, 15, 181, 241, 124, 45, 175, 116, 187, 21, 153, 183, 203, 224, 41, 90,
+        94, 30, 201, 183,
+      ],
+      multisigConfig: {
+        threshold: 2,
+        signers: [
+          'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5',
+          'g1kcdd3n0d472g2p5l8svyg9t0wq6h5857nq992f',
+        ],
+      },
+    });
+
+    await expect(
+      signCosmosAmino({
+        document: makeDocument(),
+        keyring,
+        cosmosProvider: makeMockProvider(),
+      }),
+    ).rejects.toThrow(/[Mm]ultisig/);
+  });
+
+  it('throws for AirGap (address-only) keyring', async () => {
+    const keyring = await AddressKeyring.fromAddress(
+      'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5',
+    );
+
+    await expect(
+      signCosmosAmino({
+        document: makeDocument(),
+        keyring,
+        cosmosProvider: makeMockProvider(),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.spec.ts
+++ b/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.spec.ts
@@ -110,6 +110,42 @@ describe('signCosmosAmino', () => {
     );
   });
 
+  it('treats empty-string accountNumber/sequence as missing (avoids BigInt crash)', async () => {
+    // Regression: prior behavior passed '' through as-is, causing
+    // BigInt('') → SyntaxError deep in make-tx-raw. resolveAccount now
+    // normalizes empty strings to undefined so the LCD fallback runs.
+    const keyring = await HDWalletKeyring.fromMnemonic(MNEMONIC);
+    const cosmjsWallet = await Secp256k1Wallet.fromKey(
+      await keyring.getPrivateKey(0),
+      'atone',
+    );
+    const [{ address }] = await cosmjsWallet.getAccounts();
+
+    const document = makeDocument({
+      fromAddress: address,
+      accountNumber: '',
+      sequence: '',
+    });
+    document.msgs[0].value.from_address = address;
+
+    const provider = makeMockProvider();
+    provider.getAccount.mockResolvedValue({
+      address,
+      accountNumber: '88',
+      sequence: '4',
+    });
+
+    const signed = await signCosmosAmino({
+      document,
+      keyring,
+      cosmosProvider: provider,
+    });
+
+    expect(provider.getAccount).toHaveBeenCalledWith(address);
+    expect(signed.signDoc.account_number).toBe('88');
+    expect(signed.signDoc.sequence).toBe('4');
+  });
+
   it('fetches accountNumber and sequence from provider when missing from document', async () => {
     const keyring = await HDWalletKeyring.fromMnemonic(MNEMONIC);
     const cosmjsWallet = await Secp256k1Wallet.fromKey(

--- a/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.ts
+++ b/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.ts
@@ -1,0 +1,113 @@
+import { sha256 } from '@cosmjs/crypto';
+import { toHex } from '@cosmjs/encoding';
+
+import { Keyring } from '../../wallet/keyring/keyring';
+import {
+  isHDWalletKeyring,
+  isPrivateKeyKeyring,
+  isWeb3AuthKeyring,
+  isLedgerKeyring,
+  isMultisigKeyring,
+} from '../../wallet/keyring/keyring-util';
+import { makeTxRaw } from '../proto/make-tx-raw';
+import { CosmosProvider } from '../providers/cosmos-provider';
+import { CosmosDocument, SignedCosmosTx } from '../types';
+
+import { makeStdSignDoc } from './make-std-sign-doc';
+import { serializeSignDoc } from './serialize-sign-doc';
+
+export interface SignCosmosAminoParams {
+  document: CosmosDocument;
+  keyring: Keyring;
+  // Injected by the caller (e.g. adena-extension supplies CosmosLcdProvider).
+  // Mirrors the Gno `Provider` DI pattern so adena-module stays free of
+  // HTTP-client dependencies.
+  cosmosProvider: CosmosProvider;
+  hdPath?: number;
+}
+
+/**
+ * Sign a Cosmos `MsgSend`-style transaction with SIGN_MODE_LEGACY_AMINO_JSON.
+ *
+ * Pipeline:
+ *   CosmosDocument
+ *     → resolve accountNumber / sequence (via injected cosmosProvider)
+ *     → makeStdSignDoc → serializeSignDoc → signBytes
+ *     → keyring.signRaw(signBytes) → 64-byte r‖s signature
+ *     → makeTxRaw(msgs, signature, pubkey, fee, sequence) → TxRaw protobuf bytes
+ */
+export async function signCosmosAmino(
+  params: SignCosmosAminoParams,
+): Promise<SignedCosmosTx> {
+  const { document, keyring, cosmosProvider, hdPath } = params;
+
+  const { accountNumber, sequence } = await resolveAccount(document, cosmosProvider);
+
+  const signDoc = makeStdSignDoc({
+    chainId: document.chainId,
+    accountNumber,
+    sequence,
+    msgs: document.msgs,
+    fee: document.fee,
+    memo: document.memo,
+  });
+
+  const signBytes = serializeSignDoc(signDoc);
+  const signature = await keyring.signRaw(signBytes, { hdPath });
+
+  const publicKey = await resolvePublicKey(keyring, hdPath);
+
+  const txBytes = makeTxRaw({
+    msgs: document.msgs,
+    memo: document.memo,
+    fee: document.fee,
+    sequence,
+    publicKey,
+    signature,
+  });
+
+  return {
+    txBytes,
+    txHashHex: toHex(sha256(txBytes)).toUpperCase(),
+    signDoc,
+  };
+}
+
+async function resolveAccount(
+  document: CosmosDocument,
+  cosmosProvider: CosmosProvider,
+): Promise<{ accountNumber: string; sequence: string }> {
+  if (document.accountNumber !== undefined && document.sequence !== undefined) {
+    return {
+      accountNumber: document.accountNumber,
+      sequence: document.sequence,
+    };
+  }
+
+  const account = await cosmosProvider.getAccount(document.fromAddress);
+  return {
+    accountNumber: document.accountNumber ?? account.accountNumber,
+    sequence: document.sequence ?? account.sequence,
+  };
+}
+
+async function resolvePublicKey(
+  keyring: Keyring,
+  hdPath: number | undefined,
+): Promise<Uint8Array> {
+  if (isHDWalletKeyring(keyring)) return keyring.getPublicKey(hdPath ?? 0);
+  if (isPrivateKeyKeyring(keyring)) return keyring.publicKey;
+  if (isWeb3AuthKeyring(keyring)) return keyring.publicKey;
+
+  if (isLedgerKeyring(keyring)) {
+    throw new Error('Cosmos Ledger support is coming in a later phase');
+  }
+
+  if (isMultisigKeyring(keyring)) {
+    throw new Error('Multisig accounts do not support Cosmos chains');
+  }
+
+  throw new Error(
+    `Keyring type ${keyring.type} cannot sign Cosmos transactions`,
+  );
+}

--- a/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.ts
+++ b/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.ts
@@ -77,18 +77,23 @@ async function resolveAccount(
   document: CosmosDocument,
   cosmosProvider: CosmosProvider,
 ): Promise<{ accountNumber: string; sequence: string }> {
-  if (document.accountNumber !== undefined && document.sequence !== undefined) {
-    return {
-      accountNumber: document.accountNumber,
-      sequence: document.sequence,
-    };
+  // Treat empty string as missing so downstream BigInt(sequence) / BigInt(gas)
+  // in make-tx-raw never receives '' (which would throw a cryptic SyntaxError).
+  const docAccountNumber = nonEmpty(document.accountNumber);
+  const docSequence = nonEmpty(document.sequence);
+  if (docAccountNumber !== undefined && docSequence !== undefined) {
+    return { accountNumber: docAccountNumber, sequence: docSequence };
   }
 
   const account = await cosmosProvider.getAccount(document.fromAddress);
   return {
-    accountNumber: document.accountNumber ?? account.accountNumber,
-    sequence: document.sequence ?? account.sequence,
+    accountNumber: docAccountNumber ?? account.accountNumber,
+    sequence: docSequence ?? account.sequence,
   };
+}
+
+function nonEmpty(v: string | undefined): string | undefined {
+  return v === undefined || v === '' ? undefined : v;
 }
 
 async function resolvePublicKey(

--- a/packages/adena-module/src/cosmos/codec/index.ts
+++ b/packages/adena-module/src/cosmos/codec/index.ts
@@ -1,0 +1,2 @@
+export * from './msg-send';
+export * from './registry';

--- a/packages/adena-module/src/cosmos/codec/msg-send.spec.ts
+++ b/packages/adena-module/src/cosmos/codec/msg-send.spec.ts
@@ -1,0 +1,64 @@
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx';
+
+import {
+  MSG_SEND_AMINO_TYPE,
+  MSG_SEND_TYPE_URL,
+  msgSendFromAmino,
+  msgSendToAmino,
+  msgSendToAny,
+} from './msg-send';
+
+describe('MsgSend codec', () => {
+  const aminoMsg = {
+    type: MSG_SEND_AMINO_TYPE,
+    value: {
+      from_address: 'atone1qqqsyqcyq5rqwzqfpg9scrgwpugpzysndkda8p',
+      to_address: 'atone1qyqszqgpqyqszqgpqyqszqgpqyqszqgpwc2vge',
+      amount: [{ denom: 'uphoton', amount: '1000' }],
+    },
+  };
+
+  it('round-trips amino ↔ proto', () => {
+    const proto = msgSendFromAmino(aminoMsg);
+    expect(proto.fromAddress).toBe(aminoMsg.value.from_address);
+    expect(proto.toAddress).toBe(aminoMsg.value.to_address);
+    expect(proto.amount).toEqual(aminoMsg.value.amount);
+
+    expect(msgSendToAmino(proto)).toEqual(aminoMsg);
+  });
+
+  it('toAny produces the correct typeUrl and decodable value', () => {
+    const proto = msgSendFromAmino(aminoMsg);
+    const any = msgSendToAny(proto);
+
+    expect(any.typeUrl).toBe(MSG_SEND_TYPE_URL);
+    expect(any.typeUrl).toBe('/cosmos.bank.v1beta1.MsgSend');
+
+    const decoded = MsgSend.decode(any.value);
+    expect(decoded.fromAddress).toBe(aminoMsg.value.from_address);
+    expect(decoded.toAddress).toBe(aminoMsg.value.to_address);
+  });
+
+  it('throws when amino type does not match', () => {
+    expect(() =>
+      msgSendFromAmino({ type: 'cosmos-sdk/Foo', value: {} }),
+    ).toThrow(/Expected cosmos-sdk\/MsgSend/);
+  });
+
+  it('preserves multi-coin amount arrays', () => {
+    const multi = {
+      type: MSG_SEND_AMINO_TYPE,
+      value: {
+        from_address: 'atone1qqqsyqcyq5rqwzqfpg9scrgwpugpzysndkda8p',
+        to_address: 'atone1qyqszqgpqyqszqgpqyqszqgpqyqszqgpwc2vge',
+        amount: [
+          { denom: 'uatone', amount: '500' },
+          { denom: 'uphoton', amount: '1000' },
+        ],
+      },
+    };
+    const proto = msgSendFromAmino(multi);
+    expect(proto.amount).toHaveLength(2);
+    expect(msgSendToAmino(proto)).toEqual(multi);
+  });
+});

--- a/packages/adena-module/src/cosmos/codec/msg-send.ts
+++ b/packages/adena-module/src/cosmos/codec/msg-send.ts
@@ -1,0 +1,42 @@
+import { AminoMsg } from '@cosmjs/amino';
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx';
+import { Any } from 'cosmjs-types/google/protobuf/any';
+
+export const MSG_SEND_TYPE_URL = '/cosmos.bank.v1beta1.MsgSend';
+export const MSG_SEND_AMINO_TYPE = 'cosmos-sdk/MsgSend';
+
+export interface MsgSendAminoValue {
+  from_address: string;
+  to_address: string;
+  amount: { denom: string; amount: string }[];
+}
+
+export function msgSendToAmino(proto: MsgSend): AminoMsg {
+  return {
+    type: MSG_SEND_AMINO_TYPE,
+    value: {
+      from_address: proto.fromAddress,
+      to_address: proto.toAddress,
+      amount: proto.amount.map((c) => ({ denom: c.denom, amount: c.amount })),
+    } satisfies MsgSendAminoValue,
+  };
+}
+
+export function msgSendFromAmino(amino: AminoMsg): MsgSend {
+  if (amino.type !== MSG_SEND_AMINO_TYPE) {
+    throw new Error(`Expected ${MSG_SEND_AMINO_TYPE}, got ${amino.type}`);
+  }
+  const v = amino.value as MsgSendAminoValue;
+  return MsgSend.fromPartial({
+    fromAddress: v.from_address,
+    toAddress: v.to_address,
+    amount: v.amount,
+  });
+}
+
+export function msgSendToAny(proto: MsgSend): Any {
+  return Any.fromPartial({
+    typeUrl: MSG_SEND_TYPE_URL,
+    value: MsgSend.encode(proto).finish(),
+  });
+}

--- a/packages/adena-module/src/cosmos/codec/registry.ts
+++ b/packages/adena-module/src/cosmos/codec/registry.ts
@@ -1,0 +1,36 @@
+import { AminoMsg } from '@cosmjs/amino';
+import { Any } from 'cosmjs-types/google/protobuf/any';
+
+import * as MsgSendCodec from './msg-send';
+
+export interface MessageCodec<Proto> {
+  typeUrl: string;
+  aminoType: string;
+  toAmino: (proto: Proto) => AminoMsg;
+  fromAmino: (amino: AminoMsg) => Proto;
+  toAny: (proto: Proto) => Any;
+}
+
+// Central lookup keyed by AMINO type name. Extend this map when adding
+// new Cosmos messages (e.g. MsgTransfer in the IBC phase, MsgMintPhoton later).
+const codecs: Record<string, MessageCodec<unknown>> = {
+  [MsgSendCodec.MSG_SEND_AMINO_TYPE]: {
+    typeUrl: MsgSendCodec.MSG_SEND_TYPE_URL,
+    aminoType: MsgSendCodec.MSG_SEND_AMINO_TYPE,
+    toAmino: MsgSendCodec.msgSendToAmino as (p: unknown) => AminoMsg,
+    fromAmino: MsgSendCodec.msgSendFromAmino as (a: AminoMsg) => unknown,
+    toAny: MsgSendCodec.msgSendToAny as (p: unknown) => Any,
+  },
+};
+
+export function getCodecByAminoType(aminoType: string): MessageCodec<unknown> {
+  const codec = codecs[aminoType];
+  if (!codec) {
+    throw new Error(`Unknown amino message type: ${aminoType}`);
+  }
+  return codec;
+}
+
+export function hasCodecForAminoType(aminoType: string): boolean {
+  return Object.prototype.hasOwnProperty.call(codecs, aminoType);
+}

--- a/packages/adena-module/src/cosmos/index.ts
+++ b/packages/adena-module/src/cosmos/index.ts
@@ -1,0 +1,5 @@
+export * from './amino';
+export * from './codec';
+export * from './proto';
+export * from './providers';
+export * from './types';

--- a/packages/adena-module/src/cosmos/proto/index.ts
+++ b/packages/adena-module/src/cosmos/proto/index.ts
@@ -1,0 +1,1 @@
+export * from './make-tx-raw';

--- a/packages/adena-module/src/cosmos/proto/make-tx-raw.spec.ts
+++ b/packages/adena-module/src/cosmos/proto/make-tx-raw.spec.ts
@@ -1,0 +1,112 @@
+import { Secp256k1 } from '@cosmjs/crypto';
+import { PubKey } from 'cosmjs-types/cosmos/crypto/secp256k1/keys';
+import { SignMode } from 'cosmjs-types/cosmos/tx/signing/v1beta1/signing';
+import { AuthInfo, TxBody, TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
+
+import { MSG_SEND_AMINO_TYPE, MSG_SEND_TYPE_URL } from '../codec/msg-send';
+
+import { aminoMsgsToAnys, makeTxRaw } from './make-tx-raw';
+
+describe('makeTxRaw', () => {
+  const aminoMsg = {
+    type: MSG_SEND_AMINO_TYPE,
+    value: {
+      from_address: 'atone1qqqsyqcyq5rqwzqfpg9scrgwpugpzysndkda8p',
+      to_address: 'atone1qyqszqgpqyqszqgpqyqszqgpqyqszqgpwc2vge',
+      amount: [{ denom: 'uphoton', amount: '1000' }],
+    },
+  };
+
+  // 33-byte compressed secp256k1 pubkey (arbitrary valid constant shape — 0x02 prefix + 32 bytes).
+  const compressedPubKey = new Uint8Array(33);
+  compressedPubKey[0] = 0x02;
+  for (let i = 1; i < 33; i++) compressedPubKey[i] = i;
+
+  const signature = new Uint8Array(64).fill(7);
+  const fee = {
+    amount: [{ denom: 'uphoton', amount: '1000' }],
+    gas: '200000',
+  };
+
+  it('produces a TxRaw that decodes with AMINO mode, correct pubkey typeUrl, and preserved signature', () => {
+    const txBytes = makeTxRaw({
+      msgs: [aminoMsg],
+      memo: 'hello',
+      fee,
+      sequence: '5',
+      publicKey: compressedPubKey,
+      signature,
+    });
+
+    const raw = TxRaw.decode(txBytes);
+    const body = TxBody.decode(raw.bodyBytes);
+    const authInfo = AuthInfo.decode(raw.authInfoBytes);
+
+    expect(body.memo).toBe('hello');
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].typeUrl).toBe(MSG_SEND_TYPE_URL);
+
+    const signerInfo = authInfo.signerInfos[0];
+    expect(signerInfo.modeInfo?.single?.mode).toBe(
+      SignMode.SIGN_MODE_LEGACY_AMINO_JSON,
+    );
+    expect(signerInfo.publicKey?.typeUrl).toBe(
+      '/cosmos.crypto.secp256k1.PubKey',
+    );
+    expect(signerInfo.sequence).toBe(5n);
+
+    expect(authInfo.fee?.gasLimit).toBe(200000n);
+    expect(authInfo.fee?.amount).toEqual([{ denom: 'uphoton', amount: '1000' }]);
+
+    expect(raw.signatures).toHaveLength(1);
+    expect(raw.signatures[0]).toEqual(signature);
+  });
+
+  it('compresses an uncompressed 65-byte pubkey before encoding', () => {
+    // Derive a real 33-byte compressed key, then decompress to 65 bytes to feed in.
+    // We emulate what could happen if an upstream keyring supplied uncompressed form.
+    const priv = new Uint8Array(32).fill(9);
+    // Secp256k1.makeKeypair returns compressed publicKey; decompress via Secp256k1.uncompressPubkey.
+    return Secp256k1.makeKeypair(priv).then((kp) => {
+      const compressed = Secp256k1.compressPubkey(kp.pubkey);
+      const uncompressed = kp.pubkey; // already 65 bytes
+      expect(uncompressed.length).toBe(65);
+
+      const txBytes = makeTxRaw({
+        msgs: [aminoMsg],
+        memo: '',
+        fee,
+        sequence: '0',
+        publicKey: uncompressed,
+        signature,
+      });
+
+      const raw = TxRaw.decode(txBytes);
+      const authInfo = AuthInfo.decode(raw.authInfoBytes);
+      const pub = PubKey.decode(authInfo.signerInfos[0].publicKey!.value);
+      expect(pub.key.length).toBe(33);
+      expect(Array.from(pub.key)).toEqual(Array.from(compressed));
+    });
+  });
+
+  it('passes compressed pubkey through unchanged', () => {
+    const txBytes = makeTxRaw({
+      msgs: [aminoMsg],
+      memo: '',
+      fee,
+      sequence: '0',
+      publicKey: compressedPubKey,
+      signature,
+    });
+
+    const raw = TxRaw.decode(txBytes);
+    const authInfo = AuthInfo.decode(raw.authInfoBytes);
+    const pub = PubKey.decode(authInfo.signerInfos[0].publicKey!.value);
+    expect(Array.from(pub.key)).toEqual(Array.from(compressedPubKey));
+  });
+
+  it('aminoMsgsToAnys throws on unknown amino type', () => {
+    expect(() => aminoMsgsToAnys([{ type: 'cosmos-sdk/Unknown', value: {} }]))
+      .toThrow(/Unknown amino message type/);
+  });
+});

--- a/packages/adena-module/src/cosmos/proto/make-tx-raw.ts
+++ b/packages/adena-module/src/cosmos/proto/make-tx-raw.ts
@@ -1,0 +1,76 @@
+import { AminoMsg, StdFee } from '@cosmjs/amino';
+import { Secp256k1 } from '@cosmjs/crypto';
+import { PubKey } from 'cosmjs-types/cosmos/crypto/secp256k1/keys';
+import { SignMode } from 'cosmjs-types/cosmos/tx/signing/v1beta1/signing';
+import { AuthInfo, Fee, TxBody, TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
+import { Any } from 'cosmjs-types/google/protobuf/any';
+
+import { getCodecByAminoType } from '../codec/registry';
+
+const COSMOS_SECP256K1_PUBKEY_TYPE_URL = '/cosmos.crypto.secp256k1.PubKey';
+
+export function aminoMsgsToAnys(msgs: AminoMsg[]): Any[] {
+  return msgs.map((m) => {
+    const codec = getCodecByAminoType(m.type);
+    const proto = codec.fromAmino(m);
+    return codec.toAny(proto);
+  });
+}
+
+export interface MakeTxRawParams {
+  msgs: AminoMsg[];
+  memo: string;
+  fee: StdFee;
+  sequence: string;
+  publicKey: Uint8Array;
+  signature: Uint8Array;
+}
+
+/**
+ * Assemble the final `TxRaw` protobuf bytes for broadcasting.
+ *
+ * - `signature` must be the 64-byte r‖s output of `keyring.signRaw`.
+ * - `publicKey` is compressed to 33 bytes if a 65-byte uncompressed form is
+ *   passed. Keplr and cosmos-sdk nodes reject uncompressed secp256k1 keys
+ *   with "unable to decode tx".
+ */
+export function makeTxRaw(params: MakeTxRawParams): Uint8Array {
+  const { msgs, memo, fee, sequence, publicKey, signature } = params;
+
+  const bodyBytes = TxBody.encode(
+    TxBody.fromPartial({
+      messages: aminoMsgsToAnys(msgs),
+      memo,
+    }),
+  ).finish();
+
+  const compressedPubKey =
+    publicKey.length === 33 ? publicKey : Secp256k1.compressPubkey(publicKey);
+
+  const pubKeyAny = Any.fromPartial({
+    typeUrl: COSMOS_SECP256K1_PUBKEY_TYPE_URL,
+    value: PubKey.encode({ key: compressedPubKey }).finish(),
+  });
+
+  const authInfoBytes = AuthInfo.encode({
+    signerInfos: [
+      {
+        publicKey: pubKeyAny,
+        modeInfo: {
+          single: { mode: SignMode.SIGN_MODE_LEGACY_AMINO_JSON },
+        },
+        sequence: BigInt(sequence),
+      },
+    ],
+    fee: Fee.fromPartial({
+      amount: fee.amount.map((c) => ({ denom: c.denom, amount: c.amount })),
+      gasLimit: BigInt(fee.gas),
+    }),
+  }).finish();
+
+  return TxRaw.encode({
+    bodyBytes,
+    authInfoBytes,
+    signatures: [signature],
+  }).finish();
+}

--- a/packages/adena-module/src/cosmos/providers/cosmos-provider.ts
+++ b/packages/adena-module/src/cosmos/providers/cosmos-provider.ts
@@ -1,0 +1,33 @@
+export interface CosmosAccount {
+  address: string;
+  accountNumber: string;
+  sequence: string;
+}
+
+export interface CosmosTxBroadcastResponse {
+  txhash: string;
+  code: number;
+  rawLog: string;
+  height: string;
+}
+
+export type CosmosBroadcastMode =
+  | 'BROADCAST_MODE_SYNC'
+  | 'BROADCAST_MODE_ASYNC'
+  | 'BROADCAST_MODE_BLOCK';
+
+/**
+ * Abstract Cosmos network client consumed by the signing pipeline.
+ *
+ * Mirrors the Gno `Provider` injection pattern: adena-module owns only the
+ * interface + value types, and concrete implementations (REST LCD, RPC client,
+ * mock, etc.) live in the calling package and are injected at the signing
+ * entry point. Keeps adena-module free of HTTP-client dependencies.
+ */
+export interface CosmosProvider {
+  getAccount(address: string): Promise<CosmosAccount>;
+  broadcastTx(
+    txBytes: Uint8Array,
+    mode?: CosmosBroadcastMode,
+  ): Promise<CosmosTxBroadcastResponse>;
+}

--- a/packages/adena-module/src/cosmos/providers/index.ts
+++ b/packages/adena-module/src/cosmos/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './cosmos-provider';

--- a/packages/adena-module/src/cosmos/types.ts
+++ b/packages/adena-module/src/cosmos/types.ts
@@ -1,0 +1,43 @@
+import { AminoMsg, StdFee, StdSignDoc } from '@cosmjs/amino';
+
+/**
+ * Minimum shape needed for Cosmos AMINO signing. Distinct from Gno `Document`.
+ * When `accountNumber` / `sequence` are omitted, the signer fetches them via
+ * `CosmosLcdProvider.getAccount()`.
+ */
+export interface CosmosDocument {
+  chainId: string;
+  fromAddress: string;
+  msgs: AminoMsg[];
+  fee: StdFee;
+  memo: string;
+  accountNumber?: string;
+  sequence?: string;
+}
+
+/** Result of `signCosmosAmino` — ready to pass to `broadcastTx`. */
+export interface SignedCosmosTx {
+  txBytes: Uint8Array;
+  txHashHex: string;
+  signDoc: StdSignDoc;
+}
+
+export function isCosmosDocument(doc: unknown): doc is CosmosDocument {
+  return (
+    typeof doc === 'object' &&
+    doc !== null &&
+    'chainId' in doc &&
+    'fromAddress' in doc &&
+    'msgs' in doc &&
+    'fee' in doc
+  );
+}
+
+export function isSignedCosmosTx(tx: unknown): tx is SignedCosmosTx {
+  return (
+    typeof tx === 'object' &&
+    tx !== null &&
+    'txBytes' in tx &&
+    'signDoc' in tx
+  );
+}

--- a/packages/adena-module/src/index.ts
+++ b/packages/adena-module/src/index.ts
@@ -1,4 +1,5 @@
 export * from './chain-registry';
+export * from './cosmos';
 export * from './crypto';
 export * from './encoding';
 export * from './ledger';

--- a/packages/adena-module/src/utils/cosmos-address.spec.ts
+++ b/packages/adena-module/src/utils/cosmos-address.spec.ts
@@ -1,0 +1,24 @@
+import { validateCosmosAddress } from './cosmos-address';
+
+describe('validateCosmosAddress', () => {
+  it('accepts address with matching prefix', () => {
+    const addr = 'atone1qqqsyqcyq5rqwzqfpg9scrgwpugpzysndkda8p';
+    expect(validateCosmosAddress(addr, 'atone')).toBe(true);
+  });
+
+  it('rejects address with different prefix', () => {
+    const gnoAddr = 'g1qqqsyqcyq5rqwzqfpg9scrgwpugpzysns2desa';
+    expect(validateCosmosAddress(gnoAddr, 'atone')).toBe(false);
+  });
+
+  it('rejects malformed bech32', () => {
+    expect(validateCosmosAddress('not-a-bech32', 'atone')).toBe(false);
+    expect(validateCosmosAddress('', 'atone')).toBe(false);
+    expect(validateCosmosAddress('atone1invalid', 'atone')).toBe(false);
+  });
+
+  it('rejects when prefix is empty', () => {
+    const addr = 'atone1qqx86kvt0q29tsqxqjq5tyfd8pnnn7ytpq2y93';
+    expect(validateCosmosAddress(addr, '')).toBe(false);
+  });
+});

--- a/packages/adena-module/src/utils/cosmos-address.ts
+++ b/packages/adena-module/src/utils/cosmos-address.ts
@@ -1,0 +1,15 @@
+import { fromBech32 } from '../encoding';
+
+/**
+ * Validate a bech32 address with a required prefix match.
+ * Rejects addresses whose prefix differs from `expectedPrefix`
+ * (e.g. prevents sending to `gno1...` on an AtomOne chain).
+ */
+export function validateCosmosAddress(address: string, expectedPrefix: string): boolean {
+  try {
+    const { prefix } = fromBech32(address);
+    return prefix === expectedPrefix;
+  } catch {
+    return false;
+  }
+}

--- a/packages/adena-module/src/utils/index.ts
+++ b/packages/adena-module/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './address';
+export * from './cosmos-address';
 export { arrayContentEquals, arrayContentStartsWith } from './arrays';
 export { assert, assertDefined, assertDefinedAndNotNull } from './assert';
 export * from './data';

--- a/packages/adena-module/src/wallet/wallet-sign.spec.ts
+++ b/packages/adena-module/src/wallet/wallet-sign.spec.ts
@@ -1,5 +1,15 @@
+import { Secp256k1Wallet } from '@cosmjs/amino';
 import { ABCIAccount, JSONRPCProvider, Provider } from '@gnolang/tm2-js-client';
-import { AdenaWallet, Document, txToDocument } from './..';
+
+import {
+  AdenaWallet,
+  CosmosDocument,
+  CosmosProvider,
+  Document,
+  HDWalletKeyring,
+  MSG_SEND_AMINO_TYPE,
+  txToDocument,
+} from './..';
 
 const mnemonic =
   'source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast';
@@ -113,5 +123,91 @@ describe('Transaction Sign', () => {
     expect(hex).toBe(
       '24e23d2bf56dffe045eaf5915be8c51f24084bd34fdccff9d5172d667cc0debf287c61355458553ae25d31344777c7d646315fec3d2c593016c7916682dc9f35',
     );
+  });
+});
+
+describe('Cosmos AMINO Sign via AdenaWallet', () => {
+  async function makeCosmosDocument(): Promise<CosmosDocument> {
+    // Resolve the HD-derived atone address so the signer/message addresses match.
+    const keyring = await HDWalletKeyring.fromMnemonic(mnemonic);
+    const privKey = await keyring.getPrivateKey(0);
+    const cosmjsWallet = await Secp256k1Wallet.fromKey(privKey, 'atone');
+    const [{ address }] = await cosmjsWallet.getAccounts();
+
+    return {
+      chainId: 'atomone-1',
+      fromAddress: address,
+      msgs: [
+        {
+          type: MSG_SEND_AMINO_TYPE,
+          value: {
+            from_address: address,
+            to_address: 'atone1qyqszqgpqyqszqgpqyqszqgpqyqszqgpwc2vge',
+            amount: [{ denom: 'uphoton', amount: '1000' }],
+          },
+        },
+      ],
+      fee: {
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+        gas: '200000',
+      },
+      memo: '',
+      accountNumber: '42',
+      sequence: '7',
+    };
+  }
+
+  function makeMockCosmosProvider(): CosmosProvider & {
+    getAccount: jest.Mock;
+    broadcastTx: jest.Mock;
+  } {
+    return {
+      getAccount: jest.fn().mockResolvedValue({
+        address: '',
+        accountNumber: '42',
+        sequence: '7',
+      }),
+      broadcastTx: jest.fn().mockResolvedValue({
+        txhash: 'HASH',
+        code: 0,
+        rawLog: '',
+        height: '100',
+      }),
+    };
+  }
+
+  it('signCosmosByAccountId signs with the current HD account and matches the Part 3 GOLDEN', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const document = await makeCosmosDocument();
+
+    const signed = await wallet.signCosmosByAccountId(
+      wallet.currentAccount.id,
+      document,
+      makeMockCosmosProvider(),
+    );
+
+    // Same GOLDEN locked in src/cosmos/amino/sign-cosmos-amino.spec.ts.
+    expect(Buffer.from(signed.txBytes).toString('base64')).toBe(
+      'CpABCo0BChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEm0KLGF0b25lMWpnOG10dXR1OWtoaGZ3YzRueG11aGNwZnRmMHBhamRoNXNzeTdnEixhdG9uZTFxeXFzenFncHF5cXN6cWdwcXlxc3pxZ3BxeXFzenFncHdjMnZnZRoPCgd1cGhvdG9uEgQxMDAwEmkKUApGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQPhYTbbFx4y30iZNZQfBW4i+Jhj43OdCrfNSexCg5ydshIECgIIfxgHEhUKDwoHdXBob3RvbhIEMTAwMBDAmgwaQEB7POL2vYZ6A/Qumjxm0HxNAPrCoZ1NjBTqzhZ1Qod1eAChaKDeEHhHXeSdJmSSRNo4UwihxNZs76whBBD3G0c=',
+    );
+  });
+
+  it('broadcastCosmosTx forwards to CosmosProvider.broadcastTx', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const document = await makeCosmosDocument();
+    const provider = makeMockCosmosProvider();
+    const signed = await wallet.signCosmosByAccountId(
+      wallet.currentAccount.id,
+      document,
+      provider,
+    );
+
+    const result = await wallet.broadcastCosmosTx(signed, provider);
+
+    expect(provider.broadcastTx).toHaveBeenCalledWith(
+      signed.txBytes,
+      'BROADCAST_MODE_SYNC',
+    );
+    expect(result.txhash).toBe('HASH');
   });
 });

--- a/packages/adena-module/src/wallet/wallet.ts
+++ b/packages/adena-module/src/wallet/wallet.ts
@@ -7,6 +7,13 @@ import {
   TxSignature,
 } from '@gnolang/tm2-js-client';
 
+import {
+  signCosmosAmino,
+  CosmosDocument,
+  CosmosProvider,
+  CosmosTxBroadcastResponse,
+  SignedCosmosTx,
+} from '../cosmos';
 import { Bip39, Random } from '../crypto';
 import { fromBech32 } from '../encoding';
 import { arrayContentEquals, arrayToHex, hexToArray } from '../utils';
@@ -89,6 +96,19 @@ export interface Wallet {
     accountId: string,
     tx: Tx,
   ) => Promise<BroadcastTxCommitResult>;
+  // Cosmos AMINO (Phase 3) — kept as dedicated methods so the Gno path
+  // (sign / signByAccountId / broadcastTx*) stays strictly untouched. The
+  // caller injects a CosmosProvider just like it injects `Provider` for Gno,
+  // keeping adena-module free of HTTP-client deps.
+  signCosmosByAccountId: (
+    accountId: string,
+    document: CosmosDocument,
+    cosmosProvider: CosmosProvider,
+  ) => Promise<SignedCosmosTx>;
+  broadcastCosmosTx: (
+    signedTx: SignedCosmosTx,
+    cosmosProvider: CosmosProvider,
+  ) => Promise<CosmosTxBroadcastResponse>;
   serialize: (password: string) => Promise<string>;
   clone: () => AdenaWallet;
 }
@@ -373,6 +393,41 @@ export class AdenaWallet implements Wallet {
       return keyring.broadcastTxCommit(provider, signedTx, account.hdPath);
     }
     return keyring.broadcastTxCommit(provider, signedTx);
+  }
+
+  // ─── Cosmos AMINO (Phase 3) ───────────────────────────────────────────
+  // Dedicated methods so Gno callers don't encounter union-typed returns.
+  // CosmosProvider is injected by the caller (mirrors the Gno `Provider` DI
+  // pattern — TransactionService resolves the profile via ChainRegistry and
+  // constructs the CosmosLcdProvider before calling these methods).
+
+  async signCosmosByAccountId(
+    accountId: string,
+    document: CosmosDocument,
+    cosmosProvider: CosmosProvider,
+  ): Promise<SignedCosmosTx> {
+    const account = this._accounts.find((a) => a.id === accountId);
+    if (!account) {
+      throw new Error('Account not found');
+    }
+    const keyring = this._keyrings.find((k) => k.id === account.keyringId);
+    if (!keyring) {
+      throw new Error('Keyring not found');
+    }
+    const hdPath = hasHDPath(account) ? account.hdPath : undefined;
+    return signCosmosAmino({
+      document,
+      keyring,
+      cosmosProvider,
+      hdPath,
+    });
+  }
+
+  async broadcastCosmosTx(
+    signedTx: SignedCosmosTx,
+    cosmosProvider: CosmosProvider,
+  ): Promise<CosmosTxBroadcastResponse> {
+    return cosmosProvider.broadcastTx(signedTx.txBytes, 'BROADCAST_MODE_SYNC');
   }
 
   async serialize(password: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,7 +1821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/amino@npm:^0.36.0":
+"@cosmjs/amino@npm:0.36.0, @cosmjs/amino@npm:^0.36.0":
   version: 0.36.0
   resolution: "@cosmjs/amino@npm:0.36.0"
   dependencies:
@@ -1878,6 +1878,20 @@ __metadata:
   version: 0.36.0
   resolution: "@cosmjs/math@npm:0.36.0"
   checksum: 11af6cabf8c0aa63445236ac829929f2552d9b35a74d9ce87e30ce78055a1d4ce949e3a5299159e99933ad66529e83203d1fabe1b960f6e14d1f18b9140027a2
+  languageName: node
+  linkType: hard
+
+"@cosmjs/proto-signing@npm:0.36.0":
+  version: 0.36.0
+  resolution: "@cosmjs/proto-signing@npm:0.36.0"
+  dependencies:
+    "@cosmjs/amino": ^0.36.0
+    "@cosmjs/crypto": ^0.36.0
+    "@cosmjs/encoding": ^0.36.0
+    "@cosmjs/math": ^0.36.0
+    "@cosmjs/utils": ^0.36.0
+    cosmjs-types: ^0.10.1
+  checksum: 869ffffb5148e59cef1fd04e662b5f1ae7a71c93f087cbe94013a5b5cf4ce4c09fe761aea3dc7bc11b80bba1102da31cfcac5e12d4d775420790bbb9ea92ac43
   languageName: node
   linkType: hard
 
@@ -6209,7 +6223,9 @@ __metadata:
     "@babel/preset-env": 7.23.9
     "@babel/preset-flow": 7.23.3
     "@babel/preset-typescript": 7.23.3
+    "@cosmjs/amino": 0.36.0
     "@cosmjs/ledger-amino": 0.36.0
+    "@cosmjs/proto-signing": 0.36.0
     "@gnolang/gno-js-client": 1.4.5
     "@gnolang/tm2-js-client": 1.3.3
     "@ledgerhq/hw-transport": 6.31.4
@@ -8026,6 +8042,13 @@ __metadata:
     typescript:
       optional: true
   checksum: dc339ebea427898c9e03bf01b56ba7afbac07fc7d2a2d5a15d6e9c14de98275a9565da949375aee1809591c152c0a3877bb86dbeaf74d5bd5aaa79955ad9e7a0
+  languageName: node
+  linkType: hard
+
+"cosmjs-types@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "cosmjs-types@npm:0.10.1"
+  checksum: cbb4bbb78e02b1669d65ae99101da9330b7045d9860a6765f76f665caaad632fd223412f409d1653edaa5f6a8b2fec4457d0ccd489b3604812962d9551f49b5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Phase 3 of AtomOne multichain support. End-to-end `MsgSend` pipeline — UI input → AMINO signing → TxRaw serialization → AtomOne LCD broadcast — built on top of Phase 2's `Keyring.signRaw` (#818) and Phase 1's ChainRegistry / CosmosLcdProvider / balances UI (#820). Gno send/sign paths are strictly untouched.

### adena-module

- New `cosmos/` subtree: shared types, `CosmosProvider` interface (Gno-style DI so adena-module stays HTTP-free), MsgSend codec (amino ⇄ proto) with a codec registry, `makeTxRaw` (pubkey compression, `AuthInfo`/`TxBody`/`TxRaw` encoding)
- AMINO (`signCosmosAmino`) + DIRECT (`signCosmosDirect`) pipelines, dispatched by `signCosmos` based on `CosmosSignMode`
- `validateCosmosAddress` — bech32 prefix mismatch guard (blocks `gno1...` on AtomOne)
- `Wallet.signCosmosByAccountId` / `broadcastCosmosTx` — dedicated methods so Gno callers don't see union-typed returns

### adena-extension

- `TransactionService.signCosmos` / `broadcastCosmos` — resolve profile + preferred `CosmosSignMode` via ChainRegistry, delegate to Wallet, invalidate provider dedupe cache after broadcast
- `CosmosLcdProvider.getAccount` — `/cosmos/auth/v1beta1/accounts/{addr}` with `base_account` unwrap; empty-string `account_number`/`sequence` coerced to `'0'` so first-send accounts don't hit `BigInt('')`
- `CosmosLcdProvider.broadcastTx` — throws with `code` + `raw_log` on non-zero code so LCD errors surface to the Failure screen
- `transfer-input`: Cosmos prefix validation; AddressInput `maxLength`/placeholder become props (default Gno 40, Cosmos 48)
- `use-token-balance`: separate Cosmos query — keyed by `(accountId, atomoneNetworkId)`, 10s refetch, `retry: 1`, never blocks Gno rendering
- `transfer-summary` Cosmos branch: builds `MsgSend`, Phase 3 MVP hardcoded fee `2000uphoton` / gas `200000`, Mintscan link via `profile.linkUrl`
- `token-details`: Multisig × Cosmos permanently unsupported (tooltip)
- Remove Phase 1 `readOnly` guard — Cosmos tokens are now sendable
- Four `TODO(Phase 6)` markers on hardcoded-fee sites for the feemarket migration (grep-able)

### Tests

- adena-module: AMINO/DIRECT golden vectors, TxRaw pubkey compression, msg-send round-trip, cosmos-address prefix match, Gno `.sign()` bit-equal parity with pre-Phase-2 output
- adena-extension: `cosmos-lcd-provider.spec.ts` (base_account unwrap, empty-string coerce, broadcast throw on non-zero code, invalidate clears dedupe), `cosmos-query-client.spec.ts` HTTP contract

## Test plan

- [ ] `cd packages/adena-module && npx jest` pass
- [ ] `cd packages/adena-extension && npm test` pass
- [ ] `npx tsc --noEmit` clean, `yarn build` green
- [ ] Manual: send `ATONE` on AtomOne — tx appears on Mintscan
- [ ] Manual: send `PHOTON` — balance updates after invalidate
- [ ] Manual: paste `gno1...` on Cosmos send form — "Invalid Address" before Next
- [ ] Manual: zero `PHOTON` balance — node's "insufficient fees" `raw_log` shown on the Failure screen
- [ ] Manual: AtomOne ⇄ Gno network switch — per-chain balance lifecycles stay independent
- [ ] Manual: Multisig × Cosmos — Send disabled with expected tooltip
- [ ] Manual: Ledger × Cosmos — rejected with Phase 7 message, no crash
- [ ] Manual: Gno GNOT / GRC20 transfer unchanged

## Related

- Base: \`feature/ADN-743\`
- Depends on: #820 (ADN-749), #818 (ADN-750)
- Spec: \`plans/cosmos-support/phase-03-cosmos-amino-msgsend.md\`
- Plan: \`packages/adena-extension/plans/ADN-751/{plan,implementation}.md\`
- Follow-up:
  - Phase 6 — feemarket dynamic fee (replaces the four \`TODO(Phase 6)\`)
  - Phase 7 — Ledger Cosmos signing
  - Cosmos endpoint failover (array shape already preserved)