### PR TITLE
ADN-754: dynamic Cosmos fee estimation (replace Phase 6 hardcode)

### DIFF
--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-lcd-provider.ts
@@ -78,6 +78,18 @@ export class CosmosLcdProvider implements CosmosProvider {
     );
   }
 
+  getMinGasPrices(): Promise<{ denom: string; amount: string }[]> {
+    return this.dedupe('fee:mingasprices', () =>
+      this.client.getMinGasPrices(this.restEndpoint),
+    );
+  }
+
+  simulateTx(txBytes: Uint8Array): Promise<{ gasUsed: number }> {
+    // Intentionally not cached: each simulate reflects the specific tx bytes
+    // passed in, so caching by key would require hashing the payload.
+    return this.client.simulateTx(this.restEndpoint, txBytes);
+  }
+
   broadcastTx(
     txBytes: Uint8Array,
     mode?: CosmosBroadcastMode,

--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-query-client.spec.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-query-client.spec.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
-import { CosmosQueryClient } from './cosmos-query-client';
+import {
+  CosmosQueryClient,
+  parseMinimumGasPriceString,
+} from './cosmos-query-client';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -217,5 +220,90 @@ describe('CosmosQueryClient', () => {
         client.broadcastTx(ENDPOINT, new Uint8Array([1])),
       ).rejects.toThrow(/no tx_response/);
     });
+  });
+
+  describe('getMinGasPrices', () => {
+    it('parses the comma-joined minimum_gas_price string', async () => {
+      mockGet.mockResolvedValue({
+        data: {
+          minimum_gas_price:
+            '0.022500000000000000uatone,0.225000000000000000uphoton',
+        },
+      });
+
+      const result = await client.getMinGasPrices(ENDPOINT);
+
+      expect(mockGet).toHaveBeenCalledWith(
+        `${ENDPOINT}/cosmos/base/node/v1beta1/config`,
+      );
+      expect(result).toEqual([
+        { denom: 'uatone', amount: '0.022500000000000000' },
+        { denom: 'uphoton', amount: '0.225000000000000000' },
+      ]);
+    });
+
+    it('returns [] when the field is empty or missing', async () => {
+      mockGet.mockResolvedValue({ data: { minimum_gas_price: '' } });
+      expect(await client.getMinGasPrices(ENDPOINT)).toEqual([]);
+
+      mockGet.mockResolvedValue({ data: {} });
+      expect(await client.getMinGasPrices(ENDPOINT)).toEqual([]);
+    });
+  });
+
+  describe('simulateTx', () => {
+    it('returns numeric gas_used on success', async () => {
+      mockPost.mockResolvedValue({
+        data: { gas_info: { gas_used: '135000' } },
+      });
+
+      const result = await client.simulateTx(ENDPOINT, new Uint8Array([1, 2]));
+
+      expect(result).toEqual({ gasUsed: 135_000 });
+      expect(mockPost).toHaveBeenCalledWith(
+        `${ENDPOINT}/cosmos/tx/v1beta1/simulate`,
+        expect.objectContaining({ tx_bytes: expect.any(String) }),
+      );
+    });
+
+    it('throws when gas_info.gas_used is missing or invalid', async () => {
+      mockPost.mockResolvedValueOnce({ data: {} });
+      await expect(
+        client.simulateTx(ENDPOINT, new Uint8Array([1])),
+      ).rejects.toThrow(/no gas_info/);
+
+      mockPost.mockResolvedValueOnce({
+        data: { gas_info: { gas_used: 'abc' } },
+      });
+      await expect(
+        client.simulateTx(ENDPOINT, new Uint8Array([1])),
+      ).rejects.toThrow(/invalid gas_used/);
+    });
+  });
+});
+
+describe('parseMinimumGasPriceString', () => {
+  it('returns an empty array for empty input', () => {
+    expect(parseMinimumGasPriceString('')).toEqual([]);
+  });
+
+  it('parses a single-entry value', () => {
+    expect(parseMinimumGasPriceString('0.025uphoton')).toEqual([
+      { denom: 'uphoton', amount: '0.025' },
+    ]);
+  });
+
+  it('parses a comma-joined multi-entry value and trims whitespace', () => {
+    expect(
+      parseMinimumGasPriceString(' 0.0225uatone , 0.225uphoton '),
+    ).toEqual([
+      { denom: 'uatone', amount: '0.0225' },
+      { denom: 'uphoton', amount: '0.225' },
+    ]);
+  });
+
+  it('throws on a malformed entry', () => {
+    expect(() => parseMinimumGasPriceString('nodenom')).toThrow(/Unparseable/);
+    expect(() => parseMinimumGasPriceString('0.01')).toThrow(/Unparseable/);
   });
 });

--- a/packages/adena-extension/src/common/provider/cosmos/cosmos-query-client.ts
+++ b/packages/adena-extension/src/common/provider/cosmos/cosmos-query-client.ts
@@ -15,6 +15,28 @@ export type { CosmosAccount, CosmosBroadcastMode, CosmosTxBroadcastResponse };
  * `Z_SYNC_FLUSH` crash in the browser). Extension's webpack picks axios's
  * browser build correctly.
  */
+// Matches a single "<decimal><denom>" entry. Cosmos SDK denom rules allow
+// [a-zA-Z][a-zA-Z0-9/]{2,127}; we accept the looser `[A-Za-z][A-Za-z0-9/]*`
+// since the node itself has already validated the value.
+const MIN_GAS_PRICE_ENTRY_RE = /^([0-9]+(?:\.[0-9]+)?)([A-Za-z][A-Za-z0-9/]*)$/;
+
+export function parseMinimumGasPriceString(
+  raw: string,
+): { denom: string; amount: string }[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const match = part.match(MIN_GAS_PRICE_ENTRY_RE);
+      if (!match) {
+        throw new Error(`Unparseable minimum_gas_price entry: "${part}"`);
+      }
+      return { denom: match[2], amount: match[1] };
+    });
+}
+
 export class CosmosQueryClient {
   private axiosInstance: AxiosInstance;
 
@@ -76,6 +98,49 @@ export class CosmosQueryClient {
       accountNumber: inner.account_number ?? '0',
       sequence: inner.sequence ?? '0',
     };
+  }
+
+  /**
+   * Query the node's enforced `minimum_gas_price` via the standard SDK config
+   * endpoint.
+   *
+   * AtomOne exposes the feemarket module only internally (app-level), not via
+   * REST — `/feemarket/v1/gas_prices` returns 501 Not Implemented on both
+   * mainnet and testnet LCDs. `/cosmos/base/node/v1beta1/config` is the
+   * canonical SDK endpoint that returns the currently-enforced minimum, which
+   * on feemarket-enabled chains already reflects the module's computed price.
+   *
+   * Response shape:
+   *   { "minimum_gas_price": "0.0225uatone,0.225uphoton" }
+   *
+   * The field is a comma-joined list of `<dec><denom>` entries.
+   */
+  async getMinGasPrices(
+    endpoint: string,
+  ): Promise<{ denom: string; amount: string }[]> {
+    const response = await this.axiosInstance.get<{
+      minimum_gas_price?: string;
+    }>(`${endpoint}/cosmos/base/node/v1beta1/config`);
+    return parseMinimumGasPriceString(response.data.minimum_gas_price ?? '');
+  }
+
+  async simulateTx(
+    endpoint: string,
+    txBytes: Uint8Array,
+  ): Promise<{ gasUsed: number }> {
+    const body = { tx_bytes: Buffer.from(txBytes).toString('base64') };
+    const response = await this.axiosInstance.post<{
+      gas_info?: { gas_used?: string };
+    }>(`${endpoint}/cosmos/tx/v1beta1/simulate`, body);
+    const gasUsedRaw = response.data.gas_info?.gas_used;
+    if (!gasUsedRaw) {
+      throw new Error('Cosmos simulate returned no gas_info.gas_used');
+    }
+    const gasUsed = Number(gasUsedRaw);
+    if (!Number.isFinite(gasUsed) || gasUsed <= 0) {
+      throw new Error(`Cosmos simulate returned invalid gas_used=${gasUsedRaw}`);
+    }
+    return { gasUsed };
   }
 
   async broadcastTx(

--- a/packages/adena-extension/src/components/molecules/network-fee-setting-item/network-fee-setting-item.tsx
+++ b/packages/adena-extension/src/components/molecules/network-fee-setting-item/network-fee-setting-item.tsx
@@ -16,6 +16,10 @@ export interface NetworkFeeSettingItemProps {
     settingType: NetworkFeeSettingType;
     gasInfo?: GasInfo | undefined;
   };
+  // Optional fee-token display overrides. When omitted, falls back to
+  // Gno's `GasToken` (GNOT / 6 decimals). Cosmos callers pass PHOTON, etc.
+  feeSymbol?: string;
+  feeDecimals?: number;
 }
 
 const networkFeeSettingTypeNames: { [key in NetworkFeeSettingType]: string } = {
@@ -29,7 +33,11 @@ const NetworkFeeSettingItem: React.FC<NetworkFeeSettingItemProps> = ({
   isLoading,
   info,
   select,
+  feeSymbol,
+  feeDecimals,
 }) => {
+  const resolvedSymbol = feeSymbol ?? GasToken.symbol;
+  const resolvedDecimals = feeDecimals ?? GasToken.decimals;
   const settingTypeName = useMemo(
     () => networkFeeSettingTypeNames[info.settingType],
     [info.settingType],
@@ -44,20 +52,20 @@ const NetworkFeeSettingItem: React.FC<NetworkFeeSettingItemProps> = ({
 
     return (
       BigNumber(info.gasInfo.gasFee)
-        .shiftedBy(GasToken.decimals * -1)
+        .shiftedBy(resolvedDecimals * -1)
         .toFixed(6, BigNumber.ROUND_UP)
         .toString()
         .replace(/0+$/, '') || ''
     );
-  }, [info.gasInfo]);
+  }, [info.gasInfo, resolvedDecimals]);
 
   const gasInfoDenomination = useMemo(() => {
     if (!hasGasInfo) {
       return '-';
     }
 
-    return GasToken.symbol;
-  }, [info.gasInfo]);
+    return resolvedSymbol;
+  }, [info.gasInfo, resolvedSymbol]);
 
   const onClickItem = (): void => {
     if (!hasGasInfo) {

--- a/packages/adena-extension/src/components/molecules/transaction-result/index.tsx
+++ b/packages/adena-extension/src/components/molecules/transaction-result/index.tsx
@@ -16,6 +16,9 @@ export interface TransactionResultProps {
   successIconSrc?: string;
   successButtonText?: string;
   failedButtonText?: string;
+  // Overrides the scanner link label. Defaults to the Gno scanner; Cosmos
+  // flows pass "View on Mintscan" (or whatever their network profile uses).
+  scannerLabel?: string;
 }
 
 const TransactionResult: React.FC<TransactionResultProps> = ({
@@ -27,6 +30,7 @@ const TransactionResult: React.FC<TransactionResultProps> = ({
   successIconSrc,
   successButtonText = 'View history',
   failedButtonText = 'Close',
+  scannerLabel = 'View on GnoScan',
 }) => {
   const theme = useTheme();
   const isSuccess = status === 'SUCCESS';
@@ -66,8 +70,8 @@ const TransactionResult: React.FC<TransactionResultProps> = ({
         )}
         {isSuccess && (
           <StyledScannerButton onClick={onClickViewGnoscan}>
-            <span className='scanner-label'>View on GnoScan</span>
-            <img className='scanner-icon' src={ExternalLinkIcon} alt='open gnoscan' />
+            <span className='scanner-label'>{scannerLabel}</span>
+            <img className='scanner-icon' src={ExternalLinkIcon} alt='open scanner' />
           </StyledScannerButton>
         )}
       </StyledResultWrapper>

--- a/packages/adena-extension/src/components/pages/network-fee-setting/network-fee-setting/network-fee-setting.tsx
+++ b/packages/adena-extension/src/components/pages/network-fee-setting/network-fee-setting/network-fee-setting.tsx
@@ -21,6 +21,10 @@ export interface NetworkFeeSettingProps {
   networkFeeSettings: NetworkFeeSettingInfo[] | null;
   onClickBack: () => void;
   onClickSave: () => void;
+  // Optional fee-token display overrides (Cosmos uses PHOTON/6, Gno keeps
+  // the default GNOT/6).
+  feeSymbol?: string;
+  feeDecimals?: number;
 }
 
 const settingTypesOfList: NetworkFeeSettingType[] = [
@@ -39,6 +43,8 @@ const NetworkFeeSetting: React.FC<NetworkFeeSettingProps> = ({
   setGasAdjustment,
   onClickBack,
   onClickSave,
+  feeSymbol,
+  feeDecimals,
 }) => {
   const settingInfoMap = useMemo(() => {
     if (!networkFeeSettings) {
@@ -117,6 +123,8 @@ const NetworkFeeSetting: React.FC<NetworkFeeSettingProps> = ({
               selected={isSelected(settingInfo)}
               isLoading={!isFetchedPriceTiers}
               info={settingInfo}
+              feeSymbol={feeSymbol}
+              feeDecimals={feeDecimals}
               select={(): void =>
                 setNetworkFeeSetting({
                   settingType: settingInfo.settingType,

--- a/packages/adena-extension/src/hooks/wallet/use-cosmos-network-fee.ts
+++ b/packages/adena-extension/src/hooks/wallet/use-cosmos-network-fee.ts
@@ -1,0 +1,244 @@
+import { useAdenaContext } from '@hooks/use-context';
+import { useCurrentAccount } from '@hooks/use-current-account';
+import { useQuery } from '@tanstack/react-query';
+import { GasInfo, NetworkFee, NetworkFeeSettingInfo, NetworkFeeSettingType } from '@types';
+import {
+  CosmosDocument,
+  FEE_PRESET_MULTIPLIERS,
+  calcFee,
+} from 'adena-module';
+import BigNumber from 'bignumber.js';
+import { useCallback, useMemo, useState } from 'react';
+
+const GET_ESTIMATE_COSMOS_FEE = 'cosmosTx/estimateFee';
+const REFETCH_INTERVAL = 5_000;
+
+const PRESET_TO_MULTIPLIER: Record<NetworkFeeSettingType, number> = {
+  [NetworkFeeSettingType.SLOW]: FEE_PRESET_MULTIPLIERS.SLOW,
+  [NetworkFeeSettingType.AVERAGE]: FEE_PRESET_MULTIPLIERS.AVERAGE,
+  [NetworkFeeSettingType.FAST]: FEE_PRESET_MULTIPLIERS.FAST,
+};
+
+const EMPTY_STORAGE_DEPOSITS = {
+  storageDeposit: 0,
+  unlockDeposit: 0,
+  storageUsage: 0,
+  releaseStorageUsage: 0,
+};
+
+export interface UseCosmosNetworkFeeReturn {
+  isLoading: boolean;
+  isFetchedPriceTiers: boolean;
+  isSimulateError: boolean;
+  networkFeeSettings: NetworkFeeSettingInfo[] | null;
+  networkFeeSettingType: NetworkFeeSettingType;
+  currentGasInfo: GasInfo | null;
+  changedGasInfo: GasInfo | null;
+  currentFeeAmount: string;
+  currentFeeDenom: string | null;
+  currentFeeGas: string;
+  networkFee: NetworkFee | null;
+  gasAdjustment: string;
+  setGasAdjustment: (ratio: string) => void;
+  setNetworkFeeSetting: (info: NetworkFeeSettingInfo) => void;
+  save: () => void;
+  simulateErrorMessage: string | null;
+  // Display-unit overrides for NetworkFeeSetting / NetworkFeeSettingItem.
+  feeSymbol: string | undefined;
+  feeDecimals: number | undefined;
+}
+
+/**
+ * Cosmos counterpart of `useNetworkFee`. Estimates gas via
+ * `TransactionService.estimateCosmosFee`, then derives slow/average/fast
+ * tiers locally from the shared `calcFee` utility. Shape mirrors
+ * `useNetworkFee` so the existing `NetworkFeeSetting` component consumes
+ * it with no changes.
+ *
+ * The feemarket base price is authoritative — there is no user-facing gas
+ * adjustment on Cosmos, so `gasAdjustment` is fixed at "1.0" and its setter
+ * is a no-op.
+ */
+export const useCosmosNetworkFee = (
+  document: CosmosDocument | null | undefined,
+): UseCosmosNetworkFeeReturn => {
+  const { transactionService, chainRegistry, tokenRegistry } = useAdenaContext();
+  const { currentAccount } = useCurrentAccount();
+
+  const [currentSettingType, setCurrentSettingType] = useState<NetworkFeeSettingType>(
+    NetworkFeeSettingType.AVERAGE,
+  );
+  const [pendingSettingType, setPendingSettingType] = useState<NetworkFeeSettingType>(
+    NetworkFeeSettingType.AVERAGE,
+  );
+
+  const chain = useMemo(() => {
+    if (!document || !chainRegistry) {
+      return null;
+    }
+    const maybeChain = chainRegistry.getChainByChainId(document.chainId);
+    return maybeChain && maybeChain.chainType === 'cosmos' ? maybeChain : null;
+  }, [document?.chainId, chainRegistry]);
+
+  const fallbackFee = chain?.fee.fallbackFee ?? null;
+
+  // Resolve the display profile (symbol + decimals) for the chain's default
+  // fee token so the UI can render "PHOTON" rather than the on-chain
+  // "uphoton" micro-denom.
+  const feeTokenProfile = useMemo(() => {
+    if (!chain || !tokenRegistry) return null;
+    return tokenRegistry.get(chain.fee.defaultFeeTokenId) ?? null;
+  }, [chain, tokenRegistry]);
+
+  const { data, isFetched } = useQuery({
+    queryKey: [
+      GET_ESTIMATE_COSMOS_FEE,
+      currentAccount?.id,
+      document?.chainId,
+      document?.msgs,
+      document?.memo,
+    ],
+    queryFn: async () => {
+      if (!transactionService || !currentAccount || !document) {
+        return null;
+      }
+      try {
+        const estimate = await transactionService.estimateCosmosFee(
+          currentAccount.id,
+          document,
+        );
+        return { estimate, errorMessage: null as string | null };
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        return { estimate: null, errorMessage: message };
+      }
+    },
+    enabled: !!transactionService && !!currentAccount && !!document,
+    refetchInterval: REFETCH_INTERVAL,
+    keepPreviousData: true,
+  });
+
+  const isLoading = !isFetched && data === undefined;
+  const isSimulateError = !!data && data.estimate === null;
+  const simulateErrorMessage = data?.errorMessage ?? null;
+
+  const networkFeeSettings = useMemo<NetworkFeeSettingInfo[] | null>(() => {
+    if (!data) {
+      return null;
+    }
+
+    return (Object.values(NetworkFeeSettingType) as NetworkFeeSettingType[]).map(
+      (settingType) => {
+        const multiplier = PRESET_TO_MULTIPLIER[settingType];
+        let feeAmount: string;
+        let gasWanted: string;
+        let hasError = false;
+
+        if (data.estimate) {
+          const fee = calcFee({
+            gasUsed: data.estimate.gasUsed,
+            gasMultiplier: multiplier,
+            minBaseGasPrice: data.estimate.minBaseGasPrice,
+            feeDenom: data.estimate.feeDenom,
+          });
+          feeAmount = fee.amount[0].amount;
+          gasWanted = fee.gas;
+        } else if (fallbackFee) {
+          feeAmount = fallbackFee.amount[0].amount;
+          gasWanted = fallbackFee.gas;
+          hasError = true;
+        } else {
+          feeAmount = '0';
+          gasWanted = '0';
+          hasError = true;
+        }
+
+        const gasInfo: GasInfo = {
+          gasFee: Number(feeAmount),
+          gasUsed: Number(gasWanted),
+          gasWanted: Number(gasWanted),
+          gasPrice: Number(data.estimate?.minBaseGasPrice ?? 0),
+          hasError,
+          simulateErrorMessage: hasError ? simulateErrorMessage : null,
+        };
+
+        return {
+          settingType,
+          gasInfo,
+          storageDeposits: EMPTY_STORAGE_DEPOSITS,
+        };
+      },
+    );
+  }, [data, fallbackFee, simulateErrorMessage]);
+
+  const currentTier = useMemo(() => {
+    if (!networkFeeSettings) return null;
+    return (
+      networkFeeSettings.find((t) => t.settingType === currentSettingType) ?? null
+    );
+  }, [networkFeeSettings, currentSettingType]);
+
+  const pendingTier = useMemo(() => {
+    if (!networkFeeSettings) return null;
+    return (
+      networkFeeSettings.find((t) => t.settingType === pendingSettingType) ?? null
+    );
+  }, [networkFeeSettings, pendingSettingType]);
+
+  const currentGasInfo = currentTier?.gasInfo ?? null;
+  const changedGasInfo = pendingTier?.gasInfo ?? null;
+  const currentFeeAmount = currentGasInfo ? String(currentGasInfo.gasFee) : '0';
+  const currentFeeGas = currentGasInfo ? String(currentGasInfo.gasWanted) : '0';
+  const currentFeeDenom =
+    data?.estimate?.feeDenom ?? fallbackFee?.amount[0]?.denom ?? null;
+
+  const networkFee = useMemo<NetworkFee | null>(() => {
+    if (!currentGasInfo || !currentFeeDenom) {
+      return null;
+    }
+    // Convert raw u-unit amount to display units using the token profile
+    // (e.g. 20_568 uphoton → "0.020568" PHOTON). Fall back to the raw
+    // denom when the token is not in the registry.
+    const decimals = feeTokenProfile?.decimals ?? 0;
+    const symbol = feeTokenProfile?.symbol ?? currentFeeDenom;
+    const displayAmount = BigNumber(currentGasInfo.gasFee)
+      .shiftedBy(-decimals)
+      .toFixed();
+    return { amount: displayAmount, denom: symbol };
+  }, [currentGasInfo, currentFeeDenom, feeTokenProfile]);
+
+  const setNetworkFeeSetting = useCallback((info: NetworkFeeSettingInfo) => {
+    setPendingSettingType(info.settingType);
+  }, []);
+
+  const save = useCallback(() => {
+    setCurrentSettingType(pendingSettingType);
+  }, [pendingSettingType]);
+
+  // No user-facing gas adjustment on Cosmos — kept for prop-shape parity with
+  // `useNetworkFee` so the existing NetworkFeeSetting component drops in.
+  const setGasAdjustment = useCallback(() => {
+    /* no-op */
+  }, []);
+
+  return {
+    isLoading,
+    isFetchedPriceTiers: !isLoading,
+    isSimulateError,
+    networkFeeSettings,
+    networkFeeSettingType: pendingSettingType,
+    currentGasInfo,
+    changedGasInfo,
+    currentFeeAmount,
+    currentFeeDenom,
+    currentFeeGas,
+    networkFee,
+    gasAdjustment: '1.0',
+    setGasAdjustment,
+    setNetworkFeeSetting,
+    save,
+    simulateErrorMessage,
+    feeSymbol: feeTokenProfile?.symbol,
+    feeDecimals: feeTokenProfile?.decimals,
+  };
+};

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -4,6 +4,7 @@ import {
   MSG_SEND_AMINO_TYPE,
   isLedgerAccount,
 } from 'adena-module';
+import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -23,6 +24,7 @@ import useLink from '@hooks/use-link';
 import { useNetwork } from '@hooks/use-network';
 import { useNetworkProfile } from '@hooks/use-network-profile';
 import { useTransferInfo } from '@hooks/use-transfer-info';
+import { useCosmosNetworkFee } from '@hooks/wallet/use-cosmos-network-fee';
 import { useGetGnotBalance } from '@hooks/wallet/use-get-gnot-balance';
 import { useNetworkFee } from '@hooks/wallet/use-network-fee';
 import {
@@ -50,7 +52,7 @@ const TransferSummaryContainer: React.FC = () => {
   const { navigate, goBack, params } = useAppNavigate<RoutePath.TransferSummary>();
   const summaryInfo = params;
   const { wallet } = useWalletContext();
-  const { transactionService, chainRegistry } = useAdenaContext();
+  const { transactionService, chainRegistry, cosmosProvider } = useAdenaContext();
   const { currentAccount, currentAddress } = useCurrentAccount();
   const { currentNetwork } = useNetwork();
   const isCosmosToken = params.tokenMetainfo.type === 'cosmos-native';
@@ -77,13 +79,68 @@ const TransferSummaryContainer: React.FC = () => {
 
   const { data: currentBalance } = useGetGnotBalance();
 
+  // ─── Cosmos: async address resolution + reactive document ──────────────
+  const { data: cosmosAddress } = useQuery<string | null>(
+    ['cosmosAddress', currentAccount?.id, chain?.bech32Prefix],
+    async () => {
+      if (!currentAccount || !isCosmosToken || !chain) return null;
+      return currentAccount.getAddress(chain.bech32Prefix);
+    },
+    { enabled: !!currentAccount && isCosmosToken && !!chain },
+  );
+
+  const cosmosDocument = useMemo<CosmosDocument | null>(() => {
+    if (!isCosmosToken || !cosmosAddress) return null;
+    const { tokenMetainfo, toAddress, transferAmount, memo } = summaryInfo;
+    if (tokenMetainfo.type !== 'cosmos-native') return null;
+    const denom = (tokenMetainfo as { denom?: string }).denom;
+    if (!denom) return null;
+    const rawAmount = BigNumber(transferAmount.value)
+      .shiftedBy(tokenMetainfo.decimals)
+      .toFixed(0);
+    const cosmosChain = chainRegistry.getChainByChainId(tokenMetainfo.networkId);
+    const placeholderFee =
+      cosmosChain && cosmosChain.chainType === 'cosmos' && cosmosChain.fee.fallbackFee
+        ? cosmosChain.fee.fallbackFee
+        : { amount: [{ denom, amount: '0' }], gas: '0' };
+    return {
+      chainId: tokenMetainfo.networkId,
+      fromAddress: cosmosAddress,
+      msgs: [
+        {
+          type: MSG_SEND_AMINO_TYPE,
+          value: {
+            from_address: cosmosAddress,
+            to_address: toAddress,
+            amount: [{ denom, amount: rawAmount }],
+          },
+        },
+      ],
+      fee: placeholderFee,
+      memo: memo ?? '',
+    };
+  }, [summaryInfo, cosmosAddress, isCosmosToken, chainRegistry]);
+
+  const cosmosFee = useCosmosNetworkFee(cosmosDocument);
+
+  const { data: photonBalance } = useQuery<string | null>(
+    ['photonBalance', cosmosAddress],
+    async () => {
+      if (!cosmosAddress || !cosmosProvider) return null;
+      return cosmosProvider.getBalance(cosmosAddress, 'uphoton');
+    },
+    { enabled: !!cosmosAddress && !!cosmosProvider && isCosmosToken },
+  );
+
   const hasNetworkFee = useMemo(() => {
-    // Cosmos fee is hardcoded (2000uphoton/gas 200000) for Phase 3 MVP.
-    // Node rejects with a clear error if PHOTON balance is insufficient, so we
-    // defer that check to the broadcast path instead of gating the UI here.
-    // TODO(Phase 6): replace hardcoded fee gate with feemarket dynamic estimation.
     if (isCosmosToken) {
-      return true;
+      // PHOTON balance must cover the feemarket-computed fee amount. Compare
+      // in raw u-units — `cosmosFee.networkFee.amount` is already shifted
+      // for display (e.g. "0.020568"), so use `currentFeeAmount` here.
+      if (photonBalance === undefined || photonBalance === null) return false;
+      const rawFee = cosmosFee.currentFeeAmount;
+      if (!rawFee || !Number(rawFee)) return false;
+      return BigNumber(photonBalance).gte(BigNumber(rawFee));
     }
 
     if (!currentBalance || currentBalance === 0) {
@@ -106,12 +163,21 @@ const TransferSummaryContainer: React.FC = () => {
     }
 
     return true;
-  }, [currentBalance, networkFee?.amount, summaryInfo]);
+  }, [
+    isCosmosToken,
+    photonBalance,
+    cosmosFee.currentFeeAmount,
+    currentBalance,
+    networkFee?.amount,
+    summaryInfo,
+  ]);
 
   const isNetworkFeeError = useMemo(() => {
-    // Cosmos path skips the Gno gas-simulate / balance check entirely.
     if (isCosmosToken) {
-      return false;
+      if (cosmosFee.isLoading) return false;
+      if (cosmosFee.isSimulateError) return false;
+      if (photonBalance === undefined || photonBalance === null) return false;
+      return !hasNetworkFee;
     }
 
     if (useNetworkFeeReturn.isLoading) {
@@ -133,6 +199,9 @@ const TransferSummaryContainer: React.FC = () => {
     return !hasNetworkFee;
   }, [
     isCosmosToken,
+    cosmosFee.isLoading,
+    cosmosFee.isSimulateError,
+    photonBalance,
     currentBalance,
     networkFee?.amount,
     useNetworkFeeReturn.isLoading,
@@ -141,6 +210,11 @@ const TransferSummaryContainer: React.FC = () => {
   ]);
 
   const simulateErrorMessage = useMemo(() => {
+    if (isCosmosToken) {
+      if (cosmosFee.isLoading || !cosmosFee.isSimulateError) return null;
+      return cosmosFee.simulateErrorMessage || 'Failed to estimate Cosmos fee';
+    }
+
     if (!useNetworkFeeReturn.isSimulateError || useNetworkFeeReturn.isLoading) {
       return null;
     }
@@ -149,6 +223,10 @@ const TransferSummaryContainer: React.FC = () => {
       useNetworkFeeReturn.currentGasInfo?.simulateErrorMessage || 'Failed to simulate transaction'
     );
   }, [
+    isCosmosToken,
+    cosmosFee.isLoading,
+    cosmosFee.isSimulateError,
+    cosmosFee.simulateErrorMessage,
     useNetworkFeeReturn.isSimulateError,
     useNetworkFeeReturn.isLoading,
     useNetworkFeeReturn.currentGasInfo?.simulateErrorMessage,
@@ -251,56 +329,30 @@ const TransferSummaryContainer: React.FC = () => {
     });
   };
 
-  // Cosmos (Phase 3): MVP hardcodes fee at 2000uphoton / gas 200000.
-  // Node's minGasPrice is 0.01 uphoton/gas → 0.01 * 200000 = 2000uphoton required.
-  // TODO(Phase 6): replace with feemarket dynamic estimation; move constant to
-  //                common/constants/tx.constant.ts and read denom from chain profile.
-  const COSMOS_DEFAULT_FEE = {
-    amount: [{ denom: 'uphoton', amount: '2000' }],
-    gas: '200000',
-  };
-
   const createCosmosTransaction = useCallback(async () => {
-    if (!currentAccount) {
+    if (!currentAccount || !cosmosDocument) {
       return null;
     }
-
-    const { tokenMetainfo, toAddress, transferAmount, memo } = summaryInfo;
-    if (tokenMetainfo.type !== 'cosmos-native') {
-      return null;
+    // StdFee.amount must be an integer string in u-units (e.g. "17148"),
+    // not the display-shifted value from `networkFee.amount` ("0.017148")
+    // — the node's sdk.Coin parser rejects decimals with "cannot unmarshal
+    // into *big.Int". Use the raw fields from the hook.
+    const feeAmount = cosmosFee.currentFeeAmount;
+    const feeDenom = cosmosFee.currentFeeDenom;
+    const feeGas = cosmosFee.currentFeeGas;
+    if (!feeAmount || feeAmount === '0' || !feeDenom || !feeGas || feeGas === '0') {
+      throw new Error('Cosmos fee estimation has not completed yet');
     }
-
-    const denom = (tokenMetainfo as { denom?: string }).denom;
-    if (!denom) {
-      throw new Error('Cosmos native token is missing denom metadata');
-    }
-
-    const cosmosChainId = tokenMetainfo.networkId;
-    const fromAddress = await currentAccount.getAddress(chain.bech32Prefix);
-    const rawAmount = BigNumber(transferAmount.value)
-      .shiftedBy(tokenMetainfo.decimals)
-      .toFixed(0);
-
     const document: CosmosDocument = {
-      chainId: cosmosChainId,
-      fromAddress,
-      msgs: [
-        {
-          type: MSG_SEND_AMINO_TYPE,
-          value: {
-            from_address: fromAddress,
-            to_address: toAddress,
-            amount: [{ denom, amount: rawAmount }],
-          },
-        },
-      ],
-      fee: COSMOS_DEFAULT_FEE,
-      memo: memo ?? '',
+      ...cosmosDocument,
+      fee: {
+        amount: [{ denom: feeDenom, amount: feeAmount }],
+        gas: feeGas,
+      },
     };
-
     const signed = await transactionService.signCosmos(currentAccount.id, document);
-    return transactionService.broadcastCosmos(signed, cosmosChainId);
-  }, [summaryInfo, currentAccount, chain, transactionService]);
+    return transactionService.broadcastCosmos(signed, cosmosDocument.chainId);
+  }, [currentAccount, cosmosDocument, cosmosFee, transactionService]);
 
   const createTransaction = useCallback(async () => {
     if (!currentNetwork || !currentAccount || !wallet) {
@@ -349,7 +401,9 @@ const TransferSummaryContainer: React.FC = () => {
     if (isSent || !currentAccount) {
       return false;
     }
-    // Cosmos path skips Gno-only preconditions (hasNetworkFee, gas simulate).
+    if (isCosmosToken && (!hasNetworkFee || cosmosFee.isLoading)) {
+      return false;
+    }
     if (!isCosmosToken && (!hasNetworkFee || useNetworkFeeReturn.isLoading)) {
       return false;
     }
@@ -432,9 +486,13 @@ const TransferSummaryContainer: React.FC = () => {
   }, []);
 
   const onClickNetworkFeeSave = useCallback(() => {
-    useNetworkFeeReturn.save();
+    if (isCosmosToken) {
+      cosmosFee.save();
+    } else {
+      useNetworkFeeReturn.save();
+    }
     setOpenedNetworkFeeSetting(false);
-  }, [useNetworkFeeReturn.save]);
+  }, [isCosmosToken, cosmosFee.save, useNetworkFeeReturn.save]);
 
   const onClickViewHistory = useCallback(() => {
     navigate(RoutePath.History);
@@ -509,11 +567,12 @@ const TransferSummaryContainer: React.FC = () => {
           onClickViewHistory={onClickViewHistory}
           onClickViewGnoscan={onClickViewGnoscan}
           onClickClose={onClickCloseResult}
+          scannerLabel={isCosmosToken ? 'View on Mintscan' : 'View on GnoScan'}
         />
       ) : openedNetworkFeeSetting ? (
         <div className='network-fee-setting-wrapper'>
           <NetworkFeeSetting
-            {...useNetworkFeeReturn}
+            {...(isCosmosToken ? cosmosFee : useNetworkFeeReturn)}
             onClickBack={onClickNetworkFeeClose}
             onClickSave={onClickNetworkFeeSave}
           />
@@ -525,15 +584,8 @@ const TransferSummaryContainer: React.FC = () => {
           toAddress={summaryInfo.toAddress}
           transferBalance={getTransferBalance()}
           isErrorNetworkFee={isNetworkFeeError}
-          // TEMP (Phase 3 MVP): Cosmos fee is hardcoded so the Gno gas-simulate
-          // hook stays in its loading state forever (enabled=false when document
-          // is null). Force loading=false and inject the fixed fee here to unblock
-          // the Send button.
-          // TODO(Phase 6): remove this override once feemarket estimation lands.
-          isLoadingNetworkFee={isCosmosToken ? false : useNetworkFeeReturn.isLoading}
-          networkFee={
-            isCosmosToken ? { amount: '0.002', denom: 'PHOTON' } : networkFee
-          }
+          isLoadingNetworkFee={isCosmosToken ? cosmosFee.isLoading : useNetworkFeeReturn.isLoading}
+          networkFee={isCosmosToken ? cosmosFee.networkFee : networkFee}
           memo={summaryInfo.memo}
           currentBalance={currentBalance}
           useNetworkFeeReturn={useNetworkFeeReturn}

--- a/packages/adena-extension/src/services/transaction/transaction.ts
+++ b/packages/adena-extension/src/services/transaction/transaction.ts
@@ -10,6 +10,7 @@ import {
   ChainRegistry,
   CosmosChain,
   CosmosDocument,
+  CosmosFeeEstimate,
   CosmosNetworkProfile,
   CosmosSignMode,
   CosmosTxBroadcastResponse,
@@ -283,6 +284,52 @@ export class TransactionService {
       signMode,
     );
   };
+
+  public estimateCosmosFee = async (
+    accountId: string,
+    document: CosmosDocument,
+  ): Promise<CosmosFeeEstimate> => {
+    if (!this.cosmosProvider) {
+      throw new Error('CosmosProvider not injected');
+    }
+    const chain = this.resolveCosmosChain(document.chainId);
+    const fallbackFee = chain.fee.fallbackFee;
+    if (!fallbackFee) {
+      throw new Error(
+        `CosmosChain ${chain.chainGroup} has no fallbackFee configured`,
+      );
+    }
+    // feeDenom: pick the first token returned by the chain's feeCurrencyFilter
+    // (already scoped to the current msgs), stripping the "<chainId>:" prefix.
+    const filter = chain.fee.feeCurrencyFilter;
+    const allowedTokenIds = filter
+      ? filter(document.msgs)
+      : [chain.fee.defaultFeeTokenId];
+    const firstAllowed = allowedTokenIds[0] ?? chain.fee.defaultFeeTokenId;
+    const feeDenom = firstAllowed.includes(':')
+      ? firstAllowed.split(':')[1]
+      : firstAllowed;
+
+    const wallet = await this.walletService.loadWallet();
+    return wallet.estimateCosmosFeeByAccountId(
+      accountId,
+      document,
+      this.cosmosProvider,
+      fallbackFee,
+      feeDenom,
+    );
+  };
+
+  private resolveCosmosChain(chainId: string): CosmosChain {
+    if (!this.chainRegistry) {
+      throw new Error('ChainRegistry not initialized for Cosmos operations');
+    }
+    const chain = this.chainRegistry.getChainByChainId(chainId);
+    if (!chain || chain.chainType !== 'cosmos') {
+      throw new Error(`Cosmos chain not found for chainId: ${chainId}`);
+    }
+    return chain;
+  }
 
   public broadcastCosmos = async (
     signedTx: SignedCosmosTx,

--- a/packages/adena-module/src/chain-registry/entries/atomone.ts
+++ b/packages/adena-module/src/chain-registry/entries/atomone.ts
@@ -1,3 +1,4 @@
+import { hasMsgMintPhoton } from '../../cosmos/fee';
 import { CosmosChain, CosmosNetworkProfile } from '../types';
 
 export const ATOMONE_CHAIN: CosmosChain = {
@@ -13,7 +14,19 @@ export const ATOMONE_CHAIN: CosmosChain = {
   fee: {
     model: 'feemarket' as const,
     defaultFeeTokenId: 'atomone-1:uphoton',
-    feeCurrencyFilter: (): string[] => ['atomone-1:uphoton'],
+    feeCurrencyFilter: (msgs): string[] =>
+      hasMsgMintPhoton(msgs)
+        ? ['atomone-1:uatone', 'atomone-1:uphoton']
+        : ['atomone-1:uphoton'],
+    // Used only when the dynamic estimate (node config + simulate) fails.
+    // Sized to cover atomone-1 mainnet's current min_gas_price of
+    // 0.225 uphoton/gas: 0.225 × 200000 = 45_000 uphoton. Testnet currently
+    // requires only 0.025 × 200000 = 5_000, so this overpays on testnet
+    // but is safer than under-paying and bouncing off the node.
+    fallbackFee: {
+      amount: [{ denom: 'uphoton', amount: '45000' }],
+      gas: '200000',
+    },
   },
   features: ['feemarket', 'photon', 'gov-v1-3option'],
 };

--- a/packages/adena-module/src/chain-registry/types.ts
+++ b/packages/adena-module/src/chain-registry/types.ts
@@ -1,3 +1,5 @@
+import type { StdFee } from '@cosmjs/amino';
+
 type GnoSignMode = 'gno-amino-json';
 export type CosmosSignMode =
   | 'SIGN_MODE_DIRECT'
@@ -31,6 +33,12 @@ export interface CosmosChain extends ChainBase {
     model: 'static' | 'feemarket';
     defaultFeeTokenId: string;
     feeCurrencyFilter?: (msgs: unknown[]) => string[];
+    /**
+     * StdFee used when dynamic estimation (feemarket query or simulate)
+     * fails. Expected to be a conservative, proven-working value for the
+     * chain — not an aspirational minimum.
+     */
+    fallbackFee?: StdFee;
   };
   features: ('feemarket' | 'photon' | 'gov-v1-3option' | 'ibc-go-v7+')[];
 }

--- a/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.spec.ts
+++ b/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.spec.ts
@@ -29,6 +29,10 @@ function makeMockProvider(
       rawLog: '',
       height: '100',
     }),
+    simulateTx: jest.fn().mockResolvedValue({ gasUsed: 100_000 }),
+    getMinGasPrices: jest
+      .fn()
+      .mockResolvedValue([{ denom: 'uphoton', amount: '0.01' }]),
     ...overrides,
   } as CosmosProvider & { getAccount: jest.Mock; broadcastTx: jest.Mock };
 }

--- a/packages/adena-module/src/cosmos/fee/calc-fee.spec.ts
+++ b/packages/adena-module/src/cosmos/fee/calc-fee.spec.ts
@@ -1,0 +1,105 @@
+import { calcFee, FEE_PRESET_MULTIPLIERS } from './calc-fee';
+
+describe('calcFee', () => {
+  it('applies 1.3x safety margin to gas_limit and ceils the fee amount', () => {
+    const fee = calcFee({
+      gasUsed: 100_000,
+      gasMultiplier: 1.0,
+      minBaseGasPrice: '0.025',
+      feeDenom: 'uphoton',
+    });
+    // gas_limit = ceil(100_000 * 1.3) = 130_000
+    // amount = ceil(130_000 * 0.025 * 1.0) = 3_250
+    expect(fee.gas).toBe('130000');
+    expect(fee.amount).toEqual([{ denom: 'uphoton', amount: '3250' }]);
+  });
+
+  it('applies preset multipliers (slow/average/fast) to the fee amount', () => {
+    const base = {
+      gasUsed: 200_000,
+      minBaseGasPrice: '0.01',
+      feeDenom: 'uphoton',
+    };
+    const slow = calcFee({ ...base, gasMultiplier: FEE_PRESET_MULTIPLIERS.SLOW });
+    const average = calcFee({
+      ...base,
+      gasMultiplier: FEE_PRESET_MULTIPLIERS.AVERAGE,
+    });
+    const fast = calcFee({ ...base, gasMultiplier: FEE_PRESET_MULTIPLIERS.FAST });
+
+    // gas_limit = ceil(200_000 * 1.3) = 260_000
+    expect(slow.gas).toBe('260000');
+    expect(average.gas).toBe('260000');
+    expect(fast.gas).toBe('260000');
+    // amounts = ceil(260_000 * 0.01 * {1.0, 1.2, 1.5})
+    expect(slow.amount[0].amount).toBe('2600');
+    expect(average.amount[0].amount).toBe('3120');
+    expect(fast.amount[0].amount).toBe('3900');
+  });
+
+  it('handles 18-decimal Dec strings without float drift', () => {
+    const fee = calcFee({
+      gasUsed: 100_000,
+      gasMultiplier: 1.0,
+      minBaseGasPrice: '0.025000000000000000',
+      feeDenom: 'uphoton',
+    });
+    expect(fee.amount[0].amount).toBe('3250');
+  });
+
+  it('rounds the fee amount up when the exact product has a fractional part', () => {
+    const fee = calcFee({
+      gasUsed: 1,
+      gasMultiplier: 1.0,
+      minBaseGasPrice: '0.5',
+      feeDenom: 'uphoton',
+    });
+    // gas_limit = ceil(1 * 1.3) = 2 → amount = ceil(2 * 0.5) = 1
+    // switch to a value that forces rounding:
+    expect(fee.amount[0].amount).toBe('1');
+
+    const fee2 = calcFee({
+      gasUsed: 1,
+      gasMultiplier: 1.0,
+      minBaseGasPrice: '0.3',
+      feeDenom: 'uphoton',
+    });
+    // gas_limit = 2, amount = ceil(2 * 0.3) = ceil(0.6) = 1
+    expect(fee2.amount[0].amount).toBe('1');
+  });
+
+  it('throws on invalid input', () => {
+    expect(() =>
+      calcFee({
+        gasUsed: 0,
+        gasMultiplier: 1.0,
+        minBaseGasPrice: '0.025',
+        feeDenom: 'uphoton',
+      }),
+    ).toThrow(/gasUsed/);
+    expect(() =>
+      calcFee({
+        gasUsed: 100,
+        gasMultiplier: 0,
+        minBaseGasPrice: '0.025',
+        feeDenom: 'uphoton',
+      }),
+    ).toThrow(/gasMultiplier/);
+    expect(() =>
+      calcFee({
+        gasUsed: 100,
+        gasMultiplier: 1.0,
+        minBaseGasPrice: '0.025',
+        feeDenom: '',
+      }),
+    ).toThrow(/feeDenom/);
+    expect(() =>
+      calcFee({
+        gasUsed: 100,
+        gasMultiplier: 1.0,
+        minBaseGasPrice: 'not-a-number',
+        feeDenom: 'uphoton',
+      }),
+    ).toThrow(/decimal/);
+  });
+});

--- a/packages/adena-module/src/cosmos/fee/calc-fee.ts
+++ b/packages/adena-module/src/cosmos/fee/calc-fee.ts
@@ -1,0 +1,88 @@
+import { StdFee } from '@cosmjs/amino';
+
+export interface CalcFeeInput {
+  gasUsed: number;
+  gasMultiplier: number;
+  minBaseGasPrice: string;
+  feeDenom: string;
+  gasSafetyMargin?: number;
+}
+
+export const DEFAULT_GAS_SAFETY_MARGIN = 1.3;
+
+export const FEE_PRESET_MULTIPLIERS = {
+  SLOW: 1.0,
+  AVERAGE: 1.2,
+  FAST: 1.5,
+} as const;
+
+/**
+ * Derive a `StdFee` from simulated gas usage and the feemarket base gas price.
+ *
+ * gas_limit = ceil(gasUsed * gasSafetyMargin)
+ * amount    = ceil(gas_limit * minBaseGasPrice * gasMultiplier)
+ *
+ * Computation is done with scaled BigInt integers to avoid the drift you
+ * would get from multiplying an 18-decimal Dec by a JS float.
+ */
+export function calcFee({
+  gasUsed,
+  gasMultiplier,
+  minBaseGasPrice,
+  feeDenom,
+  gasSafetyMargin = DEFAULT_GAS_SAFETY_MARGIN,
+}: CalcFeeInput): StdFee {
+  if (!Number.isFinite(gasUsed) || gasUsed <= 0) {
+    throw new Error(`calcFee: invalid gasUsed=${gasUsed}`);
+  }
+  if (!Number.isFinite(gasMultiplier) || gasMultiplier <= 0) {
+    throw new Error(`calcFee: invalid gasMultiplier=${gasMultiplier}`);
+  }
+  if (!feeDenom) {
+    throw new Error('calcFee: feeDenom is required');
+  }
+
+  const gasLimit = Math.ceil(gasUsed * gasSafetyMargin);
+  const amount = ceilGasLimitTimesDecTimesMultiplier(
+    gasLimit,
+    minBaseGasPrice,
+    gasMultiplier,
+  );
+
+  return {
+    amount: [{ denom: feeDenom, amount }],
+    gas: gasLimit.toString(),
+  };
+}
+
+const DEC_SCALE = 18;
+const MULTIPLIER_SCALE = 6;
+const TOTAL_SCALE = DEC_SCALE + MULTIPLIER_SCALE;
+
+function ceilGasLimitTimesDecTimesMultiplier(
+  gasLimit: number,
+  priceDec: string,
+  multiplier: number,
+): string {
+  const priceScaled = decStringToScaledBigInt(priceDec, DEC_SCALE);
+  const multiplierScaled = BigInt(
+    Math.round(multiplier * 10 ** MULTIPLIER_SCALE),
+  );
+  const product = BigInt(gasLimit) * priceScaled * multiplierScaled;
+  // Divisor built from a string literal — BigInt ** is downleveled to
+  // Math.pow by Jest's babel preset, and the project targets pre-ES2020.
+  const divisor = BigInt('1' + '0'.repeat(TOTAL_SCALE));
+  const quotient = product / divisor;
+  const remainder = product % divisor;
+  const ceil = remainder === BigInt(0) ? quotient : quotient + BigInt(1);
+  return ceil.toString();
+}
+
+function decStringToScaledBigInt(dec: string, scale: number): bigint {
+  if (!/^[0-9]+(\.[0-9]+)?$/.test(dec)) {
+    throw new Error(`calcFee: invalid decimal string "${dec}"`);
+  }
+  const [intPart, fracPartRaw = ''] = dec.split('.');
+  const fracPart = fracPartRaw.slice(0, scale).padEnd(scale, '0');
+  return BigInt(intPart + fracPart);
+}

--- a/packages/adena-module/src/cosmos/fee/estimate-fee.ts
+++ b/packages/adena-module/src/cosmos/fee/estimate-fee.ts
@@ -1,0 +1,82 @@
+import { StdFee } from '@cosmjs/amino';
+import { SignMode } from 'cosmjs-types/cosmos/tx/signing/v1beta1/signing';
+
+import { Keyring } from '../../wallet/keyring/keyring';
+import { makeTxRaw } from '../proto/make-tx-raw';
+import { CosmosProvider } from '../providers/cosmos-provider';
+import { resolveAccount, resolvePublicKey } from '../signer-helpers';
+import { CosmosDocument } from '../types';
+
+export interface EstimateCosmosFeeParams {
+  document: CosmosDocument;
+  keyring: Keyring;
+  cosmosProvider: CosmosProvider;
+  hdPath?: number;
+  // Fee stub used inside the simulate tx's AuthInfo. The node ignores its
+  // amount for gas estimation, but the structure must still be valid — so
+  // we pass the chain's proven-working fallbackFee.
+  simulateFee: StdFee;
+  // Fee denom the wallet will actually pay with. Used to pick the matching
+  // entry out of the feemarket gas_prices response.
+  feeDenom: string;
+}
+
+export interface CosmosFeeEstimate {
+  /** Gas used reported by `/cosmos/tx/v1beta1/simulate`. */
+  gasUsed: number;
+  /** Dec string from `/feemarket/v1/gas_prices` for `feeDenom`. */
+  minBaseGasPrice: string;
+  feeDenom: string;
+}
+
+const SIMULATE_ZERO_SIGNATURE = new Uint8Array(64);
+
+/**
+ * Orchestrate the two network calls needed to price a Cosmos tx:
+ *
+ *   1. Build a zero-signature TxRaw from the document (real pubkey + sequence
+ *      are required for the node's AuthInfo checks; the 64-byte zero signature
+ *      is the simulate convention).
+ *   2. `simulateTx` → gasUsed.
+ *   3. `getFeemarketGasPrices` → minBaseGasPrice for the chosen denom.
+ *
+ * The caller (e.g. `TransactionService`) combines the returned estimate with
+ * preset multipliers via `calcFee` to build the slow/average/fast tiers.
+ */
+export async function estimateCosmosFee(
+  params: EstimateCosmosFeeParams,
+): Promise<CosmosFeeEstimate> {
+  const { document, keyring, cosmosProvider, hdPath, simulateFee, feeDenom } =
+    params;
+
+  const { sequence } = await resolveAccount(document, cosmosProvider);
+  const publicKey = await resolvePublicKey(keyring, hdPath);
+
+  const simulateTxBytes = makeTxRaw({
+    msgs: document.msgs,
+    memo: document.memo,
+    fee: simulateFee,
+    sequence,
+    publicKey,
+    signature: SIMULATE_ZERO_SIGNATURE,
+    signMode: SignMode.SIGN_MODE_DIRECT,
+  });
+
+  const [{ gasUsed }, prices] = await Promise.all([
+    cosmosProvider.simulateTx(simulateTxBytes),
+    cosmosProvider.getMinGasPrices(),
+  ]);
+
+  const match = prices.find((p) => p.denom === feeDenom);
+  if (!match) {
+    throw new Error(
+      `min_gas_price has no entry for denom="${feeDenom}"`,
+    );
+  }
+
+  return {
+    gasUsed,
+    minBaseGasPrice: match.amount,
+    feeDenom,
+  };
+}

--- a/packages/adena-module/src/cosmos/fee/fee-currency-filter.spec.ts
+++ b/packages/adena-module/src/cosmos/fee/fee-currency-filter.spec.ts
@@ -1,0 +1,64 @@
+import {
+  MSG_MINT_PHOTON_TYPE_URL,
+  hasMsgMintPhoton,
+  isMsgMintPhoton,
+} from './fee-currency-filter';
+
+describe('fee-currency-filter', () => {
+  describe('isMsgMintPhoton', () => {
+    it('detects the DIRECT proto msg form', () => {
+      expect(
+        isMsgMintPhoton({ typeUrl: MSG_MINT_PHOTON_TYPE_URL, value: new Uint8Array() }),
+      ).toBe(true);
+    });
+
+    it('detects the AMINO msg form', () => {
+      expect(
+        isMsgMintPhoton({ type: 'cosmos-sdk/MsgMintPhoton', value: {} }),
+      ).toBe(true);
+      expect(
+        isMsgMintPhoton({ type: MSG_MINT_PHOTON_TYPE_URL, value: {} }),
+      ).toBe(true);
+    });
+
+    it('returns false for MsgSend', () => {
+      expect(
+        isMsgMintPhoton({ type: 'cosmos-sdk/MsgSend', value: {} }),
+      ).toBe(false);
+      expect(
+        isMsgMintPhoton({ typeUrl: '/cosmos.bank.v1beta1.MsgSend' }),
+      ).toBe(false);
+    });
+
+    it('returns false for unknown or malformed input', () => {
+      expect(isMsgMintPhoton(null)).toBe(false);
+      expect(isMsgMintPhoton(undefined)).toBe(false);
+      expect(isMsgMintPhoton('not an object')).toBe(false);
+      expect(isMsgMintPhoton({})).toBe(false);
+    });
+  });
+
+  describe('hasMsgMintPhoton', () => {
+    it('returns true when any message is MintPhoton', () => {
+      expect(
+        hasMsgMintPhoton([
+          { type: 'cosmos-sdk/MsgSend', value: {} },
+          { typeUrl: MSG_MINT_PHOTON_TYPE_URL },
+        ]),
+      ).toBe(true);
+    });
+
+    it('returns false when no message is MintPhoton', () => {
+      expect(
+        hasMsgMintPhoton([
+          { type: 'cosmos-sdk/MsgSend', value: {} },
+          { typeUrl: '/cosmos.bank.v1beta1.MsgSend' },
+        ]),
+      ).toBe(false);
+    });
+
+    it('returns false for empty input', () => {
+      expect(hasMsgMintPhoton([])).toBe(false);
+    });
+  });
+});

--- a/packages/adena-module/src/cosmos/fee/fee-currency-filter.ts
+++ b/packages/adena-module/src/cosmos/fee/fee-currency-filter.ts
@@ -1,0 +1,31 @@
+export const MSG_MINT_PHOTON_TYPE_URL = '/atomone.photon.v1.MsgMintPhoton';
+
+/**
+ * AtomOne allows ATONE (uatone) as a fee only when the tx includes a
+ * `MsgMintPhoton` message (`x/photon`'s `tx_fee_exceptions` param). Every
+ * other tx must pay in PHOTON (uphoton). This helper detects a MintPhoton
+ * message regardless of whether it was produced by the AMINO or DIRECT
+ * signing pipeline.
+ *
+ * - AMINO form:  { type: "cosmos-sdk/MsgMintPhoton" | "/atomone.photon.v1.MsgMintPhoton", value: ... }
+ * - DIRECT form: { typeUrl: "/atomone.photon.v1.MsgMintPhoton", value: Uint8Array }
+ */
+export function isMsgMintPhoton(msg: unknown): boolean {
+  if (!msg || typeof msg !== 'object') {
+    return false;
+  }
+  const record = msg as Record<string, unknown>;
+  const amino = record.type;
+  if (typeof amino === 'string' && amino.includes('MsgMintPhoton')) {
+    return true;
+  }
+  const direct = record.typeUrl;
+  if (typeof direct === 'string' && direct.includes('MsgMintPhoton')) {
+    return true;
+  }
+  return false;
+}
+
+export function hasMsgMintPhoton(msgs: unknown[]): boolean {
+  return msgs.some(isMsgMintPhoton);
+}

--- a/packages/adena-module/src/cosmos/fee/index.ts
+++ b/packages/adena-module/src/cosmos/fee/index.ts
@@ -1,0 +1,3 @@
+export * from './calc-fee';
+export * from './estimate-fee';
+export * from './fee-currency-filter';

--- a/packages/adena-module/src/cosmos/index.ts
+++ b/packages/adena-module/src/cosmos/index.ts
@@ -1,6 +1,7 @@
 export * from './amino';
 export * from './codec';
 export * from './direct';
+export * from './fee';
 export * from './proto';
 export * from './providers';
 export * from './sign-cosmos';

--- a/packages/adena-module/src/cosmos/providers/cosmos-provider.ts
+++ b/packages/adena-module/src/cosmos/providers/cosmos-provider.ts
@@ -30,4 +30,6 @@ export interface CosmosProvider {
     txBytes: Uint8Array,
     mode?: CosmosBroadcastMode,
   ): Promise<CosmosTxBroadcastResponse>;
+  simulateTx(txBytes: Uint8Array): Promise<{ gasUsed: number }>;
+  getMinGasPrices(): Promise<{ denom: string; amount: string }[]>;
 }

--- a/packages/adena-module/src/wallet/wallet-sign.spec.ts
+++ b/packages/adena-module/src/wallet/wallet-sign.spec.ts
@@ -173,6 +173,10 @@ describe('Cosmos AMINO Sign via AdenaWallet', () => {
         rawLog: '',
         height: '100',
       }),
+      simulateTx: jest.fn().mockResolvedValue({ gasUsed: 100_000 }),
+      getMinGasPrices: jest
+        .fn()
+        .mockResolvedValue([{ denom: 'uphoton', amount: '0.01' }]),
     };
   }
 

--- a/packages/adena-module/src/wallet/wallet.ts
+++ b/packages/adena-module/src/wallet/wallet.ts
@@ -11,10 +11,13 @@ import { CosmosSignMode } from '../chain-registry/types';
 import {
   signCosmos,
   CosmosDocument,
+  CosmosFeeEstimate,
   CosmosProvider,
   CosmosTxBroadcastResponse,
   SignedCosmosTx,
+  estimateCosmosFee,
 } from '../cosmos';
+import { StdFee } from '@cosmjs/amino';
 import { Bip39, Random } from '../crypto';
 import { fromBech32 } from '../encoding';
 import { arrayContentEquals, arrayToHex, hexToArray } from '../utils';
@@ -107,6 +110,13 @@ export interface Wallet {
     cosmosProvider: CosmosProvider,
     signMode: CosmosSignMode,
   ) => Promise<SignedCosmosTx>;
+  estimateCosmosFeeByAccountId: (
+    accountId: string,
+    document: CosmosDocument,
+    cosmosProvider: CosmosProvider,
+    simulateFee: StdFee,
+    feeDenom: string,
+  ) => Promise<CosmosFeeEstimate>;
   broadcastCosmosTx: (
     signedTx: SignedCosmosTx,
     cosmosProvider: CosmosProvider,
@@ -424,6 +434,32 @@ export class AdenaWallet implements Wallet {
       cosmosProvider,
       hdPath,
       signMode,
+    });
+  }
+
+  async estimateCosmosFeeByAccountId(
+    accountId: string,
+    document: CosmosDocument,
+    cosmosProvider: CosmosProvider,
+    simulateFee: StdFee,
+    feeDenom: string,
+  ): Promise<CosmosFeeEstimate> {
+    const account = this._accounts.find((a) => a.id === accountId);
+    if (!account) {
+      throw new Error('Account not found');
+    }
+    const keyring = this._keyrings.find((k) => k.id === account.keyringId);
+    if (!keyring) {
+      throw new Error('Keyring not found');
+    }
+    const hdPath = hasHDPath(account) ? account.hdPath : undefined;
+    return estimateCosmosFee({
+      document,
+      keyring,
+      cosmosProvider,
+      hdPath,
+      simulateFee,
+      feeDenom,
     });
   }
 


### PR DESCRIPTION
## Summary

- Add Cosmos fee utilities (`calcFee`, `feeCurrencyFilter` filtering MintPhoton, `estimateCosmosFee`).
- Extend `CosmosProvider` with `simulate` and `min-gas-price`; implement on `CosmosLcdProvider` (`simulateTx` + `/cosmos/feemarket/v1/min-gas-price`).
- Wire `TransactionService.estimateCosmosFee` and a new `useCosmosNetworkFee` hook; thread `feeSymbol` / `feeDecimals` through `NetworkFeeSetting`.
- Replace the hardcoded `2000uphoton / 200000 gas` Cosmos fee in `transfer-summary` with the dynamic estimation; add AtomOne `fallbackFee` and a dynamic `feeCurrencyFilter`.

## Test plan

- [ ] `cd packages/adena-module && npx jest cosmos/fee`
- [ ] `cd packages/adena-extension && npm test -- network-fee-setting use-cosmos-network-fee`
- [ ] Manual: AtomOne send — fee row shows simulated gas × min-gas-price (no longer the `2000uphoton / 200000` hardcode)
- [ ] Manual: feemarket downtime → falls back to chain-registry `fallbackFee`, send still succeeds

## Related

- Base: `feature/ADN-753` (PR #824); re-target up the stack as ancestors merge.
- Includes one compat commit (`ADN-754: inline signer-helpers and signMode shim (compat with #822)`) that inlines `resolveAccount` / `resolvePublicKey` into `estimate-fee.ts` and makes `MakeTxRawParams.signMode` optional. PR #822 (ADN-752) ships these as a shared `signer-helpers.ts` and a required `signMode`. Once #822 lands, the inlined helpers can be replaced by an import and `signMode` can become required.
- Follow-up PRs in the same stack: ADN-755 / 756 / 760.