### PR TITLE
ADN-755: Ledger signing for Cosmos transfers

### DIFF
--- a/packages/adena-extension/src/components/pages/transfer-ledger-reject/transfer-ledger-reject.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-ledger-reject/transfer-ledger-reject.tsx
@@ -8,18 +8,23 @@ import { TransferLedgerRejectWrapper } from './transfer-ledger-reject.styles';
 
 export interface TransferLedgerRejectProps {
   onClickClose: () => void;
+  title?: string;
+  desc?: string;
 }
 
-const text = {
-  title: 'Transaction Rejected',
-  desc: 'The transaction has been rejected on\nyour ledger device. Please approve the\ntransaction in your wallet to complete\nthe transaction.',
-};
+const DEFAULT_TITLE = 'Transaction Rejected';
+const DEFAULT_DESC =
+  'The transaction has been rejected on\nyour ledger device. Please approve the\ntransaction in your wallet to complete\nthe transaction.';
 
-const TransferLedgerReject: React.FC<TransferLedgerRejectProps> = ({ onClickClose }) => {
+const TransferLedgerReject: React.FC<TransferLedgerRejectProps> = ({
+  onClickClose,
+  title = DEFAULT_TITLE,
+  desc = DEFAULT_DESC,
+}) => {
   return (
     <TransferLedgerRejectWrapper>
       <img className='reject-icon' src={IconConnectFailPermission} alt='logo-image' />
-      <TitleWithDesc title={text.title} desc={text.desc} />
+      <TitleWithDesc title={title} desc={desc} />
       <Button
         fullWidth
         hierarchy='dark'

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas-info.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas-info.ts
@@ -75,7 +75,7 @@ export const makeEstimateGasTransaction = async (
 
   const modifiedDocument = modifyDocument(document, gasWanted, gasFee);
   if (!withSignTransaction) {
-    return documentToDefaultTx(modifiedDocument);
+    return documentToDefaultTx(modifiedDocument, account.publicKey);
   }
 
   const { signed } = await transactionService
@@ -86,7 +86,11 @@ export const makeEstimateGasTransaction = async (
       };
     });
   if (!signed) {
-    return documentToDefaultTx(modifiedDocument);
+    // Fallback path — createTransaction fails for accounts that can't sign
+    // in-process (Ledger without an attached connector, AirGap). Pass the
+    // account's pubkey so gno.land simulate can verify pub_key ↔ address
+    // matching for pre-initialized accounts.
+    return documentToDefaultTx(modifiedDocument, account.publicKey);
   }
 
   return signed;

--- a/packages/adena-extension/src/hooks/web/connect-ledger/use-select-account-screen.ts
+++ b/packages/adena-extension/src/hooks/web/connect-ledger/use-select-account-screen.ts
@@ -125,7 +125,14 @@ const useSelectAccountScreen = (): useSelectAccountScreenReturn => {
     if (!transport) {
       return;
     }
-    const keyring = await LedgerKeyring.fromLedger(AdenaLedgerConnector.fromTransport(transport));
+    // Reuse the keyringId already baked into the accounts (set during
+    // enumeration via LedgerAccount.createBy). Creating a fresh keyring
+    // here would mint a new UUID that no account references, leaving the
+    // persisted wallet with `account.keyringId` pointing at nothing —
+    // every `keyrings.find(k => k.id === account.keyringId)` would throw.
+    const existingKeyringId = resultSavedAccounts[0]?.keyringId;
+    const keyring = new LedgerKeyring({ id: existingKeyringId });
+    keyring.setConnector(AdenaLedgerConnector.fromTransport(transport));
 
     await transport.close();
 

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-ledger-cosmos-loading/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-ledger-cosmos-loading/index.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import styled from 'styled-components';
+
+import TransferLedgerLoading from '@components/pages/transfer-ledger-loading/transfer-ledger-loading';
+import useAppNavigate from '@hooks/use-app-navigate';
+import { useAdenaContext } from '@hooks/use-context';
+import { useCurrentAccount } from '@hooks/use-current-account';
+import { createNotificationSendMessageByHash } from '@inject/message/methods/transaction-event';
+import mixins from '@styles/mixins';
+import { RoutePath } from '@types';
+import {
+  AdenaLedgerConnector,
+  CosmosDocument,
+  Document,
+  isLedgerAccount,
+  LedgerError,
+  LedgerErrorKind,
+} from 'adena-module';
+
+const TransferLedgerCosmosLoadingLayout = styled.div`
+  ${mixins.flex({ align: 'normal', justify: 'normal' })};
+  width: 100%;
+  height: 100%;
+  padding: 24px 20px 120px 20px;
+`;
+
+// TransferLedgerLoading presentational is shaped around Gno Document. Adapt
+// CosmosDocument to it so the same review table can be reused without forking
+// another near-identical component.
+function toCompatDocument(cosmos: CosmosDocument): Document {
+  return {
+    chain_id: cosmos.chainId,
+    account_number: cosmos.accountNumber ?? '',
+    sequence: cosmos.sequence ?? '',
+    fee: {
+      gas: cosmos.fee.gas,
+      amount: cosmos.fee.amount.map((a) => ({
+        denom: a.denom,
+        amount: a.amount,
+      })),
+    },
+    msgs: [],
+    memo: cosmos.memo,
+  };
+}
+
+interface RejectScreenCopy {
+  title: string;
+  desc: string;
+}
+
+const LEDGER_ERROR_COPY: Record<LedgerErrorKind, RejectScreenCopy> = {
+  DeviceLocked: {
+    title: 'Ledger Device Locked',
+    desc: 'Unlock your Ledger device and try the\ntransaction again.',
+  },
+  AppNotOpen: {
+    title: 'Cosmos App Not Open',
+    desc: 'Open the Cosmos app on your Ledger\nand try the transaction again.',
+  },
+  UserRejected: {
+    title: 'Transaction Rejected',
+    desc: 'The transaction has been rejected on\nyour ledger device. Please approve the\ntransaction in your wallet to complete\nthe transaction.',
+  },
+  Timeout: {
+    title: 'Ledger Timed Out',
+    desc: 'No response from your Ledger device.\nPlease try the transaction again.',
+  },
+  TransportFailed: {
+    title: 'Ledger Disconnected',
+    desc: 'Reconnect your Ledger device and try\nthe transaction again.',
+  },
+  Unknown: {
+    title: 'Ledger Signing Failed',
+    desc: 'An unexpected error occurred while\nsigning. Please try again.',
+  },
+};
+
+const SIGN_FAILURE_COPY: RejectScreenCopy = {
+  title: 'Signing Failed',
+  desc: 'The transaction could not be signed.\nPlease try again.',
+};
+
+const BROADCAST_FAILURE_COPY: RejectScreenCopy = {
+  title: 'Broadcast Failed',
+  desc: 'The transaction was signed but could\nnot be broadcast. Check your network\nand try again.',
+};
+
+const LEDGER_NOT_FOUND_COPY: RejectScreenCopy = {
+  title: 'Ledger Not Connected',
+  desc: 'Connect your Ledger device and try\nthe transaction again.',
+};
+
+const TransferLedgerCosmosLoadingContainer = (): JSX.Element => {
+  const { navigate, goBack, params } = useAppNavigate<RoutePath.TransferLedgerCosmosLoading>();
+  const { transactionService } = useAdenaContext();
+  const { currentAccount } = useCurrentAccount();
+  const startedRef = useRef(false);
+  const document = params.document;
+  const summary = params.summary;
+  const compatDocument = useMemo(() => toCompatDocument(document), [document]);
+
+  const navigateToReject = useCallback(
+    (copy: RejectScreenCopy) => {
+      navigate(RoutePath.TransferLedgerReject, { state: copy });
+    },
+    [navigate],
+  );
+
+  // Sign and broadcast are intentionally split: a broadcast failure must not
+  // re-enter the signing flow with a stale signed tx (sequence would already
+  // be consumed). Each phase navigates to its own reject screen on failure;
+  // there is no automatic retry — recovery requires the user to start over.
+  const run = useCallback(async () => {
+    if (!currentAccount || !isLedgerAccount(currentAccount)) {
+      return;
+    }
+
+    const transport = await AdenaLedgerConnector.openConnected();
+    if (!transport) {
+      navigateToReject(LEDGER_NOT_FOUND_COPY);
+      return;
+    }
+    const ledgerConnector = AdenaLedgerConnector.fromTransport(transport);
+
+    let signed;
+    try {
+      signed = await transactionService.signCosmosWithLedger(
+        ledgerConnector,
+        currentAccount,
+        document,
+      );
+    } catch (error) {
+      if (error instanceof LedgerError) {
+        navigateToReject(LEDGER_ERROR_COPY[error.kind]);
+      } else {
+        navigateToReject(SIGN_FAILURE_COPY);
+      }
+      return;
+    } finally {
+      await transport.close().catch(() => undefined);
+    }
+
+    try {
+      const result = await transactionService.broadcastCosmos(signed, document.chainId);
+      createNotificationSendMessageByHash(result.txhash);
+      if (summary) {
+        navigate(RoutePath.TransferSummary, {
+          state: {
+            ...summary,
+            ledgerResult: { status: 'SUCCESS', hash: result.txhash },
+          },
+        });
+      } else {
+        navigate(RoutePath.History);
+      }
+    } catch (error) {
+      console.log(error);
+      navigateToReject(BROADCAST_FAILURE_COPY);
+    }
+  }, [currentAccount, document, navigate, navigateToReject, summary, transactionService]);
+
+  useEffect(() => {
+    if (startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+    run();
+  }, [run]);
+
+  return (
+    <TransferLedgerCosmosLoadingLayout>
+      <TransferLedgerLoading document={compatDocument} onClickCancel={goBack} />
+    </TransferLedgerCosmosLoadingLayout>
+  );
+};
+
+export default TransferLedgerCosmosLoadingContainer;

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-ledger-loading/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-ledger-loading/index.tsx
@@ -24,25 +24,47 @@ const TransferLedgerLoadingContainer = (): JSX.Element => {
   const { currentAccount } = useCurrentAccount();
   const [connected, setConnected] = useState(false);
   const document = params.document;
+  const summary = params.summary;
 
   useEffect(() => {
     requestTransaction();
   }, [connected]);
 
+  // FIXME(ADN-755): same infinite-retry pattern as the Cosmos loading page.
+  // When createTransaction returns null for any non-UserRejected reason
+  // (device locked, app not open, transport failure, broadcast error), the
+  // setTimeout below flips `connected` back to false which re-fires the
+  // useEffect and re-runs the entire flow every second. The Cosmos page was
+  // rewritten to navigate to a dedicated reject screen per error kind; the
+  // Gno path is left unchanged here to limit blast radius and should be
+  // ported in a follow-up ticket.
   const requestTransaction = useCallback(() => {
     if (connected) {
       return false;
     }
     setConnected(true);
-    return createTransaction().then((result) => {
-      if (!result) {
+    return createTransaction().then((hash) => {
+      if (!hash) {
         setTimeout(() => setConnected(false), 1000);
         return false;
       }
-      navigate(RoutePath.History);
+      // If we came from TransferSummary, route back so its existing RESULT
+      // screen renders (same UX as HD/PK transfers). NFT transfers reuse
+      // this page without summary → fall back to the historical direct
+      // History navigation.
+      if (summary) {
+        navigate(RoutePath.TransferSummary, {
+          state: {
+            ...summary,
+            ledgerResult: { status: 'SUCCESS', hash },
+          },
+        });
+      } else {
+        navigate(RoutePath.History);
+      }
       return true;
     });
-  }, [connected]);
+  }, [connected, navigate, summary]);
 
   const createTransaction = useCallback(async () => {
     if (!wallet) {
@@ -59,7 +81,7 @@ const TransferLedgerLoadingContainer = (): JSX.Element => {
     }
     const ledgerConnector = AdenaLedgerConnector.fromTransport(connected);
 
-    const result = await transactionService
+    const hash = await transactionService
       .createTransactionWithLedger(ledgerConnector, currentAccount, document)
       .then(async ({ signed }) => {
         connected.close();
@@ -70,7 +92,6 @@ const TransferLedgerLoadingContainer = (): JSX.Element => {
         );
         return response.hash;
       })
-      .then(createNotificationSendMessageByHash)
       .catch((error: Error) => {
         console.log(error);
         connected.close();
@@ -79,8 +100,11 @@ const TransferLedgerLoadingContainer = (): JSX.Element => {
         }
         return null;
       });
-    return result;
-  }, [currentAccount, document]);
+    if (hash) {
+      createNotificationSendMessageByHash(hash);
+    }
+    return hash;
+  }, [currentAccount, document, navigate, transactionService, wallet]);
 
   return (
     <TransferLedgerLoadingLayout>

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-ledger-reject/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-ledger-reject/index.tsx
@@ -15,7 +15,7 @@ const TransferLedgerRejectLayout = styled.div`
 `;
 
 const TransferLedgerRejectContainer: React.FC = () => {
-  const { navigate } = useAppNavigate();
+  const { navigate, params } = useAppNavigate<RoutePath.TransferLedgerReject>();
 
   const onClickClose = useCallback(() => {
     navigate(RoutePath.Wallet);
@@ -23,7 +23,11 @@ const TransferLedgerRejectContainer: React.FC = () => {
 
   return (
     <TransferLedgerRejectLayout>
-      <TransferLedgerReject onClickClose={onClickClose} />
+      <TransferLedgerReject
+        onClickClose={onClickClose}
+        title={params?.title}
+        desc={params?.desc}
+      />
     </TransferLedgerRejectLayout>
   );
 };

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -410,6 +410,9 @@ const TransferSummaryContainer: React.FC = () => {
 
     setIsSent(true);
     if (isLedgerAccount(currentAccount)) {
+      if (isCosmosToken) {
+        return transferByLedgerCosmos();
+      }
       return transferByLedger();
     }
 
@@ -459,10 +462,35 @@ const TransferSummaryContainer: React.FC = () => {
   const transferByLedger = useCallback(async () => {
     const document = await createDocument();
     if (document) {
-      navigate(RoutePath.TransferLedgerLoading, { state: { document } });
+      navigate(RoutePath.TransferLedgerLoading, {
+        state: { document, summary: summaryInfo },
+      });
     }
     return true;
-  }, [createDocument]);
+  }, [createDocument, navigate, summaryInfo]);
+
+  const transferByLedgerCosmos = useCallback(async () => {
+    if (!cosmosDocument) {
+      return false;
+    }
+    const feeAmount = cosmosFee.currentFeeAmount;
+    const feeDenom = cosmosFee.currentFeeDenom;
+    const feeGas = cosmosFee.currentFeeGas;
+    if (!feeAmount || feeAmount === '0' || !feeDenom || !feeGas || feeGas === '0') {
+      return false;
+    }
+    const document: CosmosDocument = {
+      ...cosmosDocument,
+      fee: {
+        amount: [{ denom: feeDenom, amount: feeAmount }],
+        gas: feeGas,
+      },
+    };
+    navigate(RoutePath.TransferLedgerCosmosLoading, {
+      state: { document, summary: summaryInfo },
+    });
+    return true;
+  }, [cosmosDocument, cosmosFee, navigate, summaryInfo]);
 
   const onClickBack = useCallback(() => {
     setMemorizedTransferInfo(summaryInfo);
@@ -529,6 +557,24 @@ const TransferSummaryContainer: React.FC = () => {
       });
     }
   }, [simulateErrorMessage]);
+
+  useEffect(() => {
+    // When a Ledger loading page navigates back after broadcast, it seeds
+    // `params.ledgerResult` — enter the RESULT screen so the Ledger user
+    // gets the same completion UI (View History / View on Scanner / Close)
+    // as HD/PK transfers instead of jumping straight to History.
+    const ledgerResult = summaryInfo.ledgerResult;
+    if (ledgerResult) {
+      setTransferResult({
+        status: ledgerResult.status,
+        hash: ledgerResult.hash ?? null,
+        errorMessage: ledgerResult.errorMessage ?? null,
+      });
+      setScreenState('RESULT');
+    }
+    // One-shot on mount; intentionally no deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     // Cosmos path builds its document inline at broadcast time — skip the

--- a/packages/adena-extension/src/router/popup/index.tsx
+++ b/packages/adena-extension/src/router/popup/index.tsx
@@ -47,6 +47,7 @@ import { Staking } from '@pages/popup/wallet/staking';
 import { TokenDetails } from '@pages/popup/wallet/token-details';
 import { TransactionDetail } from '@pages/popup/wallet/transaction-detail';
 import TransferInput from '@pages/popup/wallet/transfer-input';
+import TransferLedgerCosmosLoading from '@pages/popup/wallet/transfer-ledger-cosmos-loading';
 import TransferLedgerLoading from '@pages/popup/wallet/transfer-ledger-loading';
 import TransferLedgerReject from '@pages/popup/wallet/transfer-ledger-reject';
 import TransferSummary from '@pages/popup/wallet/transfer-summary';
@@ -115,6 +116,10 @@ export const PopupRouter = (): JSX.Element => {
         <Route path={RoutePath.NftTransferSummary} element={<NFTTransferSummary />} />
         <Route path={RoutePath.NftTransferInput} element={<NFTTransferInput />} />
         <Route path={RoutePath.TransferLedgerLoading} element={<TransferLedgerLoading />} />
+        <Route
+          path={RoutePath.TransferLedgerCosmosLoading}
+          element={<TransferLedgerCosmosLoading />}
+        />
         <Route path={RoutePath.TransferLedgerReject} element={<TransferLedgerReject />} />
         <Route path={RoutePath.BroadcastTransaction} element={<BroadcastTransactionScreen />} />
         <Route

--- a/packages/adena-extension/src/services/transaction/transaction.ts
+++ b/packages/adena-extension/src/services/transaction/transaction.ts
@@ -19,6 +19,7 @@ import {
   LedgerKeyring,
   SignedCosmosTx,
   sha256,
+  signCosmos,
   Wallet,
 } from 'adena-module';
 
@@ -330,6 +331,31 @@ export class TransactionService {
     }
     return chain;
   }
+
+  /**
+   * Sign a Cosmos document with a Ledger keyring. Parallel to `signCosmos` but
+   * bypasses the wallet-owned keyring (whose connector is null after restore)
+   * and uses a keyring freshly bound to an active `AdenaLedgerConnector`.
+   */
+  public signCosmosWithLedger = async (
+    ledgerConnector: AdenaLedgerConnector,
+    account: LedgerAccount,
+    document: CosmosDocument,
+  ): Promise<SignedCosmosTx> => {
+    if (!this.cosmosProvider) {
+      throw new Error('CosmosProvider not injected');
+    }
+    this.resolveCosmosProfile(document.chainId);
+    const signMode = this.resolvePreferredSignMode(document.chainId);
+    const keyring = await LedgerKeyring.fromLedger(ledgerConnector);
+    return signCosmos({
+      document,
+      keyring,
+      cosmosProvider: this.cosmosProvider,
+      hdPath: account.hdPath,
+      signMode,
+    });
+  };
 
   public broadcastCosmos = async (
     signedTx: SignedCosmosTx,

--- a/packages/adena-extension/src/services/transaction/transaction.ts
+++ b/packages/adena-extension/src/services/transaction/transaction.ts
@@ -19,7 +19,7 @@ import {
   LedgerKeyring,
   SignedCosmosTx,
   sha256,
-  signCosmos,
+  signCosmosAmino,
   Wallet,
 } from 'adena-module';
 
@@ -346,14 +346,17 @@ export class TransactionService {
       throw new Error('CosmosProvider not injected');
     }
     this.resolveCosmosProfile(document.chainId);
-    const signMode = this.resolvePreferredSignMode(document.chainId);
+    // PR #822 (ADN-752) introduces a unified `signCosmos` dispatcher that
+    // routes by `chain.signing.preferred`. Until #822 lands, hardcode the
+    // AMINO pipeline — the Cosmos Ledger app only renders AMINO JSON
+    // anyway, so AMINO is the only mode that produces a usable display
+    // for Ledger users.
     const keyring = await LedgerKeyring.fromLedger(ledgerConnector);
-    return signCosmos({
+    return signCosmosAmino({
       document,
       keyring,
       cosmosProvider: this.cosmosProvider,
       hdPath: account.hdPath,
-      signMode,
     });
   };
 

--- a/packages/adena-extension/src/types/router.ts
+++ b/packages/adena-extension/src/types/router.ts
@@ -9,7 +9,7 @@ import {
   TokenModel,
   TransactionInfo,
 } from '@types';
-import { Document } from 'adena-module';
+import { CosmosDocument, Document } from 'adena-module';
 
 export const REGISTER_PATH = 'register.html' as const;
 export const SECURITY_PATH = 'security.html' as const;
@@ -64,6 +64,7 @@ export enum RoutePath {
   TransferSummary = '/wallet/transfer-summary',
   NftTransferSummary = '/wallet/nft-transfer-summary',
   TransferLedgerLoading = '/wallet/transfer-ledger/loading',
+  TransferLedgerCosmosLoading = '/wallet/transfer-ledger/cosmos-loading',
   TransferLedgerReject = '/wallet/transfer-ledger/reject',
   BroadcastTransaction = '/wallet/broadcast-transaction',
   BroadcastMultisigTransactionScreen = '/wallet/broadcast-multiig-transaction',
@@ -187,6 +188,15 @@ export type RouteParams = {
     };
     gasInfo: GasInfo | null;
     memo: string;
+    // Populated only when a Ledger loading page navigates back after a
+    // successful/failed broadcast — lets TransferSummary enter its RESULT
+    // screen (same UX HD/PK transfers already get) without a dedicated
+    // Ledger completion page.
+    ledgerResult?: {
+      status: 'SUCCESS' | 'FAILED';
+      hash?: string | null;
+      errorMessage?: string | null;
+    };
   };
   [RoutePath.NftTransferSummary]: {
     grc721Token: GRC721Model;
@@ -199,8 +209,21 @@ export type RouteParams = {
   };
   [RoutePath.TransferLedgerLoading]: {
     document: Document;
+    // Original TransferSummary params — carried through so the Ledger
+    // loading page can navigate back to TransferSummary with the broadcast
+    // result and reuse its existing RESULT screen. Optional because NFT
+    // transfers reuse this page but don't have an equivalent result screen
+    // on the NFT summary side.
+    summary?: RouteParams[RoutePath.TransferSummary];
   };
-  [RoutePath.TransferLedgerReject]: null;
+  [RoutePath.TransferLedgerCosmosLoading]: {
+    document: CosmosDocument;
+    summary?: RouteParams[RoutePath.TransferSummary];
+  };
+  [RoutePath.TransferLedgerReject]: {
+    title?: string;
+    desc?: string;
+  } | null;
   [RoutePath.BroadcastTransaction]: null;
   [RoutePath.BroadcastMultisigTransactionScreen]: null;
   [RoutePath.SignMultisigTransactionScreen]: null;

--- a/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.spec.ts
+++ b/packages/adena-module/src/cosmos/amino/sign-cosmos-amino.spec.ts
@@ -2,6 +2,8 @@ import { Secp256k1Wallet } from '@cosmjs/amino';
 import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
 
 import { HDWalletKeyring } from '../../wallet/keyring/hd-wallet-keyring';
+import type { LedgerConnector } from '@cosmjs/ledger-amino';
+
 import { LedgerKeyring } from '../../wallet/keyring/ledger-keyring';
 import { MultisigKeyring } from '../../wallet/keyring/multisig-keyring';
 import { AddressKeyring } from '../../wallet/keyring/address-keyring';
@@ -193,15 +195,28 @@ describe('signCosmosAmino', () => {
     expect(signed.signDoc.sequence).toBe('3');
   });
 
-  it('throws forward-looking message for Ledger keyring', async () => {
+  it('produces a signed Cosmos tx when the keyring is a Ledger', async () => {
+    // With the Phase 7 stub lifted, a Ledger keyring flows through the same
+    // pipeline as HD/private-key keyrings: signRaw → 64-byte r||s →
+    // makeTxRaw. We mock the connector to stay unit-scope.
+    const pubkey = new Uint8Array(33).fill(0x02);
+    const signature = new Uint8Array(64).fill(0x09);
+    const connector = {
+      sign: jest.fn().mockResolvedValue(signature),
+      getPubkey: jest.fn().mockResolvedValue(pubkey),
+    } as unknown as LedgerConnector;
     const keyring = new LedgerKeyring({});
-    await expect(
-      signCosmosAmino({
-        document: makeDocument(),
-        keyring,
-        cosmosProvider: makeMockProvider(),
-      }),
-    ).rejects.toThrow(/Phase 7/);
+    keyring.setConnector(connector);
+
+    const signed = await signCosmosAmino({
+      document: makeDocument(),
+      keyring,
+      cosmosProvider: makeMockProvider(),
+    });
+
+    expect(connector.sign).toHaveBeenCalledTimes(1);
+    const ourTxRaw = TxRaw.decode(signed.txBytes);
+    expect(Buffer.from(ourTxRaw.signatures[0]).equals(Buffer.from(signature))).toBe(true);
   });
 
   it('throws permanent-unsupport message for Multisig keyring', async () => {

--- a/packages/adena-module/src/cosmos/fee/estimate-fee.ts
+++ b/packages/adena-module/src/cosmos/fee/estimate-fee.ts
@@ -1,15 +1,19 @@
 import { StdFee } from '@cosmjs/amino';
 import { SignMode } from 'cosmjs-types/cosmos/tx/signing/v1beta1/signing';
 
-import { Keyring } from '../../wallet/keyring/keyring';
 import { makeTxRaw } from '../proto/make-tx-raw';
 import { CosmosProvider } from '../providers/cosmos-provider';
-import { resolveAccount, resolvePublicKey } from '../signer-helpers';
+import { resolveAccount } from '../signer-helpers';
 import { CosmosDocument } from '../types';
 
 export interface EstimateCosmosFeeParams {
   document: CosmosDocument;
-  keyring: Keyring;
+  // Public key of the signer. Used only to populate the simulate tx's
+  // AuthInfo — no signing happens in this function (we send a zero
+  // signature). Passing the key directly (rather than a Keyring) keeps fee
+  // estimation usable when the persisted wallet keyring is unreachable
+  // (e.g. Ledger accounts whose keyringId drifted from the stored keyring).
+  publicKey: Uint8Array;
   cosmosProvider: CosmosProvider;
   hdPath?: number;
   // Fee stub used inside the simulate tx's AuthInfo. The node ignores its
@@ -46,11 +50,10 @@ const SIMULATE_ZERO_SIGNATURE = new Uint8Array(64);
 export async function estimateCosmosFee(
   params: EstimateCosmosFeeParams,
 ): Promise<CosmosFeeEstimate> {
-  const { document, keyring, cosmosProvider, hdPath, simulateFee, feeDenom } =
+  const { document, publicKey, cosmosProvider, simulateFee, feeDenom } =
     params;
 
   const { sequence } = await resolveAccount(document, cosmosProvider);
-  const publicKey = await resolvePublicKey(keyring, hdPath);
 
   const simulateTxBytes = makeTxRaw({
     msgs: document.msgs,

--- a/packages/adena-module/src/ledger/index.ts
+++ b/packages/adena-module/src/ledger/index.ts
@@ -1,1 +1,3 @@
 export * from './ledger-connector';
+export * from './ledger-errors';
+export * from './ledger-app-utils';

--- a/packages/adena-module/src/ledger/ledger-app-utils.spec.ts
+++ b/packages/adena-module/src/ledger/ledger-app-utils.spec.ts
@@ -1,0 +1,154 @@
+import type Transport from '@ledgerhq/hw-transport';
+import CosmosApp from 'ledger-cosmos-js';
+
+import { ensureAppOpen } from './ledger-app-utils';
+import { LedgerError } from './ledger-errors';
+
+jest.mock('ledger-cosmos-js');
+
+const MockedCosmosApp = CosmosApp as unknown as jest.Mock;
+
+type AppInfoMock = jest.Mock<Promise<unknown>, []>;
+
+function makeTransport(): { transport: Transport; send: jest.Mock } {
+  const send = jest.fn().mockResolvedValue(Buffer.from([0x90, 0x00]));
+  const transport = { send } as unknown as Transport;
+  return { transport, send };
+}
+
+function ok(appName: string) {
+  return {
+    appName,
+    appVersion: '1.0.0',
+    return_code: 0x9000,
+    error_message: 'No errors',
+  };
+}
+
+function mockAppInfoSequence(responses: Array<unknown>): AppInfoMock {
+  const appInfo = jest.fn() as AppInfoMock;
+  for (const res of responses) {
+    appInfo.mockResolvedValueOnce(res as never);
+  }
+  return appInfo;
+}
+
+describe('ensureAppOpen', () => {
+  beforeEach(() => {
+    MockedCosmosApp.mockReset();
+  });
+
+  it('resolves immediately when the expected app is already open', async () => {
+    const { transport, send } = makeTransport();
+    const appInfo = mockAppInfoSequence([ok('Cosmos')]);
+    MockedCosmosApp.mockImplementation(() => ({ appInfo }));
+
+    const result = await ensureAppOpen(transport, 'Cosmos', {
+      pollIntervalMs: 1,
+      maxAttempts: 3,
+    });
+
+    expect(result).toBe(transport);
+    expect(appInfo).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('opens the app and resolves after polling until the correct app appears', async () => {
+    const { transport, send } = makeTransport();
+    const appInfo = mockAppInfoSequence([
+      ok('Ethereum'),
+      ok('Ethereum'),
+      ok('Ethereum'),
+      ok('Cosmos'),
+    ]);
+    MockedCosmosApp.mockImplementation(() => ({ appInfo }));
+
+    const reopenTransport = jest.fn().mockResolvedValue(transport);
+
+    const result = await ensureAppOpen(transport, 'Cosmos', {
+      pollIntervalMs: 1,
+      maxAttempts: 10,
+      reopenTransport,
+    });
+
+    expect(result).toBe(transport);
+    expect(send).toHaveBeenCalledWith(
+      0xe0,
+      0xd8,
+      0x00,
+      0x00,
+      Buffer.from('Cosmos', 'ascii'),
+    );
+    expect(reopenTransport).toHaveBeenCalledTimes(3);
+    expect(appInfo).toHaveBeenCalledTimes(4);
+  });
+
+  it('throws LedgerError("AppNotOpen") when the app never switches', async () => {
+    const { transport } = makeTransport();
+    const appInfo = jest.fn().mockResolvedValue(ok('Ethereum'));
+    MockedCosmosApp.mockImplementation(() => ({ appInfo }));
+
+    await expect(
+      ensureAppOpen(transport, 'Cosmos', {
+        pollIntervalMs: 1,
+        maxAttempts: 3,
+      }),
+    ).rejects.toMatchObject({
+      name: 'LedgerError',
+      kind: 'AppNotOpen',
+    });
+
+    expect(appInfo).toHaveBeenCalledTimes(4); // 1 initial + 3 polls
+  });
+
+  it('continues polling if reopenTransport throws transiently', async () => {
+    const { transport } = makeTransport();
+    const appInfo = mockAppInfoSequence([ok('Ethereum'), ok('Cosmos')]);
+    MockedCosmosApp.mockImplementation(() => ({ appInfo }));
+
+    const reopenTransport = jest
+      .fn<Promise<Transport>, []>()
+      .mockRejectedValueOnce(new Error('transport closed'))
+      .mockResolvedValue(transport);
+
+    const result = await ensureAppOpen(transport, 'Cosmos', {
+      pollIntervalMs: 1,
+      maxAttempts: 5,
+      reopenTransport,
+    });
+
+    expect(result).toBe(transport);
+    expect(reopenTransport).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a failed appInfo call as "not open" and keeps polling', async () => {
+    const { transport } = makeTransport();
+    const appInfo = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('disconnected'))
+      .mockRejectedValueOnce(new Error('still disconnected'))
+      .mockResolvedValueOnce(ok('Cosmos'));
+    MockedCosmosApp.mockImplementation(() => ({ appInfo }));
+
+    const result = await ensureAppOpen(transport, 'Cosmos', {
+      pollIntervalMs: 1,
+      maxAttempts: 5,
+    });
+
+    expect(result).toBe(transport);
+    expect(appInfo).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws a plain LedgerError instance so callers can check with instanceof', async () => {
+    const { transport } = makeTransport();
+    const appInfo = jest.fn().mockResolvedValue(ok('Ethereum'));
+    MockedCosmosApp.mockImplementation(() => ({ appInfo }));
+
+    await ensureAppOpen(transport, 'Cosmos', {
+      pollIntervalMs: 1,
+      maxAttempts: 1,
+    }).catch((err) => {
+      expect(err).toBeInstanceOf(LedgerError);
+    });
+  });
+});

--- a/packages/adena-module/src/ledger/ledger-app-utils.ts
+++ b/packages/adena-module/src/ledger/ledger-app-utils.ts
@@ -1,0 +1,101 @@
+import Transport from '@ledgerhq/hw-transport';
+import CosmosApp, { AppInfoResponse } from 'ledger-cosmos-js';
+
+import { LedgerError } from './ledger-errors';
+
+const DEFAULT_POLL_INTERVAL_MS = 200;
+const DEFAULT_POLL_MAX_ATTEMPTS = 25;
+const BOLOS_CLA = 0xe0;
+const BOLOS_INS_OPEN_APP = 0xd8;
+const NO_ERRORS_MESSAGE = 'No errors';
+
+export interface AppInfo {
+  appName: string;
+  errorMessage: string;
+  returnCode: number;
+}
+
+export interface EnsureAppOpenOptions {
+  reopenTransport?: () => Promise<Transport>;
+  pollIntervalMs?: number;
+  maxAttempts?: number;
+}
+
+export async function getAppInfo(transport: Transport): Promise<AppInfo | null> {
+  try {
+    const app = new CosmosApp(transport);
+    const response = (await app.appInfo()) as Partial<AppInfoResponse>;
+    const appName = typeof response.appName === 'string' ? response.appName : null;
+    if (!appName) {
+      return null;
+    }
+    return {
+      appName,
+      errorMessage: response.error_message ?? '',
+      returnCode: response.return_code ?? 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function openApp(transport: Transport, appName: string): Promise<void> {
+  await transport.send(
+    BOLOS_CLA,
+    BOLOS_INS_OPEN_APP,
+    0x00,
+    0x00,
+    Buffer.from(appName, 'ascii'),
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isAppMatch(info: AppInfo | null, expectedApp: string): boolean {
+  return !!info && info.appName === expectedApp && info.errorMessage === NO_ERRORS_MESSAGE;
+}
+
+export async function ensureAppOpen(
+  transport: Transport,
+  expectedApp = 'Cosmos',
+  options: EnsureAppOpenOptions = {},
+): Promise<Transport> {
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const maxAttempts = options.maxAttempts ?? DEFAULT_POLL_MAX_ATTEMPTS;
+
+  const current = await getAppInfo(transport);
+  if (isAppMatch(current, expectedApp)) {
+    return transport;
+  }
+
+  try {
+    await openApp(transport, expectedApp);
+  } catch {
+    // openApp often disconnects the transport; polling below will re-check.
+  }
+
+  let activeTransport = transport;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await sleep(pollIntervalMs);
+
+    if (options.reopenTransport) {
+      try {
+        activeTransport = await options.reopenTransport();
+      } catch {
+        continue;
+      }
+    }
+
+    const info = await getAppInfo(activeTransport);
+    if (isAppMatch(info, expectedApp)) {
+      return activeTransport;
+    }
+  }
+
+  throw new LedgerError(
+    'AppNotOpen',
+    `Expected Ledger app "${expectedApp}" but it did not open in time`,
+  );
+}

--- a/packages/adena-module/src/ledger/ledger-errors.spec.ts
+++ b/packages/adena-module/src/ledger/ledger-errors.spec.ts
@@ -1,0 +1,104 @@
+import { LedgerError, classifyLedgerError } from './ledger-errors';
+
+describe('LedgerError', () => {
+  it('sets kind, message, name, and prototype', () => {
+    const err = new LedgerError('DeviceLocked', 'locked');
+
+    expect(err).toBeInstanceOf(LedgerError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.kind).toBe('DeviceLocked');
+    expect(err.message).toBe('locked');
+    expect(err.name).toBe('LedgerError');
+  });
+
+  it('preserves the original cause', () => {
+    const original = new Error('boom');
+    const err = new LedgerError('Unknown', 'wrapped', original);
+
+    expect(err.cause).toBe(original);
+  });
+});
+
+describe('classifyLedgerError', () => {
+  it('returns the input unchanged when already a LedgerError', () => {
+    const original = new LedgerError('UserRejected', 'nope');
+
+    expect(classifyLedgerError(original)).toBe(original);
+  });
+
+  it.each<[string, number, LedgerError['kind']]>([
+    ['device locked (0x5515)', 0x5515, 'DeviceLocked'],
+    ['device locked (0x6b0c)', 0x6b0c, 'DeviceLocked'],
+    ['app not open (0x6511)', 0x6511, 'AppNotOpen'],
+    ['app not open (0x6e00)', 0x6e00, 'AppNotOpen'],
+    ['app not open (0x6e01)', 0x6e01, 'AppNotOpen'],
+    ['user rejected (0x6985)', 0x6985, 'UserRejected'],
+    ['user rejected (0x6986)', 0x6986, 'UserRejected'],
+    ['timeout (0x6804)', 0x6804, 'Timeout'],
+  ])('maps %s to %s via return_code', (_label, statusCode, expectedKind) => {
+    const result = classifyLedgerError({
+      return_code: statusCode,
+      error_message: 'some device message',
+    });
+
+    expect(result).toBeInstanceOf(LedgerError);
+    expect(result.kind).toBe(expectedKind);
+    expect(result.message).toBe('some device message');
+  });
+
+  it('reads status from alternative keys (statusCode)', () => {
+    const result = classifyLedgerError({ statusCode: 0x6985, message: 'denied' });
+
+    expect(result.kind).toBe('UserRejected');
+  });
+
+  it('falls back to DeviceLocked when message mentions a locked device', () => {
+    const result = classifyLedgerError(new Error('Ledger device is locked'));
+
+    expect(result.kind).toBe('DeviceLocked');
+  });
+
+  it('falls back to AppNotOpen when message mentions opening the app', () => {
+    const result = classifyLedgerError(
+      new Error('App does not seem to be open, please open the Cosmos app'),
+    );
+
+    expect(result.kind).toBe('AppNotOpen');
+  });
+
+  it('falls back to UserRejected when message mentions transaction rejection', () => {
+    const result = classifyLedgerError(new Error('Transaction rejected by user'));
+
+    expect(result.kind).toBe('UserRejected');
+  });
+
+  it('falls back to Timeout when message mentions timing out', () => {
+    const result = classifyLedgerError(new Error('request timed out'));
+
+    expect(result.kind).toBe('Timeout');
+  });
+
+  it('falls back to TransportFailed when transport disconnects', () => {
+    const result = classifyLedgerError(new Error('Transport was disconnected'));
+
+    expect(result.kind).toBe('TransportFailed');
+  });
+
+  it('returns Unknown for unrecognized errors and preserves the cause', () => {
+    const cause = { weird: true };
+    const result = classifyLedgerError(cause);
+
+    expect(result.kind).toBe('Unknown');
+    expect(result.message).toBe('Unknown Ledger error');
+    expect(result.cause).toBe(cause);
+  });
+
+  it('prefers status mapping over message heuristics', () => {
+    const result = classifyLedgerError({
+      return_code: 0x6985,
+      error_message: 'Transport was disconnected',
+    });
+
+    expect(result.kind).toBe('UserRejected');
+  });
+});

--- a/packages/adena-module/src/ledger/ledger-errors.ts
+++ b/packages/adena-module/src/ledger/ledger-errors.ts
@@ -1,0 +1,124 @@
+export type LedgerErrorKind =
+  | 'DeviceLocked'
+  | 'AppNotOpen'
+  | 'UserRejected'
+  | 'Timeout'
+  | 'TransportFailed'
+  | 'Unknown';
+
+export class LedgerError extends Error {
+  public readonly kind: LedgerErrorKind;
+  public readonly cause?: unknown;
+
+  constructor(kind: LedgerErrorKind, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'LedgerError';
+    this.kind = kind;
+    this.cause = cause;
+    Object.setPrototypeOf(this, LedgerError.prototype);
+  }
+}
+
+// Ledger / BOLOS status words used by ledger-cosmos-js and @cosmjs/ledger-amino.
+// Reference: https://developers.ledger.com/docs/device-app/develop/references/status-words
+const STATUS_TO_KIND: Record<number, LedgerErrorKind> = {
+  0x5515: 'DeviceLocked',
+  0x6b0c: 'DeviceLocked',
+  0x6511: 'AppNotOpen',
+  0x6e00: 'AppNotOpen',
+  0x6e01: 'AppNotOpen',
+  0x6985: 'UserRejected',
+  0x6986: 'UserRejected',
+  0x6804: 'Timeout',
+};
+
+function coerceNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function extractStatus(err: unknown): number | undefined {
+  if (err === null || typeof err !== 'object') {
+    return undefined;
+  }
+  const record = err as Record<string, unknown>;
+  return (
+    coerceNumber(record.return_code) ??
+    coerceNumber(record.returnCode) ??
+    coerceNumber(record.statusCode) ??
+    coerceNumber(record.status)
+  );
+}
+
+function extractMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === 'string') {
+    return err;
+  }
+  if (err !== null && typeof err === 'object') {
+    const record = err as Record<string, unknown>;
+    const candidate = record.error_message ?? record.message;
+    if (typeof candidate === 'string') {
+      return candidate;
+    }
+  }
+  return 'Unknown Ledger error';
+}
+
+export function classifyLedgerError(err: unknown): LedgerError {
+  if (err instanceof LedgerError) {
+    return err;
+  }
+
+  const status = extractStatus(err);
+  const message = extractMessage(err);
+
+  if (status !== undefined && STATUS_TO_KIND[status]) {
+    return new LedgerError(STATUS_TO_KIND[status], message, err);
+  }
+
+  const lower = message.toLowerCase();
+
+  if (
+    lower.includes('locked device') ||
+    lower.includes('device is locked') ||
+    lower.includes('device locked')
+  ) {
+    return new LedgerError('DeviceLocked', message, err);
+  }
+
+  if (
+    lower.includes('app does not seem to be open') ||
+    lower.includes('application is not open') ||
+    lower.includes('please open the') ||
+    lower.includes('open the cosmos app')
+  ) {
+    return new LedgerError('AppNotOpen', message, err);
+  }
+
+  if (
+    lower.includes('transaction rejected') ||
+    lower.includes('denied by the user') ||
+    lower.includes('user rejected') ||
+    lower.includes('rejected by user')
+  ) {
+    return new LedgerError('UserRejected', message, err);
+  }
+
+  if (lower.includes('timeout') || lower.includes('timed out')) {
+    return new LedgerError('Timeout', message, err);
+  }
+
+  if (
+    lower.includes('disconnect') ||
+    lower.includes('transport') ||
+    lower.includes('no device selected') ||
+    lower.includes('cannot open device') ||
+    lower.includes('device not found')
+  ) {
+    return new LedgerError('TransportFailed', message, err);
+  }
+
+  return new LedgerError('Unknown', message, err);
+}

--- a/packages/adena-module/src/types/ledger-cosmos-js.d.ts
+++ b/packages/adena-module/src/types/ledger-cosmos-js.d.ts
@@ -1,0 +1,59 @@
+declare module 'ledger-cosmos-js' {
+  import Transport from '@ledgerhq/hw-transport';
+
+  export interface ErrorResponse {
+    readonly return_code: number;
+    readonly error_message: string;
+  }
+
+  export interface AppInfoResponse {
+    readonly appName: string;
+    readonly appVersion: string;
+    readonly return_code: number;
+    readonly error_message: string;
+  }
+
+  export interface VersionResponse {
+    readonly major: number;
+    readonly minor: number;
+    readonly patch: number;
+    readonly test_mode: boolean;
+    readonly device_locked: boolean;
+    readonly return_code: number;
+    readonly error_message: string;
+  }
+
+  export interface PublicKeyResponse {
+    readonly compressed_pk: Buffer;
+    readonly return_code: number;
+    readonly error_message: string;
+  }
+
+  export interface AddressAndPublicKeyResponse {
+    readonly compressed_pk: Buffer;
+    readonly address: string;
+    readonly return_code: number;
+    readonly error_message: string;
+  }
+
+  export interface SignResponse {
+    readonly signature: Buffer;
+    readonly return_code: number;
+    readonly error_message: string;
+  }
+
+  export default class CosmosApp {
+    static getBech32FromPK(hrp: string, pk: Buffer): string;
+
+    constructor(transport: Transport, scrambleKey?: string);
+
+    getVersion: () => Promise<VersionResponse | ErrorResponse>;
+    appInfo: () => Promise<AppInfoResponse | ErrorResponse>;
+    publicKey: (path: Array<number>) => Promise<PublicKeyResponse | ErrorResponse>;
+    showAddressAndPubKey: (
+      path: Array<number>,
+      hrp: string,
+    ) => Promise<AddressAndPublicKeyResponse | ErrorResponse>;
+    sign: (path: Array<number>, message: string) => Promise<SignResponse | ErrorResponse>;
+  }
+}

--- a/packages/adena-module/src/utils/messages.spec.ts
+++ b/packages/adena-module/src/utils/messages.spec.ts
@@ -1,0 +1,60 @@
+import { MsgEndpoint } from '@gnolang/gno-js-client';
+import { PubKeySecp256k1 } from '@gnolang/tm2-js-client';
+
+import { Document, documentToDefaultTx } from './messages';
+
+function makeDocument(): Document {
+  return {
+    msgs: [
+      {
+        type: MsgEndpoint.MSG_SEND,
+        value: {
+          from_address: 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5',
+          to_address: 'g1kcdd3n0d472g2p5l8svyg9t0wq6h5857nq992f',
+          amount: '1000ugnot',
+        },
+      } as unknown as Document['msgs'][number],
+    ],
+    fee: {
+      gas: '200000',
+      amount: [{ denom: 'ugnot', amount: '1000' }],
+    },
+    memo: '',
+    chain_id: 'staging',
+    account_number: '0',
+    sequence: '0',
+  };
+}
+
+describe('documentToDefaultTx', () => {
+  it('leaves pub_key empty when no publicKey is provided (back-compat)', () => {
+    const tx = documentToDefaultTx(makeDocument());
+
+    expect(tx.signatures).toHaveLength(1);
+    const sig = tx.signatures[0];
+    expect(sig.pub_key?.type_url).toBe('');
+    expect(sig.pub_key?.value).toEqual(new Uint8Array());
+    expect(sig.signature).toEqual(new Uint8Array());
+  });
+
+  it('leaves pub_key empty when publicKey is an empty Uint8Array (AirGap case)', () => {
+    const tx = documentToDefaultTx(makeDocument(), new Uint8Array());
+
+    expect(tx.signatures[0].pub_key?.type_url).toBe('');
+    expect(tx.signatures[0].pub_key?.value).toEqual(new Uint8Array());
+  });
+
+  it('wraps the provided compressed pubkey with /tm.PubKeySecp256k1', () => {
+    const pubkey = new Uint8Array(33).fill(0x02);
+    const tx = documentToDefaultTx(makeDocument(), pubkey);
+
+    const sig = tx.signatures[0];
+    expect(sig.pub_key?.type_url).toBe('/tm.PubKeySecp256k1');
+
+    const wrapped = PubKeySecp256k1.encode({ key: pubkey }).finish();
+    expect(Buffer.from(sig.pub_key!.value).equals(Buffer.from(wrapped))).toBe(true);
+
+    // Signature stays empty — simulate does not verify the signature itself.
+    expect(sig.signature).toEqual(new Uint8Array());
+  });
+});

--- a/packages/adena-module/src/utils/messages.ts
+++ b/packages/adena-module/src/utils/messages.ts
@@ -264,8 +264,24 @@ export function documentToTx(document: Document): Tx {
   };
 }
 
-export function documentToDefaultTx(document: Document): Tx {
+export function documentToDefaultTx(document: Document, publicKey?: Uint8Array): Tx {
   const messages: Any[] = document.msgs.map(encodeMessageValue);
+  // gno.land /app/simulate skips signature verification but still validates
+  // pub_key ↔ signer-address derivation. When the caller has a pubkey (e.g. a
+  // Ledger account whose signing requires hardware that isn't attached during
+  // gas estimation), include it so simulate accepts the placeholder tx for
+  // pre-initialized accounts. Callers with no pubkey (AirGap) pass undefined
+  // and keep the historical empty placeholder.
+  const pubKey =
+    publicKey && publicKey.length > 0
+      ? {
+          type_url: '/tm.PubKeySecp256k1',
+          value: PubKeySecp256k1.encode({ key: publicKey }).finish(),
+        }
+      : {
+          type_url: '',
+          value: new Uint8Array(),
+        };
   return {
     messages,
     fee: TxFee.create({
@@ -276,10 +292,7 @@ export function documentToDefaultTx(document: Document): Tx {
     }),
     signatures: [
       {
-        pub_key: {
-          type_url: '',
-          value: new Uint8Array(),
-        },
+        pub_key: pubKey,
         signature: new Uint8Array(),
       },
     ],

--- a/packages/adena-module/src/wallet/keyring/ledger-keyring.spec.ts
+++ b/packages/adena-module/src/wallet/keyring/ledger-keyring.spec.ts
@@ -1,0 +1,80 @@
+import { LedgerConnector } from '@cosmjs/ledger-amino';
+import { generateHDPath } from '@gnolang/tm2-js-client';
+
+import { LedgerError } from '../../ledger/ledger-errors';
+import { LedgerKeyring } from './ledger-keyring';
+
+const BYTES = new TextEncoder().encode('cosmos amino sign doc');
+
+function makeConnector(sign: jest.Mock): LedgerConnector {
+  return {
+    sign,
+    getPubkey: jest.fn(),
+  } as unknown as LedgerConnector;
+}
+
+async function attachConnector(sign: jest.Mock): Promise<LedgerKeyring> {
+  const keyring = new LedgerKeyring({});
+  keyring.setConnector(makeConnector(sign));
+  return keyring;
+}
+
+describe('LedgerKeyring.signRaw', () => {
+  it('returns the 64-byte r||s signature produced by the connector', async () => {
+    const signature = new Uint8Array(64).fill(0x07);
+    const sign = jest.fn().mockResolvedValue(signature);
+    const keyring = await attachConnector(sign);
+
+    const result = await keyring.signRaw(BYTES);
+
+    expect(result).toBe(signature);
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(sign.mock.calls[0][0]).toBe(BYTES);
+    expect(sign.mock.calls[0][1]).toEqual(generateHDPath(0));
+  });
+
+  it('forwards the requested hdPath index to the connector', async () => {
+    const sign = jest.fn().mockResolvedValue(new Uint8Array(64));
+    const keyring = await attachConnector(sign);
+
+    await keyring.signRaw(BYTES, { hdPath: 3 });
+
+    expect(sign.mock.calls[0][1]).toEqual(generateHDPath(3));
+  });
+
+  it('throws LedgerError(TransportFailed) when the connector is not attached', async () => {
+    const keyring = new LedgerKeyring({});
+
+    await expect(keyring.signRaw(BYTES)).rejects.toBeInstanceOf(LedgerError);
+    await expect(keyring.signRaw(BYTES)).rejects.toMatchObject({
+      kind: 'TransportFailed',
+    });
+  });
+
+  it.each<[string, unknown, string]>([
+    ['device locked (0x6b0c)', { return_code: 0x6b0c, error_message: 'locked' }, 'DeviceLocked'],
+    ['user rejected (0x6985)', { return_code: 0x6985, error_message: 'denied' }, 'UserRejected'],
+    [
+      'cosmjs "Please open the Cosmos Ledger app" message',
+      new Error('Please open the Cosmos Ledger app on your Ledger device.'),
+      'AppNotOpen',
+    ],
+    ['transport disconnect', new Error('Transport was disconnected'), 'TransportFailed'],
+  ])('classifies %s as %s', async (_label, thrown, expectedKind) => {
+    const sign = jest.fn().mockRejectedValue(thrown);
+    const keyring = await attachConnector(sign);
+
+    await expect(keyring.signRaw(BYTES)).rejects.toMatchObject({
+      name: 'LedgerError',
+      kind: expectedKind,
+    });
+  });
+
+  it('preserves existing LedgerError instances without re-wrapping', async () => {
+    const original = new LedgerError('UserRejected', 'user tapped reject');
+    const sign = jest.fn().mockRejectedValue(original);
+    const keyring = await attachConnector(sign);
+
+    await expect(keyring.signRaw(BYTES)).rejects.toBe(original);
+  });
+});

--- a/packages/adena-module/src/wallet/keyring/ledger-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/ledger-keyring.ts
@@ -8,6 +8,7 @@ import {
 } from '@gnolang/tm2-js-client';
 import { v4 as uuidv4 } from 'uuid';
 
+import { LedgerError, classifyLedgerError } from '../../ledger/ledger-errors';
 import { Document, makeSignedTx, useTm2Wallet } from './../..';
 import { Keyring, KeyringData, KeyringType, SignRawOptions } from './keyring';
 
@@ -40,14 +41,20 @@ export class LedgerKeyring implements Keyring {
     };
   }
 
-  async signRaw(_bytes: Uint8Array, _opts?: SignRawOptions): Promise<Uint8Array> {
-    // Ledger hardware enforces "trust display": the device only signs documents
-    // it can parse and render to the user. Raw opaque bytes would be blind
-    // signing, which the device refuses. Phase 7 replaces this stub with a
-    // device-friendly path (signAmino/signDirect) alongside Cosmos-app routing.
-    throw new Error(
-      `Ledger signRaw is not implemented yet (Phase 7) (keyring ${this.id})`,
-    );
+  async signRaw(bytes: Uint8Array, opts?: SignRawOptions): Promise<Uint8Array> {
+    // Cosmos AMINO path: the device signs the UTF-8 JSON sign doc that cosmjs
+    // forwards verbatim to the Ledger Cosmos app. @cosmjs/ledger-amino's
+    // connector.sign() handles the DER → 64-byte r||s conversion and the
+    // verifyCosmosAppIsOpen pre-flight check internally.
+    if (!this.connector) {
+      throw new LedgerError('TransportFailed', 'Ledger connector is not attached');
+    }
+    const hdPath = generateHDPath(opts?.hdPath ?? 0);
+    try {
+      return await this.connector.sign(bytes, hdPath);
+    } catch (err) {
+      throw classifyLedgerError(err);
+    }
   }
 
   async sign(provider: Provider, document: Document, hdPath: number = 0) {

--- a/packages/adena-module/src/wallet/keyring/sign-raw.spec.ts
+++ b/packages/adena-module/src/wallet/keyring/sign-raw.spec.ts
@@ -3,7 +3,6 @@ import { Secp256k1, Secp256k1Signature } from '@cosmjs/crypto';
 import { sha256 } from '../../crypto';
 import { AddressKeyring } from './address-keyring';
 import { HDWalletKeyring } from './hd-wallet-keyring';
-import { LedgerKeyring } from './ledger-keyring';
 import { MultisigKeyring } from './multisig-keyring';
 import { PrivateKeyKeyring } from './private-key-keyring';
 import { Web3AuthKeyring } from './web3-auth-keyring';
@@ -91,11 +90,6 @@ describe('Keyring.signRaw — private-key keyrings', () => {
 });
 
 describe('Keyring.signRaw — non-signing keyrings', () => {
-  it('LedgerKeyring throws Phase 7 message', async () => {
-    const keyring = new LedgerKeyring({});
-    await expect(keyring.signRaw(BYTES)).rejects.toThrow(/Phase 7/);
-  });
-
   it('AddressKeyring throws AIRGAP message', async () => {
     const keyring = await AddressKeyring.fromAddress(
       'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5',

--- a/packages/adena-module/src/wallet/wallet.ts
+++ b/packages/adena-module/src/wallet/wallet.ts
@@ -448,14 +448,15 @@ export class AdenaWallet implements Wallet {
     if (!account) {
       throw new Error('Account not found');
     }
-    const keyring = this._keyrings.find((k) => k.id === account.keyringId);
-    if (!keyring) {
-      throw new Error('Keyring not found');
-    }
+    // estimateCosmosFee only needs a public key to populate the simulate tx's
+    // AuthInfo — no signing. Reading publicKey straight from the account
+    // avoids the keyring lookup, which is unnecessary for a read-only gas
+    // query and brittle for Ledger accounts whose persisted keyring id can
+    // drift from account.keyringId (connect-ledger wizard bug).
     const hdPath = hasHDPath(account) ? account.hdPath : undefined;
     return estimateCosmosFee({
       document,
-      keyring,
+      publicKey: account.publicKey,
       cosmosProvider,
       hdPath,
       simulateFee,


### PR DESCRIPTION
## Summary

- Implement `LedgerKeyring.signRaw` and dispatch the Ledger keyring through the Cosmos sign pipeline.
- Add Ledger app guard utilities (`ledger-app-utils`) and typed error classification (`ledger-errors`).
- Estimate Cosmos gas without an attached keyring — `estimateCosmosFee` now takes the signer's `publicKey` directly so post-restart Ledger accounts can simulate.
- Preserve Ledger keyring id when reconnecting in the connect-ledger wizard so persisted accounts stay linked to a real keyring.
- Add `TransferLedgerCosmosLoading` route with typed error screens; `transfer-summary` routes Ledger × Cosmos to it.

## Test plan

- [ ] `cd packages/adena-module && npx jest ledger keyring/ledger-keyring keyring/sign-raw`
- [ ] `cd packages/adena-extension && npm test`
- [ ] Manual (Ledger Cosmos app): send ATONE / PHOTON — sign and broadcast succeed
- [ ] Manual: cancel on device, app-not-open, wrong-app — each maps to the typed reject screen

## Related

- Base: `feature/ADN-743` (rebased on top of merged #821 / #818 / #820 / #822 / #824 / #825).
- Ledger × Cosmos uses `signCosmosAmino` directly rather than the `signCosmos` dispatcher introduced in #822, because the Cosmos Ledger app only renders AMINO JSON; routing Ledger through the dispatcher would route to DIRECT on chains whose `signing.preferred` is DIRECT and break the device flow.
- Follow-up PRs in the same stack: ADN-756 / 760.