### PR TITLE
fix: allow self-sends for non-GRC20 tokens and align Send summary card with design

### DIFF
--- a/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary-address/transfer-summary-address.styles.ts
+++ b/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary-address/transfer-summary-address.styles.ts
@@ -5,8 +5,7 @@ export const TransferSummaryAddressWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding: 0 18px;
-  ${fonts.body1Reg};
+  ${fonts.body2Reg};
   background-color: ${getTheme('neutral', '_9')};
   border-radius: 18px;
 
@@ -17,6 +16,7 @@ export const TransferSummaryAddressWrapper = styled.div`
     align-items: center;
     width: 100%;
     height: 46px;
+    padding: 0 18px;
     border-top: 1px solid ${getTheme('neutral', '_6')};
   }
 
@@ -41,15 +41,10 @@ export const TransferSummaryAddressWrapper = styled.div`
     min-height: 46px;
     height: auto;
     align-items: flex-start;
-    padding: 11px 0;
-  }
-
-  .memo-row .label {
-    line-height: 24px;
+    padding: 12px 18px;
   }
 
   .memo-row .memo-value {
-    line-height: 24px;
     word-break: break-word;
     white-space: pre-wrap;
   }

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-input/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-input/index.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { isNativeTokenModel } from '@common/validation/validation-token';
+import { isGRC20TokenModel } from '@common/validation/validation-token';
 import {
   CHAIN_DISPLAY_NAME,
   chainOptionsFromRegistry,
@@ -250,7 +250,7 @@ const TransferInputContainer: React.FC = () => {
     }
     const validAddress =
       addressBookInput.validateAddressBookInput() &&
-      (isNativeTokenModel(tokenMetainfo) || (await addressBookInput.validateEqualAddress()));
+      (!isGRC20TokenModel(tokenMetainfo) || (await addressBookInput.validateEqualAddress()));
     const validBalance = balanceInput.validateBalanceInput();
     if (validAddress && validBalance) {
       saveHistoryData();


### PR DESCRIPTION
## Summary

Two unrelated regressions surfaced after the AtomOne/Photon work landed on the Send flow. Bundled here because both are small, both touch only the Send-screen popup, and both are visible the moment a user opens the Cosmos send flow.

### 1. Self-address validation blocks Cosmos sends with the wrong message

`transfer-input/index.tsx` gated `validateEqualAddress()` on `isNativeTokenModel(...)`, which is true only for `gno-native`. After `cosmos-native` routed through the same page (PR #821 / ADN-751), sending ATONE or PHOTON to one's own address fires the GRC20-only branch and shows _"You can't send GRC20 tokens to your own address"_. Cosmos chains routinely allow self-sends and the message is wrong.

Inverted the gate to run the check only for GRC20 tokens (`isGRC20TokenModel`). GRC20 behavior and message are unchanged; native, cosmos-native, and future IBC token types skip the check. Same fix prevents the same regression when ibc-native / ibc-tokens flows land.

### 2. Send summary address card style drifts from the design

Two issues on the To / Network / Memo card:
- Wrapper used `padding: 0 18px`, so the `.row` `border-top` dividers stopped short of the card edges and looked truncated against the rounded background.
- Body text rendered at 16px (`body1Reg`); the design intent and visual balance call for 14px (`body2Reg`).

Moved the 18px horizontal padding from the wrapper onto each row so the dividers now span edge-to-edge of the card. Switched the card font token to `body2Reg`. Dropped the redundant `.memo-row .label` and `.memo-row .memo-value` `line-height: 24px` overrides — they were only there to match the old `body1Reg` line-height, and `body2Reg`'s default 21px now applies cleanly.

The summary card is shared between Gno and Cosmos send flows, so both screens get the fix.

## Test plan

- [ ] AtomOne account → Send → enter own atone address → Next proceeds, summary renders, broadcast succeeds.
- [ ] Photon (uphoton) → same self-send scenario.
- [ ] Regression: GRC20 token → own address still blocked with the existing message.
- [ ] Regression: GNOT (gno-native) → self-send still passes through as before.
- [ ] Visual check: To / Network / Memo card on the Send summary screen renders with 14px text and edge-to-edge row dividers, matching the Figma spec.
- [ ] NFT transfer (`nft-transfer-input`) self-address behavior unchanged (intentionally not touched — GRC721 is Gno-only).