### PR TITLE
ADN-759: harden Send amount input against unintended value changes

### DIFF
--- a/packages/adena-extension/src/components/pages/transfer-input/balance-input/balance-input.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-input/balance-input/balance-input.tsx
@@ -27,11 +27,15 @@ const BalanceInput: React.FC<BalanceInputProps> = ({
           min='0'
           value={amount}
           autoComplete='off'
+          // Whitelist digits + a single decimal point. Catches scientific
+          // notation, signs, and other inputs that bypass onKeyDown via paste
+          // or drag-and-drop.
           onChange={(event): void => {
-            if (event.target.value.startsWith('-')) {
+            const value = event.target.value;
+            if (!/^[0-9]*\.?[0-9]*$/.test(value)) {
               return;
             }
-            onChangeAmount(event.target.value);
+            onChangeAmount(value);
           }}
           onKeyDown={(event): void => {
             if (

--- a/packages/adena-extension/src/components/pages/transfer-input/balance-input/balance-input.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-input/balance-input/balance-input.tsx
@@ -34,7 +34,13 @@ const BalanceInput: React.FC<BalanceInputProps> = ({
             onChangeAmount(event.target.value);
           }}
           onKeyDown={(event): void => {
-            if (event.key === '-' || event.key === 'e' || event.key === 'E') {
+            if (
+              event.key === '-' ||
+              event.key === 'e' ||
+              event.key === 'E' ||
+              event.key === 'ArrowUp' ||
+              event.key === 'ArrowDown'
+            ) {
               event.preventDefault();
             }
           }}

--- a/packages/adena-extension/src/components/pages/transfer-input/balance-input/balance-input.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-input/balance-input/balance-input.tsx
@@ -24,9 +24,21 @@ const BalanceInput: React.FC<BalanceInputProps> = ({
         <input
           className='amount-input'
           type='number'
+          min='0'
           value={amount}
           autoComplete='off'
-          onChange={(event): void => onChangeAmount(event.target.value)}
+          onChange={(event): void => {
+            if (event.target.value.startsWith('-')) {
+              return;
+            }
+            onChangeAmount(event.target.value);
+          }}
+          onKeyDown={(event): void => {
+            if (event.key === '-' || event.key === 'e' || event.key === 'E') {
+              event.preventDefault();
+            }
+          }}
+          onWheel={(event): void => event.currentTarget.blur()}
           placeholder='Amount'
         />
         <span className='denom'>{denom}</span>


### PR DESCRIPTION
## Summary

Tighten the Send amount `<input type="number">` so the value can only change through deliberate typing of digits and the decimal point. Previously, the field accepted negative values, exponent notation, arrow-key increments, and mouse-wheel scrolling — each of which produced a broadcast-unsafe amount or surprised the user mid-form.

- Add `min="0"` and reject any `onChange` whose value starts with `-`.
- `onKeyDown` swallows `-`, `e`, `E`, `ArrowUp`, `ArrowDown` so the field never enters scientific notation or steps the value via keyboard.
- `onWheel` blurs the field, neutralizing the browser's default wheel-to-step behavior without disabling page scroll.

## Test plan

- [ ] `cd packages/adena-extension && yarn build`
- [ ] Manual: open Send → amount field
  - Press `-`, `e`, `E`, ArrowUp, ArrowDown — value does not change
  - Scroll the mouse wheel while focused on the field — value does not change (field blurs instead)
  - Paste `-123` — field does not accept the leading minus

## Related

- UX hardening only; one file (`balance-input.tsx`). Independent of the in-flight Cosmos stack — safe to land on `main` directly.