### PR TITLE
chore: bump package version to v1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adena-wallet",
-  "version": "1.18.6",
+  "version": "1.19.0",
   "description": "Adena Wallet",
   "license": "Adena License",
   "private": true,

--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adena-extension",
-  "version": "1.18.6",
+  "version": "1.19.0",
   "private": true,
   "description": "Adena is a friendly browser extension wallet for the Gno.land blockchain.",
   "scripts": {

--- a/packages/adena-extension/public/manifest.json
+++ b/packages/adena-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Adena",
   "description": "Adena is a friendly browser extension wallet for the gno.land blockchain.",
   "manifest_version": 3,
-  "version": "1.18.6",
+  "version": "1.19.0",
   "action": {
     "default_icon": {
       "16": "icons/icon16.png",

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adena-module",
   "private": true,
-  "version": "1.18.6",
+  "version": "1.19.0",
   "description": "Adena's Wallet",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
Bumps `adena-wallet`, `adena-extension`, `adena-module`, and the extension manifest from `1.18.6` to `1.19.0` ahead of the multichain-support release.

## Test plan
- [ ] Confirm `package.json`, `packages/adena-extension/package.json`, `packages/adena-extension/public/manifest.json`, and `packages/adena-module/package.json` all report `1.19.0`
- [ ] Build the extension and check the version surfaces correctly in `chrome://extensions`