### PR TITLE
security: address Findings #01–#06 from security review

### DIFF
--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -93,6 +93,7 @@
     "qrcode.react": "3.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-idle-timer": "5.7.2",
     "react-router-dom": "6.22.1",
     "recoil": "0.7.7",
     "styled-components": "6.1.14",

--- a/packages/adena-extension/src/App/use-app.ts
+++ b/packages/adena-extension/src/App/use-app.ts
@@ -1,13 +1,17 @@
-import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect } from 'react';
+import { useIdleTimer } from 'react-idle-timer';
 import { useLocation } from 'react-router-dom';
 
-import { ADENA_WALLET_EXTENSION_ID } from '@common/constants/storage.constant';
+import { isAutoLockTriggeredMessage } from '@common/utils/auto-lock-timer';
+import { CommandMessage } from '@inject/message/command-message';
 import { useAccountName } from '@hooks/use-account-name';
 import { useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { useNetwork } from '@hooks/use-network';
 import useScrollHistory from '@hooks/use-scroll-history';
 import { useTokenMetainfo } from '@hooks/use-token-metainfo';
+import { useWallet } from '@hooks/use-wallet';
 
 const useApp = (): void => {
   const { wallet } = useWalletContext();
@@ -17,14 +21,49 @@ const useApp = (): void => {
   const { initTokenMetainfos } = useTokenMetainfo();
   const { pathname, key } = useLocation();
   const { scrollMove } = useScrollHistory();
+  const { lockedWallet } = useWallet();
+  const queryClient = useQueryClient();
 
+  // Listen for the AUTO_LOCK_TRIGGERED broadcast from background. Without
+  // this, the popup keeps rendering the unlocked screen until the next user
+  // interaction nudges react-query to refetch — invalidating the cached
+  // `wallet/locked` query forces an immediate re-evaluation, which the
+  // existing routing logic in use-init-wallet picks up.
   useEffect(() => {
-    try {
-      chrome?.runtime?.connect({ name: ADENA_WALLET_EXTENSION_ID });
-    } catch (error) {
-      console.warn('Failed to connect to chrome runtime:', error);
-    }
+    const handler = (message: unknown): void => {
+      if (isAutoLockTriggeredMessage(message)) {
+        queryClient.invalidateQueries({ queryKey: ['wallet/locked'] });
+      }
+    };
+    chrome.runtime.onMessage.addListener(handler);
+    return (): void => {
+      chrome.runtime.onMessage.removeListener(handler);
+    };
+  }, [queryClient]);
+
+  const sendActivityPing = useCallback(() => {
+    chrome.runtime
+      .sendMessage(CommandMessage.command('resetAutoLockTimer'))
+      .catch(() => undefined);
   }, []);
+
+  // Send an activity ping whenever a real user input is detected. The throttle
+  // collapses bursts (mouse moves, keystrokes) into one message every 5s so we
+  // don't flood the background with sendMessage calls.
+  useIdleTimer({
+    throttle: 5000,
+    onAction: sendActivityPing,
+    disabled: lockedWallet !== false,
+  });
+
+  // Mounting any UI surface (popup, separate window, web page) counts as
+  // activity, so reset the timer on first render too — otherwise a user who
+  // opens the popup without moving the mouse would see no reset event.
+  useEffect(() => {
+    if (lockedWallet === false) {
+      sendActivityPing();
+    }
+  }, [lockedWallet, sendActivityPing]);
 
   useEffect(() => {
     checkNetworkState();

--- a/packages/adena-extension/src/background.ts
+++ b/packages/adena-extension/src/background.ts
@@ -405,6 +405,13 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  // Reject messages that did not originate from this extension's own contexts
+  // (background, popup, options, content scripts). External extensions must
+  // use chrome.runtime.onMessageExternal instead.
+  if (sender.id !== chrome.runtime.id) {
+    return;
+  }
+
   // Handle ping from content script for connection check
   if (message?.type === 'ping') {
     sendResponse({ status: 'pong' });

--- a/packages/adena-extension/src/background.ts
+++ b/packages/adena-extension/src/background.ts
@@ -1,8 +1,8 @@
 import { AlarmKey, SCHEDULE_ALARMS } from '@common/constants/alarm-key.constant';
-import { ADENA_WALLET_EXTENSION_ID } from '@common/constants/storage.constant';
 import { TransactionEventStore } from '@common/event-store';
 import { MemoryProvider } from '@common/provider/memory/memory-provider';
 import { ChromeLocalStorage } from '@common/storage';
+import { AUTO_LOCK_TRIGGERED_MESSAGE } from '@common/utils/auto-lock-timer';
 import { CommandHandler } from '@inject/message/command-handler';
 import {
   CommandMessage,
@@ -329,42 +329,22 @@ chrome.action.onClicked.addListener(async () => {
   });
 });
 
-chrome.runtime.onConnect.addListener(async (port) => {
-  if (port.name !== ADENA_WALLET_EXTENSION_ID) {
-    return;
-  }
-
-  inMemoryProvider.addConnection();
-  inMemoryProvider.updateExpiredTimeBy(null);
-
-  port.onDisconnect.addListener(async () => {
-    inMemoryProvider.removeConnection();
-
-    if (!inMemoryProvider.isActive()) {
-      const expiredTime = new Date().getTime() + inMemoryProvider.getExpiredPasswordDurationTime();
-      inMemoryProvider.updateExpiredTimeBy(expiredTime);
-
-      console.info('Password Expired time:', new Date(expiredTime));
-    }
-  });
-});
-
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   try {
     const currentTime = new Date().getTime();
     chrome.storage.local.set({ SESSION: currentTime });
 
     switch (alarm?.name) {
-      case AlarmKey.EXPIRED_PASSWORD:
-        if (!inMemoryProvider.isExpired(currentTime)) {
-          return;
-        }
-
+      case AlarmKey.AUTO_LOCK_TIMER:
         await chrome.storage.session.clear();
         await clearInMemoryKey(inMemoryProvider);
-
-        inMemoryProvider.updateExpiredTimeBy(null);
-        console.info('Password Expired');
+        // Tell any open UI surface that auto-lock just fired so it can
+        // invalidate cached lock state and route to Login immediately.
+        // The send rejects when no UI is listening — that's expected.
+        chrome.runtime
+          .sendMessage({ type: AUTO_LOCK_TRIGGERED_MESSAGE })
+          .catch(() => undefined);
+        console.info('Auto-lock fired');
         break;
       default:
         break;

--- a/packages/adena-extension/src/common/constants/alarm-key.constant.ts
+++ b/packages/adena-extension/src/common/constants/alarm-key.constant.ts
@@ -1,5 +1,5 @@
 export enum AlarmKey {
-  EXPIRED_PASSWORD = 'EXPIRED_PASSWORD',
+  AUTO_LOCK_TIMER = 'AUTO_LOCK_TIMER',
   WAKE_ALARM = 'WAKE_ALARM',
   WAKE_ALARM_DELAY_15S = 'WAKE_ALARM_DELAY_15S',
   WAKE_ALARM_DELAY_30S = 'WAKE_ALARM_DELAY_30S',
@@ -7,7 +7,6 @@ export enum AlarmKey {
 }
 
 export const SCHEDULE_ALARMS: { key: string; periodInMinutes: number; delay: number }[] = [
-  { key: AlarmKey.EXPIRED_PASSWORD, periodInMinutes: 1, delay: 0 },
   { key: AlarmKey.WAKE_ALARM, periodInMinutes: 1, delay: 0 },
   { key: AlarmKey.WAKE_ALARM_DELAY_15S, periodInMinutes: 1, delay: 15_000 },
   { key: AlarmKey.WAKE_ALARM_DELAY_30S, periodInMinutes: 1, delay: 30_000 },

--- a/packages/adena-extension/src/common/constants/command-key.constant.ts
+++ b/packages/adena-extension/src/common/constants/command-key.constant.ts
@@ -4,6 +4,8 @@ export const COMMAND_KEYS = {
   clearEncryptKey: 'CLEAR_ENCRYPT_KEY',
   clearPopup: 'CLEAR_POPUP',
   checkMetadata: 'CHECK_METADATA',
+  resetAutoLockTimer: 'RESET_AUTO_LOCK_TIMER',
+  updateAutoLockTimer: 'UPDATE_AUTO_LOCK_TIMER',
 } as const;
 export type CommandKeyType = keyof typeof COMMAND_KEYS;
 export type CommandValueType = (typeof COMMAND_KEYS)[keyof typeof COMMAND_KEYS];

--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.spec.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.spec.ts
@@ -1,0 +1,52 @@
+describe('GNO_CONNECT_ALLOWED_ORIGINS', () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  const loadAllowlist = (): readonly string[] => {
+    let result: readonly string[] = [];
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      result = require('./gno-connect-allowlist.constant').GNO_CONNECT_ALLOWED_ORIGINS;
+    });
+    return result;
+  };
+
+  it('production build trusts only https chains.json origins', () => {
+    process.env.NODE_ENV = 'production';
+    const result = loadAllowlist();
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        'https://gno.land',
+        'https://betanet.testnets.gno.land',
+        'https://staging.gno.land',
+        'https://test13.testnets.gno.land',
+      ]),
+    );
+    expect(result.some((url) => url.startsWith('http://'))).toBe(false);
+  });
+
+  it('development build also trusts loopback origins from chains.json', () => {
+    process.env.NODE_ENV = 'development';
+    const result = loadAllowlist();
+
+    expect(result).toEqual(expect.arrayContaining(['https://gno.land', 'http://127.0.0.1:8888']));
+  });
+
+  it('test environment behaves like development (non-production)', () => {
+    process.env.NODE_ENV = 'test';
+    const result = loadAllowlist();
+
+    expect(result).toContain('http://127.0.0.1:8888');
+  });
+
+  it('contains no duplicates', () => {
+    process.env.NODE_ENV = 'production';
+    const result = loadAllowlist();
+
+    expect(new Set(result).size).toBe(result.length);
+  });
+});

--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
@@ -1,0 +1,10 @@
+// dApp origin allowlist for gnoconnect meta-tag based RPC injection.
+// Pages served from these origins may declare their preferred RPC and chain ID
+// via <meta name="gnoconnect:rpc"> / <meta name="gnoconnect:chainid">.
+// Initial set is sourced from chains.json gnoUrl values.
+export const GNO_CONNECT_ALLOWED_ORIGINS: readonly string[] = [
+    'https://gno.land',
+    'https://betanet.testnets.gno.land',
+    'https://staging.gno.land',
+    'https://test13.testnets.gno.land',
+] as const;

--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
@@ -1,10 +1,17 @@
-// dApp origin allowlist for gnoconnect meta-tag based RPC injection.
-// Pages served from these origins may declare their preferred RPC and chain ID
-// via <meta name="gnoconnect:rpc"> / <meta name="gnoconnect:chainid">.
-// Initial set is sourced from chains.json gnoUrl values.
-export const GNO_CONNECT_ALLOWED_ORIGINS: readonly string[] = [
-    'https://gno.land',
-    'https://betanet.testnets.gno.land',
-    'https://staging.gno.land',
-    'https://test13.testnets.gno.land',
-] as const;
+import CHAIN_DATA from '@resources/chains/chains.json';
+
+// dApp origin allowlist for gnoconnect meta-tag RPC injection.
+// Derived from chains.json gnoUrl. Loopback origins (127.0.0.1, localhost)
+// are trusted only in development builds — in production any process
+// holding the local port (other dev servers, malicious postinstall, etc.)
+// could otherwise inject RPC endpoints into the wallet flow.
+const isDevelopmentBuild = process.env.NODE_ENV !== 'production';
+
+const isLoopbackOrigin = (url: string): boolean =>
+  url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost');
+
+export const GNO_CONNECT_ALLOWED_ORIGINS: readonly string[] = CHAIN_DATA.map(
+  (chain) => chain.gnoUrl,
+)
+  .filter((url): url is string => Boolean(url))
+  .filter((url) => url.startsWith('https://') || (isDevelopmentBuild && isLoopbackOrigin(url)));

--- a/packages/adena-extension/src/common/provider/memory/memory-provider.ts
+++ b/packages/adena-extension/src/common/provider/memory/memory-provider.ts
@@ -1,10 +1,5 @@
-const EXPIRED_PASSWORD_DURATION_MIN = 5;
-
 export class MemoryProvider {
   private memory: Map<string, any> = new Map();
-  private activeConnections = 0;
-  private expiredPasswordDuration = EXPIRED_PASSWORD_DURATION_MIN;
-  private expiredTime: number | null = null;
 
   public get = <T = any>(key: string): T | null => {
     if (!this.memory.get(key)) {
@@ -20,41 +15,5 @@ export class MemoryProvider {
 
   public async init(): Promise<void> {
     this.memory = new Map();
-  }
-
-  public addConnection(): void {
-    this.activeConnections++;
-  }
-
-  public removeConnection(): void {
-    this.activeConnections--;
-  }
-
-  public isActive(): boolean {
-    return this.activeConnections > 0;
-  }
-
-  public getExpiredPasswordDurationTime(): number {
-    return this.expiredPasswordDuration * 60 * 1000;
-  }
-
-  public setExpiredPasswordDurationMinutes(duration: number): void {
-    this.expiredPasswordDuration = duration;
-  }
-
-  public isExpired(time: number): boolean {
-    if (this.isActive()) {
-      return false;
-    }
-
-    if (!this.expiredTime) {
-      return false;
-    }
-
-    return this.expiredTime < time;
-  }
-
-  public updateExpiredTimeBy(time: number | null): void {
-    this.expiredTime = time;
   }
 }

--- a/packages/adena-extension/src/common/storage/chrome-local-storage.ts
+++ b/packages/adena-extension/src/common/storage/chrome-local-storage.ts
@@ -22,7 +22,8 @@ type StorageKeyTypes =
   | 'ADD_ACCOUNT_GUIDE_CONFIRM_DATE'
   | 'ACCOUNT_GRC721_COLLECTIONS'
   | 'ACCOUNT_GRC721_PINNED_PACKAGES'
-  | 'KDF_SALT';
+  | 'KDF_SALT'
+  | 'AUTO_LOCK_TIMEOUT_MINUTES';
 
 // List of all available storage keys
 const StorageKeys: StorageKeyTypes[] = [
@@ -45,6 +46,7 @@ const StorageKeys: StorageKeyTypes[] = [
   'ACCOUNT_GRC721_COLLECTIONS',
   'ACCOUNT_GRC721_PINNED_PACKAGES',
   'KDF_SALT',
+  'AUTO_LOCK_TIMEOUT_MINUTES',
 ];
 
 // Function to validate if a given key is a valid storage key

--- a/packages/adena-extension/src/common/storage/chrome-local-storage.ts
+++ b/packages/adena-extension/src/common/storage/chrome-local-storage.ts
@@ -11,7 +11,6 @@ type StorageKeyTypes =
   | 'CURRENT_NETWORK_ID'
   | 'CURRENT_ATOMONE_NETWORK_ID'
   | 'SERIALIZED'
-  | 'ENCRYPTED_STORED_PASSWORD'
   | 'CURRENT_ACCOUNT_ID'
   | 'ACCOUNT_NAMES'
   | 'ESTABLISH_SITES'
@@ -22,7 +21,8 @@ type StorageKeyTypes =
   | 'WALLET_CREATION_GUIDE_CONFIRM_DATE'
   | 'ADD_ACCOUNT_GUIDE_CONFIRM_DATE'
   | 'ACCOUNT_GRC721_COLLECTIONS'
-  | 'ACCOUNT_GRC721_PINNED_PACKAGES';
+  | 'ACCOUNT_GRC721_PINNED_PACKAGES'
+  | 'KDF_SALT';
 
 // List of all available storage keys
 const StorageKeys: StorageKeyTypes[] = [
@@ -33,7 +33,6 @@ const StorageKeys: StorageKeyTypes[] = [
   'CURRENT_NETWORK_ID',
   'CURRENT_ATOMONE_NETWORK_ID',
   'SERIALIZED',
-  'ENCRYPTED_STORED_PASSWORD',
   'CURRENT_ACCOUNT_ID',
   'ACCOUNT_NAMES',
   'ESTABLISH_SITES',
@@ -45,6 +44,7 @@ const StorageKeys: StorageKeyTypes[] = [
   'ADD_ACCOUNT_GUIDE_CONFIRM_DATE',
   'ACCOUNT_GRC721_COLLECTIONS',
   'ACCOUNT_GRC721_PINNED_PACKAGES',
+  'KDF_SALT',
 ];
 
 // Function to validate if a given key is a valid storage key
@@ -96,6 +96,11 @@ export class ChromeLocalStorage implements Storage {
   public updatePassword = async (password: string): Promise<StorageModelLatest | null> => {
     const current = await this.migrator.getCurrent();
     this.current = await this.migrator.migrate(current, password);
+    if (this.current) {
+      await this.storage.set({
+        [ChromeLocalStorage.StorageKey]: JSON.stringify(this.current),
+      });
+    }
     return this.current;
   };
 

--- a/packages/adena-extension/src/common/utils/address-chain.spec.ts
+++ b/packages/adena-extension/src/common/utils/address-chain.spec.ts
@@ -1,0 +1,29 @@
+import { createChainRegistry } from 'adena-module';
+import { inferChainGroup } from './address-chain';
+
+describe('inferChainGroup', () => {
+  const registry = createChainRegistry();
+
+  it('returns "gno" for a gno bech32 address (g1...)', () => {
+    expect(inferChainGroup('g1abc1234567890abcdefghijklmnopqr', registry)).toBe('gno');
+  });
+
+  it('returns "atomone" for an atomone bech32 address (atone1...)', () => {
+    expect(inferChainGroup('atone1abc1234567890abcdefghijklmnopqrstuvwx', registry)).toBe(
+      'atomone',
+    );
+  });
+
+  it('falls back to "gno" for an unknown chain prefix', () => {
+    expect(inferChainGroup('cosmos1abc1234567890abcdefghijklmnopqrstuvwx', registry)).toBe('gno');
+  });
+
+  it('falls back to "gno" for an empty string', () => {
+    expect(inferChainGroup('', registry)).toBe('gno');
+  });
+
+  it('falls back to "gno" for partial input that has not reached a separator yet', () => {
+    expect(inferChainGroup('at', registry)).toBe('gno');
+    expect(inferChainGroup('atone', registry)).toBe('gno');
+  });
+});

--- a/packages/adena-extension/src/common/utils/address-chain.ts
+++ b/packages/adena-extension/src/common/utils/address-chain.ts
@@ -1,0 +1,15 @@
+import type { ChainRegistry } from 'adena-module';
+
+// Returns the chainGroup that owns the given bech32 address prefix.
+// Sorts registered chains by prefix length (longest first) so a chain
+// with a longer prefix wins over one whose prefix is a substring of it.
+// Falls back to 'gno' for unknown or partial input so the form keeps a
+// usable default while the user is still typing.
+export function inferChainGroup(address: string, chainRegistry: ChainRegistry): string {
+  const matched = chainRegistry
+    .listChains()
+    .slice()
+    .sort((a, b) => b.bech32Prefix.length - a.bech32Prefix.length)
+    .find((chain) => address.startsWith(chain.bech32Prefix + '1'));
+  return matched?.chainGroup ?? 'gno';
+}

--- a/packages/adena-extension/src/common/utils/auto-lock-timer.spec.ts
+++ b/packages/adena-extension/src/common/utils/auto-lock-timer.spec.ts
@@ -1,0 +1,82 @@
+import { readAutoLockMinutes } from './auto-lock-timer';
+
+type StorageGet = (key: string) => Promise<{ ADENA_DATA?: string | object }>;
+
+const mockChromeStorage = (get: StorageGet): void => {
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: {
+      local: { get },
+    },
+  };
+};
+
+const dataBlob = (autoLockValue: unknown): string =>
+  JSON.stringify({ data: { AUTO_LOCK_TIMEOUT_MINUTES: autoLockValue } });
+
+describe('readAutoLockMinutes', () => {
+  afterEach(() => {
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+  });
+
+  it('returns the default 5 minutes when ADENA_DATA is absent', async () => {
+    mockChromeStorage(async () => ({}));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('returns the default when the AUTO_LOCK_TIMEOUT_MINUTES key is missing', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: JSON.stringify({ data: {} }) }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('returns the default when the value is an empty string', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('') }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('returns the configured number for valid stringified integers', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('15') }));
+
+    expect(await readAutoLockMinutes()).toBe(15);
+  });
+
+  it('returns 0 to honor the explicit "auto-lock disabled" setting', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('0') }));
+
+    expect(await readAutoLockMinutes()).toBe(0);
+  });
+
+  it('falls back to the default for non-numeric strings', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('abc') }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('falls back to the default for negative values', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('-3') }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('falls back to the default when ADENA_DATA contains malformed JSON', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: 'not-json' }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('falls back to the default when chrome.storage rejects', async () => {
+    mockChromeStorage(() => Promise.reject(new Error('storage unavailable')));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('accepts an already-parsed object payload', async () => {
+    mockChromeStorage(async () => ({
+      ADENA_DATA: { data: { AUTO_LOCK_TIMEOUT_MINUTES: '30' } },
+    }));
+
+    expect(await readAutoLockMinutes()).toBe(30);
+  });
+});

--- a/packages/adena-extension/src/common/utils/auto-lock-timer.ts
+++ b/packages/adena-extension/src/common/utils/auto-lock-timer.ts
@@ -1,0 +1,94 @@
+import { AlarmKey } from '@common/constants/alarm-key.constant';
+
+const STORAGE_KEY = 'ADENA_DATA';
+const DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES = 5;
+
+// Broadcast type used by background to notify any open UI surface that the
+// auto-lock alarm just fired. The UI reacts by invalidating the cached
+// `wallet/locked` query so the lock screen renders immediately, instead of
+// waiting for the next user interaction to trigger a refetch.
+export const AUTO_LOCK_TRIGGERED_MESSAGE = 'AUTO_LOCK_TRIGGERED';
+
+export interface AutoLockTriggeredMessage {
+  type: typeof AUTO_LOCK_TRIGGERED_MESSAGE;
+}
+
+export const isAutoLockTriggeredMessage = (
+  message: unknown,
+): message is AutoLockTriggeredMessage => {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    (message as { type?: unknown }).type === AUTO_LOCK_TRIGGERED_MESSAGE
+  );
+};
+
+/**
+ * Read the user-configured auto-lock duration from chrome.storage.local.
+ *
+ * Bypasses the StorageManager / ChromeLocalStorage abstraction on purpose:
+ * those go through the storage migrator on every access, which is
+ * heavyweight for a hot path that fires on every UI activity ping in the
+ * background service worker. We only need a single key lookup here, so a
+ * raw read against the ADENA_DATA blob is the right tradeoff.
+ *
+ * Returns DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES when the value is missing or unparsable.
+ * Returns 0 when the user has explicitly disabled auto-lock.
+ */
+export async function readAutoLockMinutes(): Promise<number> {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY);
+    const raw = result?.[STORAGE_KEY];
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    const value = parsed?.data?.AUTO_LOCK_TIMEOUT_MINUTES;
+    if (value === null || value === undefined || value === '') {
+      return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+    }
+    const minutes = Number(value);
+    if (!Number.isFinite(minutes) || minutes < 0) {
+      return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+    }
+    return minutes;
+  } catch {
+    return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+  }
+}
+
+/**
+ * Wallet is considered unlocked when both encrypted password fragments
+ * exist in chrome.storage.session.
+ */
+export async function isWalletUnlocked(): Promise<boolean> {
+  try {
+    const session = await chrome.storage.session.get(['ENCRYPTED_KEY', 'ENCRYPTED_PASSWORD']);
+    return !!session.ENCRYPTED_KEY && !!session.ENCRYPTED_PASSWORD;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Replace any pending auto-lock alarm with a fresh one matching the user's
+ * configured duration. Skips creation when the wallet is locked or the
+ * duration is zero (auto-lock disabled).
+ *
+ * chrome.alarms persists across service worker restarts and laptop sleep,
+ * so a single one-shot alarm is enough — no in-memory bookkeeping needed.
+ */
+export async function resetAutoLockAlarm(): Promise<void> {
+  await chrome.alarms.clear(AlarmKey.AUTO_LOCK_TIMER);
+  if (!(await isWalletUnlocked())) {
+    return;
+  }
+  const minutes = await readAutoLockMinutes();
+  if (minutes <= 0) {
+    return;
+  }
+  // Chrome enforces a 1-minute floor on delayInMinutes in production builds.
+  const delayInMinutes = Math.max(minutes, 1);
+  chrome.alarms.create(AlarmKey.AUTO_LOCK_TIMER, { delayInMinutes });
+}
+
+export async function clearAutoLockAlarm(): Promise<void> {
+  await chrome.alarms.clear(AlarmKey.AUTO_LOCK_TIMER);
+}

--- a/packages/adena-extension/src/common/utils/crypto-utils.ts
+++ b/packages/adena-extension/src/common/utils/crypto-utils.ts
@@ -1,15 +1,4 @@
 import { CommandMessage, CommandMessageData } from '@inject/message/command-message';
-import CryptoJS from 'crypto-js';
-
-const salt = 'W9+fs3FJ9p5KdR1XzQy2A6ZT4vjN8LvM9J8pVZmN9rU=';
-
-export const encryptSha256Password = (password: string, salt = ''): string => {
-  return CryptoJS.SHA256(salt + password).toString();
-};
-
-export const encryptWalletPassword = (password: string): string => {
-  return encryptSha256Password(password, salt);
-};
 
 // Sends a message to the background script to encrypt a password
 export const encryptPassword = async (

--- a/packages/adena-extension/src/components/pages/web/main-account-header/index.tsx
+++ b/packages/adena-extension/src/components/pages/web/main-account-header/index.tsx
@@ -22,11 +22,13 @@ const StyledBlank = styled(Row)`
 
 export type WebMainAccountHeaderProps = {
   account: Account | null;
+  displayName?: string;
   onClickGoBack: () => void;
 };
 
 export const WebMainAccountHeader = ({
   account,
+  displayName,
   onClickGoBack,
 }: WebMainAccountHeaderProps): ReactElement => {
   const theme = useTheme();
@@ -59,7 +61,7 @@ export const WebMainAccountHeader = ({
           <WebText
             type='title4'
           >
-            {account.name}
+            {displayName || account.name}
           </WebText>
           <WebText
             type='body4'

--- a/packages/adena-extension/src/hooks/certify/use-auto-lock-timer.ts
+++ b/packages/adena-extension/src/hooks/certify/use-auto-lock-timer.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES,
+  MAX_AUTO_LOCK_TIMEOUT_MINUTES,
+} from '@repositories/wallet';
+import useAppNavigate from '@hooks/use-app-navigate';
+import { useAdenaContext } from '@hooks/use-context';
+
+export type UseAutoLockTimerReturn = {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  errorMessage: string;
+  isLoading: boolean;
+  saveDisabled: boolean;
+  onSave: () => Promise<void>;
+  onCancel: () => void;
+};
+
+const RANGE_ERROR_MESSAGE = `Please set a time between 0 ~ ${MAX_AUTO_LOCK_TIMEOUT_MINUTES} minutes (a day).`;
+
+const validate = (raw: string): { minutes: number | null; errorMessage: string } => {
+  const trimmed = raw.trim();
+  // Empty / non-digit inputs are rejected at the input layer, but guard here
+  // anyway — the input filter is the UX, this is the safety net.
+  if (trimmed === '' || !/^\d+$/.test(trimmed)) {
+    return { minutes: null, errorMessage: RANGE_ERROR_MESSAGE };
+  }
+  const minutes = Number(trimmed);
+  if (!Number.isFinite(minutes) || minutes < 0 || minutes > MAX_AUTO_LOCK_TIMEOUT_MINUTES) {
+    return { minutes: null, errorMessage: RANGE_ERROR_MESSAGE };
+  }
+  return { minutes, errorMessage: '' };
+};
+
+export const useAutoLockTimer = (): UseAutoLockTimerReturn => {
+  const { walletService } = useAdenaContext();
+  const { goBack } = useAppNavigate();
+
+  const [value, setValue] = useState<string>(`${DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES}`);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    walletService
+      .getAutoLockTimeoutMinutes()
+      .then((minutes) => {
+        if (!cancelled) {
+          setValue(`${minutes}`);
+          setIsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [walletService]);
+
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    // Only accept digit-only strings (or empty for backspacing). Reject any
+    // keystroke that introduces "-", ".", "e", letters, etc. so the user
+    // cannot enter a non-natural-number in the first place.
+    if (next !== '' && !/^\d+$/.test(next)) {
+      return;
+    }
+    setValue(next);
+    setErrorMessage('');
+  }, []);
+
+  const onSave = useCallback(async () => {
+    const { minutes, errorMessage: validationError } = validate(value);
+    if (minutes === null) {
+      setErrorMessage(validationError);
+      return;
+    }
+    await walletService.updateAutoLockTimeoutMinutes(minutes);
+    goBack();
+  }, [value, walletService, goBack]);
+
+  const { errorMessage: previewError } = validate(value);
+  const saveDisabled = isLoading || previewError !== '';
+
+  return {
+    value,
+    onChange,
+    errorMessage,
+    isLoading,
+    saveDisabled,
+    onSave,
+    onCancel: goBack,
+  };
+};

--- a/packages/adena-extension/src/hooks/certify/use-change-password.ts
+++ b/packages/adena-extension/src/hooks/certify/use-change-password.ts
@@ -1,5 +1,4 @@
 import { PasswordValidationError } from '@common/errors';
-import { encryptWalletPassword } from '@common/utils/crypto-utils';
 import { evaluatePassword, EvaluatePasswordResult } from '@common/utils/password-utils';
 import {
   validateEqualsChangePassword,
@@ -109,8 +108,10 @@ export const useChangePassword = (): UseChangePasswordReturn => {
     let isValid = true;
     let errorMessage = '';
     try {
-      const encryptedCurrentPassword = encryptWalletPassword(currentPassword);
-      validateInvalidPassword(encryptedCurrentPassword, storedPassword);
+      const isValid = await walletService.equalsPassword(currentPassword);
+      if (!isValid) {
+        throw new PasswordValidationError('INVALID_PASSWORD');
+      }
     } catch (error) {
       isValid = false;
       if (error instanceof PasswordValidationError) {

--- a/packages/adena-extension/src/hooks/use-address-book-input.ts
+++ b/packages/adena-extension/src/hooks/use-address-book-input.ts
@@ -1,6 +1,7 @@
 import { validateCosmosAddress } from 'adena-module';
 import { useCallback, useEffect, useState } from 'react';
 
+import { inferChainGroup } from '@common/utils/address-chain';
 import { formatAddress, formatNickname } from '@common/utils/client-utils';
 import { AddressBookItem } from '@repositories/wallet';
 
@@ -36,7 +37,7 @@ export type UseAddressBookInputHookReturn = {
 };
 
 export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHookReturn => {
-  const { addressBookService } = useAdenaContext();
+  const { addressBookService, chainRegistry } = useAdenaContext();
   const { wallet } = useWalletContext();
   const { getCurrentAddress } = useCurrentAccount();
   const chain = useChain(chainGroup);
@@ -75,13 +76,14 @@ export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHook
       if (address !== currentAddress) {
         currentAccountInfos.push({
           addressBookId: account.id,
-          name: formatNickname(accountNames[account.id], 12),
+          name: formatNickname(accountNames[account.id] || account.name, 12),
           description: `(${formatAddress(address)})`,
         });
       }
     }
     const addressBookInfos = addressBooks
       .filter((addressBook) => addressBook.address !== currentAddress)
+      .filter((addressBook) => inferChainGroup(addressBook.address, chainRegistry) === chainGroup)
       .map((addressBook) => {
         return {
           addressBookId: addressBook.id,
@@ -91,7 +93,7 @@ export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHook
       });
 
     return [...currentAccountInfos, ...addressBookInfos];
-  }, [addressBooks, wallet?.accounts, addressPrefix]);
+  }, [addressBooks, wallet?.accounts, addressPrefix, chainGroup, accountNames]);
 
   const getSelectedAddressBookInfos = useCallback(() => {
     if (selectedAddressBook === null) {
@@ -161,14 +163,14 @@ export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHook
         const address = await selectedAccount.getAddress(addressPrefix);
         setSelectedAddressBook({
           id: selectedAccount.id,
-          name: selectedAccount.name,
+          name: accountNames[selectedAccount.id] || selectedAccount.name,
           address,
           createdAt: `${new Date().getTime()}`,
         });
         return;
       }
     },
-    [addressBooks, wallet?.accounts, addressPrefix],
+    [addressBooks, wallet?.accounts, addressPrefix, accountNames],
   );
 
   const validateAddressBookInput = useCallback(() => {

--- a/packages/adena-extension/src/hooks/web/common/use-create-password-screen.ts
+++ b/packages/adena-extension/src/hooks/web/common/use-create-password-screen.ts
@@ -1,4 +1,3 @@
-import { AdenaWallet } from 'adena-module';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { PasswordValidationError } from '@common/errors';
@@ -13,6 +12,7 @@ import { useAdenaContext } from '@hooks/use-context';
 import useIndicatorStep, {
   UseIndicatorStepReturn,
 } from '@hooks/wallet/broadcast-transaction/use-indicator-step';
+import { pendingWalletStore } from '@services/wallet/pending-wallet-store';
 import { RoutePath } from '@types';
 
 export type UseCreatePasswordScreenReturn = {
@@ -48,8 +48,9 @@ export type UseCreatePasswordScreenReturn = {
 export const useCreatePasswordScreen = (): UseCreatePasswordScreenReturn => {
   const { walletService, accountService } = useAdenaContext();
   const indicatorInfo = useIndicatorStep({});
-  const { navigate, params } = useAppNavigate<RoutePath.WebCreatePassword>();
+  const { navigate } = useAppNavigate<RoutePath.WebCreatePassword>();
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const consumedRef = useRef(false);
   const [inputs, setInputs] = useState({
     password: '',
     confirmPassword: '',
@@ -132,18 +133,23 @@ export const useCreatePasswordScreen = (): UseCreatePasswordScreenReturn => {
     setInputs({ password: '', confirmPassword: '' });
   };
 
-  const _saveWalletByPassword = async (password: string): Promise<void> => {
-    const { serializedWallet } = params;
-    const wallet = AdenaWallet.fromJSON(serializedWallet);
-    await walletService.saveWallet(wallet, password);
-    await accountService.changeCurrentAccount(wallet.currentAccount);
-    await setInputs({ password: '', confirmPassword: '' });
-
-    // Clear the wallet payload from history.state so the plaintext keyring
-    // JSON does not linger in the back-stack after it has been committed to
-    // encrypted storage. Receiver-side cleanup covers all flows that reach
-    // this screen (create / import / google-login / airgap / ledger).
-    window.history.replaceState({}, '');
+  const _saveWalletByPassword = async (password: string): Promise<boolean> => {
+    const wallet = pendingWalletStore.consume();
+    if (!wallet) {
+      navigate(RoutePath.WebWalletCreate, { replace: true });
+      return false;
+    }
+    consumedRef.current = true;
+    try {
+      await walletService.saveWallet(wallet, password);
+      await accountService.changeCurrentAccount(wallet.currentAccount);
+      return true;
+    } finally {
+      // Zeroize Uint8Array seed/entropy/privateKey buffers via sodium.memzero,
+      // covering both success and failure paths.
+      wallet.destroy();
+      setInputs({ password: '', confirmPassword: '' });
+    }
   };
 
   const onChangePassword = useCallback(
@@ -164,8 +170,10 @@ export const useCreatePasswordScreen = (): UseCreatePasswordScreenReturn => {
       return;
     }
 
-    _saveWalletByPassword(password).then(() => {
-      navigate(RoutePath.WebWalletAllSet);
+    _saveWalletByPassword(password).then((saved) => {
+      if (saved) {
+        navigate(RoutePath.WebWalletAllSet);
+      }
     });
   };
 
@@ -194,6 +202,26 @@ export const useCreatePasswordScreen = (): UseCreatePasswordScreenReturn => {
       inputRef.current.focus();
     }
   }, [inputRef]);
+
+  // Guard against direct entry / refresh: if the entry hook has not parked a
+  // wallet in the store, redirect to the start of the create flow rather than
+  // rendering an unsavable password form.
+  useEffect(() => {
+    if (!pendingWalletStore.has()) {
+      navigate(RoutePath.WebWalletCreate, { replace: true });
+    }
+  }, []);
+
+  // Wipe on unmount when the user leaves without committing — covers back
+  // navigation, manual route change, and tab close. Skipped if save already
+  // consumed the wallet (destroy ran in the finally block).
+  useEffect(() => {
+    return (): void => {
+      if (!consumedRef.current) {
+        pendingWalletStore.clear();
+      }
+    };
+  }, []);
 
   return {
     indicatorInfo,

--- a/packages/adena-extension/src/hooks/web/common/use-create-password-screen.ts
+++ b/packages/adena-extension/src/hooks/web/common/use-create-password-screen.ts
@@ -138,6 +138,12 @@ export const useCreatePasswordScreen = (): UseCreatePasswordScreenReturn => {
     await walletService.saveWallet(wallet, password);
     await accountService.changeCurrentAccount(wallet.currentAccount);
     await setInputs({ password: '', confirmPassword: '' });
+
+    // Clear the wallet payload from history.state so the plaintext keyring
+    // JSON does not linger in the back-stack after it has been committed to
+    // encrypted storage. Receiver-side cleanup covers all flows that reach
+    // this screen (create / import / google-login / airgap / ledger).
+    window.history.replaceState({}, '');
   };
 
   const onChangePassword = useCallback(

--- a/packages/adena-extension/src/hooks/web/common/use-create-password-screen.ts
+++ b/packages/adena-extension/src/hooks/web/common/use-create-password-screen.ts
@@ -134,7 +134,7 @@ export const useCreatePasswordScreen = (): UseCreatePasswordScreenReturn => {
 
   const _saveWalletByPassword = async (password: string): Promise<void> => {
     const { serializedWallet } = params;
-    const wallet = await AdenaWallet.deserialize(serializedWallet, '');
+    const wallet = AdenaWallet.fromJSON(serializedWallet);
     await walletService.saveWallet(wallet, password);
     await accountService.changeCurrentAccount(wallet.currentAccount);
     await setInputs({ password: '', confirmPassword: '' });

--- a/packages/adena-extension/src/hooks/web/connect-ledger/use-select-account-screen.ts
+++ b/packages/adena-extension/src/hooks/web/connect-ledger/use-select-account-screen.ts
@@ -12,6 +12,7 @@ import { RoutePath } from '@types';
 import { useChain } from '@hooks/use-chain';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import useAppNavigate from '@hooks/use-app-navigate';
+import { pendingWalletStore } from '@services/wallet/pending-wallet-store';
 import { useQuery } from '@tanstack/react-query';
 import useIndicatorStep, {
   UseIndicatorStepReturn,
@@ -159,13 +160,8 @@ const useSelectAccountScreen = (): useSelectAccountScreenReturn => {
         keyrings: [keyring.toData()],
         currentAccountId: resultSavedAccounts[0]?.id,
       });
-      const serializedWallet = newWallet.toJSON();
-      navigate(RoutePath.WebCreatePassword, {
-        state: {
-          serializedWallet,
-          stepLength: 5,
-        },
-      });
+      pendingWalletStore.set(newWallet);
+      navigate(RoutePath.WebCreatePassword);
     }
   };
 

--- a/packages/adena-extension/src/hooks/web/connect-ledger/use-select-account-screen.ts
+++ b/packages/adena-extension/src/hooks/web/connect-ledger/use-select-account-screen.ts
@@ -159,9 +159,10 @@ const useSelectAccountScreen = (): useSelectAccountScreenReturn => {
         keyrings: [keyring.toData()],
         currentAccountId: resultSavedAccounts[0]?.id,
       });
+      const serializedWallet = newWallet.toJSON();
       navigate(RoutePath.WebCreatePassword, {
         state: {
-          serializedWallet: await newWallet.serialize(''),
+          serializedWallet,
           stepLength: 5,
         },
       });

--- a/packages/adena-extension/src/hooks/web/google-login/use-google-login-screen.ts
+++ b/packages/adena-extension/src/hooks/web/google-login/use-google-login-screen.ts
@@ -5,6 +5,7 @@ import { GoogleTorusSigner } from 'adena-torus-signin/src';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
+import { pendingWalletStore } from '@services/wallet/pending-wallet-store';
 import { RoutePath } from '@types';
 import useQuestionnaire from '../use-questionnaire';
 import useIndicatorStep, {
@@ -110,13 +111,8 @@ const useGoogleLoginScreen = (): UseGoogleLoginReturn => {
   const _createGoogleAccount = useCallback(
     async (privateKey: string) => {
       const createdWallet = await AdenaWallet.createByWeb3Auth(privateKey);
-      const serializedWallet = createdWallet.toJSON();
-      navigate(RoutePath.WebCreatePassword, {
-        state: {
-          serializedWallet,
-          stepLength: indicatorInfo.stepLength,
-        },
-      });
+      pendingWalletStore.set(createdWallet);
+      navigate(RoutePath.WebCreatePassword);
     },
     [navigate],
   );

--- a/packages/adena-extension/src/hooks/web/google-login/use-google-login-screen.ts
+++ b/packages/adena-extension/src/hooks/web/google-login/use-google-login-screen.ts
@@ -110,7 +110,7 @@ const useGoogleLoginScreen = (): UseGoogleLoginReturn => {
   const _createGoogleAccount = useCallback(
     async (privateKey: string) => {
       const createdWallet = await AdenaWallet.createByWeb3Auth(privateKey);
-      const serializedWallet = await createdWallet.serialize('');
+      const serializedWallet = createdWallet.toJSON();
       navigate(RoutePath.WebCreatePassword, {
         state: {
           serializedWallet,

--- a/packages/adena-extension/src/hooks/web/setup-airgap/use-setup-airgap-screen.ts
+++ b/packages/adena-extension/src/hooks/web/setup-airgap/use-setup-airgap-screen.ts
@@ -130,8 +130,7 @@ const useSetupAirgapScreen = (): UseSetupAirgapScreenReturn => {
 
   const _createAddressAccount = useCallback(async () => {
     const createdWallet = await AdenaWallet.createByAddress(address);
-    const serializedWallet = await createdWallet.serialize('');
-    return serializedWallet;
+    return createdWallet.toJSON();
   }, [address, walletService, indicatorInfo]);
 
   const addAccount = useCallback(async () => {

--- a/packages/adena-extension/src/hooks/web/setup-airgap/use-setup-airgap-screen.ts
+++ b/packages/adena-extension/src/hooks/web/setup-airgap/use-setup-airgap-screen.ts
@@ -11,6 +11,7 @@ import useAppNavigate from '@hooks/use-app-navigate';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { useChain } from '@hooks/use-chain';
+import { pendingWalletStore } from '@services/wallet/pending-wallet-store';
 import { RoutePath } from '@types';
 import { useLoadAccounts } from '@hooks/use-load-accounts';
 import { waitForRun } from '@common/utils/timeout-utils';
@@ -129,9 +130,8 @@ const useSetupAirgapScreen = (): UseSetupAirgapScreenReturn => {
   }, [address, walletService]);
 
   const _createAddressAccount = useCallback(async () => {
-    const createdWallet = await AdenaWallet.createByAddress(address);
-    return createdWallet.toJSON();
-  }, [address, walletService, indicatorInfo]);
+    return AdenaWallet.createByAddress(address);
+  }, [address]);
 
   const addAccount = useCallback(async () => {
     if (blockedEvent) {
@@ -144,13 +144,9 @@ const useSetupAirgapScreen = (): UseSetupAirgapScreenReturn => {
       navigate(RoutePath.WebAccountAddedComplete);
     } else {
       setSetupAirgapState('LOADING');
-      const serializedWallet = await waitForRun<string>(_createAddressAccount);
-      navigate(RoutePath.WebCreatePassword, {
-        state: {
-          serializedWallet,
-          stepLength: indicatorInfo.stepLength,
-        },
-      });
+      const createdWallet = await waitForRun<AdenaWallet>(_createAddressAccount);
+      pendingWalletStore.set(createdWallet);
+      navigate(RoutePath.WebCreatePassword);
     }
     setBlockedEvent(false);
   }, [blockedEvent, walletService, _addAddressAccount, _createAddressAccount]);

--- a/packages/adena-extension/src/hooks/web/use-wallet-create-screen.ts
+++ b/packages/adena-extension/src/hooks/web/use-wallet-create-screen.ts
@@ -8,6 +8,7 @@ import { useCurrentAccount } from '@hooks/use-current-account';
 import useIndicatorStep, {
   UseIndicatorStepReturn,
 } from '@hooks/wallet/broadcast-transaction/use-indicator-step';
+import { pendingWalletStore } from '@services/wallet/pending-wallet-store';
 import { RoutePath } from '@types';
 import useQuestionnaire from './use-questionnaire';
 
@@ -100,10 +101,8 @@ const useWalletCreateScreen = (): UseWalletCreateReturn => {
         const createdWallet = await AdenaWallet.createByMnemonic(rawSeeds);
         rawSeeds = '';
 
-        const serializedWallet = createdWallet.toJSON();
-        navigate(RoutePath.WebCreatePassword, {
-          state: { serializedWallet, stepLength: indicatorInfo.stepLength },
-        });
+        pendingWalletStore.set(createdWallet);
+        navigate(RoutePath.WebCreatePassword);
       }
     }
   }, [step, ableToSkipQuestionnaire, wallet, indicatorInfo]);

--- a/packages/adena-extension/src/hooks/web/use-wallet-create-screen.ts
+++ b/packages/adena-extension/src/hooks/web/use-wallet-create-screen.ts
@@ -100,7 +100,7 @@ const useWalletCreateScreen = (): UseWalletCreateReturn => {
         const createdWallet = await AdenaWallet.createByMnemonic(rawSeeds);
         rawSeeds = '';
 
-        const serializedWallet = await createdWallet.serialize('');
+        const serializedWallet = createdWallet.toJSON();
         navigate(RoutePath.WebCreatePassword, {
           state: { serializedWallet, stepLength: indicatorInfo.stepLength },
         });

--- a/packages/adena-extension/src/hooks/web/use-wallet-import-screen.ts
+++ b/packages/adena-extension/src/hooks/web/use-wallet-import-screen.ts
@@ -45,8 +45,7 @@ const isValidMnemonic = (mnemonic: string): boolean => {
 const createSerializedWalletWithMnemonic = (mnemonic: string): Promise<string | null> => {
   return waitForRun<string>(async () => {
     const createdWallet = await AdenaWallet.createByMnemonic(mnemonic);
-    const serializedWallet = await createdWallet.serialize('');
-    return serializedWallet;
+    return createdWallet.toJSON();
   }).catch(() => null);
 };
 
@@ -58,8 +57,7 @@ const createSerializedWalletWithPrivateKeyKeyring = (keyring: Keyring): Promise<
     createdWallet.addAccount(account);
     createdWallet.addKeyring(keyring);
 
-    const serializedWallet = await createdWallet.serialize('');
-    return serializedWallet;
+    return createdWallet.toJSON();
   }).catch(() => null);
 };
 

--- a/packages/adena-extension/src/hooks/web/use-wallet-import-screen.ts
+++ b/packages/adena-extension/src/hooks/web/use-wallet-import-screen.ts
@@ -13,6 +13,7 @@ import useAppNavigate from '@hooks/use-app-navigate';
 import useIndicatorStep, {
   UseIndicatorStepReturn,
 } from '@hooks/wallet/broadcast-transaction/use-indicator-step';
+import { pendingWalletStore } from '@services/wallet/pending-wallet-store';
 import { ImportWalletType, RoutePath } from '@types';
 
 import { stringFromBase64, stringToBase64 } from '@common/utils/encoding-util';
@@ -42,22 +43,21 @@ const isValidMnemonic = (mnemonic: string): boolean => {
   return true;
 };
 
-const createSerializedWalletWithMnemonic = (mnemonic: string): Promise<string | null> => {
-  return waitForRun<string>(async () => {
-    const createdWallet = await AdenaWallet.createByMnemonic(mnemonic);
-    return createdWallet.toJSON();
+const createWalletWithMnemonic = (mnemonic: string): Promise<AdenaWallet | null> => {
+  return waitForRun<AdenaWallet>(async () => {
+    return AdenaWallet.createByMnemonic(mnemonic);
   }).catch(() => null);
 };
 
-const createSerializedWalletWithPrivateKeyKeyring = (keyring: Keyring): Promise<string | null> => {
-  return waitForRun<string>(async () => {
+const createWalletWithPrivateKeyKeyring = (keyring: Keyring): Promise<AdenaWallet | null> => {
+  return waitForRun<AdenaWallet>(async () => {
     const account = await SingleAccount.createBy(keyring, 'Account');
-    const createdWallet = await new AdenaWallet();
+    const createdWallet = new AdenaWallet();
     createdWallet.currentAccountId = account.id;
     createdWallet.addAccount(account);
     createdWallet.addKeyring(keyring);
 
-    return createdWallet.toJSON();
+    return createdWallet;
   }).catch(() => null);
 };
 
@@ -131,7 +131,7 @@ const useWalletImportScreen = (): UseWalletImportReturn => {
         });
       }
     } else if (step === 'SET_SEED_PHRASE') {
-      let serializedWallet: string | null = '';
+      let createdWallet: AdenaWallet | null = null;
 
       const isSeed = inputType === '12seeds' || inputType === '24seeds';
       if (isSeed) {
@@ -141,7 +141,7 @@ const useWalletImportScreen = (): UseWalletImportReturn => {
         }
 
         setStep('LOADING');
-        serializedWallet = await createSerializedWalletWithMnemonic(decodedInputValue);
+        createdWallet = await createWalletWithMnemonic(decodedInputValue);
         setInputValue('');
       } else {
         let keyring = await PrivateKeyKeyring.fromPrivateKeyStr(decodedInputValue).catch(
@@ -153,20 +153,18 @@ const useWalletImportScreen = (): UseWalletImportReturn => {
         }
 
         setStep('LOADING');
-        serializedWallet = await createSerializedWalletWithPrivateKeyKeyring(keyring);
+        createdWallet = await createWalletWithPrivateKeyKeyring(keyring);
         keyring = null;
         setInputValue('');
       }
 
-      if (!serializedWallet) {
+      if (!createdWallet) {
         navigate(RoutePath.WebNotFound);
         return;
       }
 
-      navigate(RoutePath.WebCreatePassword, {
-        state: { serializedWallet, stepLength: indicatorInfo.stepLength },
-        replace: true,
-      });
+      pendingWalletStore.set(createdWallet);
+      navigate(RoutePath.WebCreatePassword, { replace: true });
     }
   }, [step, inputType, inputValue, ableToSkipQuestionnaire]);
 

--- a/packages/adena-extension/src/hooks/web/wallet-export/use-wallet-export-screen.ts
+++ b/packages/adena-extension/src/hooks/web/wallet-export/use-wallet-export-screen.ts
@@ -6,7 +6,6 @@ import {
   WALLET_EXPORT_TYPE_STORAGE_KEY,
 } from '@common/constants/storage.constant';
 import { AdenaStorage } from '@common/storage';
-import { encryptWalletPassword } from '@common/utils/crypto-utils';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import useIndicatorStep, {
@@ -120,10 +119,7 @@ const useWalletExportScreen = (): UseWalletExportReturn => {
         return false;
       }
 
-      return walletService
-        .loadWalletPassword()
-        .then((storedPassword) => storedPassword === encryptWalletPassword(password))
-        .catch(() => false);
+      return walletService.equalsPassword(password).catch(() => false);
     },
     [exportType, walletService],
   );
@@ -133,9 +129,8 @@ const useWalletExportScreen = (): UseWalletExportReturn => {
       if (exportType === 'NONE' || !account) {
         return;
       }
-      const encryptedWalletPassword = encryptWalletPassword(password);
       const wallet = await walletService
-        .loadWalletWithPassword(encryptedWalletPassword)
+        .loadWalletWithPassword(password)
         .catch((e) => {
           console.warn(e);
           return null;

--- a/packages/adena-extension/src/inject/cosmos/offline-signer.spec.ts
+++ b/packages/adena-extension/src/inject/cosmos/offline-signer.spec.ts
@@ -39,7 +39,6 @@ beforeEach(() => {
 describe('decodeCosmosKey', () => {
   it('decodes base64 pubKey and address back to Uint8Array', () => {
     const wire: SerializedCosmosKey = {
-      name: 'account',
       algo: 'secp256k1',
       pubKey: bytesToBase64([1, 2, 3]),
       address: bytesToBase64([4, 5]),
@@ -66,7 +65,6 @@ describe('createOfflineSigner', () => {
     mockExecutorInstance.getCosmosKey.mockResolvedValue({
       status: 'success',
       data: {
-        name: 'account',
         algo: 'secp256k1',
         pubKey: bytesToBase64([7, 8, 9]),
         address: bytesToBase64([10, 11]),

--- a/packages/adena-extension/src/inject/cosmos/offline-signer.ts
+++ b/packages/adena-extension/src/inject/cosmos/offline-signer.ts
@@ -18,7 +18,6 @@ import { AdenaExecutor } from '../executor/executor';
 
 export function decodeCosmosKey(wire: SerializedCosmosKey): CosmosKey {
   return {
-    name: wire.name,
     algo: wire.algo,
     bech32Address: wire.bech32Address,
     isNanoLedger: wire.isNanoLedger,

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -124,7 +124,8 @@ export class CommandHandler {
     const switchNetworkResponse = await executor.switchNetwork(gnoConnectInfo.chainId);
     if (
       switchNetworkResponse.type !== WalletResponseSuccessType.SWITCH_NETWORK_SUCCESS &&
-      switchNetworkResponse.type !== WalletResponseFailureType.REDUNDANT_CHANGE_REQUEST
+      switchNetworkResponse.type !== WalletResponseFailureType.REDUNDANT_CHANGE_REQUEST &&
+      switchNetworkResponse.type !== WalletResponseFailureType.UNADDED_NETWORK
     ) {
       console.info('response: ', switchNetworkResponse);
       return;

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -18,6 +18,7 @@ import {
   GnoArgumentInfo,
   GnoConnectInfo,
   GnoMessageInfo,
+  isAllowedGnoConnectOrigin,
   parseGnoConnectInfo,
   parseGnoMessageInfo,
 } from './methods/gno-connect';
@@ -95,6 +96,11 @@ export class CommandHandler {
     }
 
     const currentUrl = window?.location?.href || '';
+    const currentOrigin = window?.location?.origin || '';
+    if (!isAllowedGnoConnectOrigin(currentOrigin)) {
+      return;
+    }
+
     const gnoMessageInfo = message.data.gnoMessageInfo || parseGnoMessageInfo(currentUrl);
     const gnoConnectInfo = message.data.gnoConnectInfo || parseGnoConnectInfo();
 
@@ -118,8 +124,7 @@ export class CommandHandler {
     const switchNetworkResponse = await executor.switchNetwork(gnoConnectInfo.chainId);
     if (
       switchNetworkResponse.type !== WalletResponseSuccessType.SWITCH_NETWORK_SUCCESS &&
-      switchNetworkResponse.type !== WalletResponseFailureType.REDUNDANT_CHANGE_REQUEST &&
-      switchNetworkResponse.type !== WalletResponseFailureType.UNADDED_NETWORK
+      switchNetworkResponse.type !== WalletResponseFailureType.REDUNDANT_CHANGE_REQUEST
     ) {
       console.info('response: ', switchNetworkResponse);
       return;

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -4,6 +4,7 @@ import { GnoDocumentInfo } from '@common/provider/gno';
 import { GnoProvider } from '@common/provider/gno/gno-provider';
 import { isInterRealmParameter } from '@common/provider/gno/utils';
 import { MemoryProvider } from '@common/provider/memory/memory-provider';
+import { clearAutoLockAlarm, resetAutoLockAlarm } from '@common/utils/auto-lock-timer';
 import { AdenaExecutor } from '@inject/executor';
 import { ContractMessage, TransactionParams } from '@inject/types';
 import { CheckMetadataMessageData, CommandMessageData } from './command-message';
@@ -75,6 +76,20 @@ export class CommandHandler {
         sendResponse(makeSuccessResponse(message));
         return;
       }
+
+      if (message.command === 'resetAutoLockTimer') {
+        await resetAutoLockAlarm();
+        sendResponse(makeSuccessResponse(message));
+        return;
+      }
+
+      if (message.command === 'updateAutoLockTimer') {
+        // The new duration is already persisted by the service layer; the
+        // helper re-reads from storage so we don't need to trust the payload.
+        await resetAutoLockAlarm();
+        sendResponse(makeSuccessResponse(message));
+        return;
+      }
     } catch (error) {
       console.info(error);
       sendResponse(makeInternalErrorResponse(message));
@@ -82,6 +97,7 @@ export class CommandHandler {
 
     if (message.command === 'clearPopup') {
       await clearInMemoryKey(inMemoryProvider);
+      await clearAutoLockAlarm();
       await clearPopup();
       sendResponse({ ...message, code: 200 });
       return;

--- a/packages/adena-extension/src/inject/message/methods/cosmos.ts
+++ b/packages/adena-extension/src/inject/message/methods/cosmos.ts
@@ -235,7 +235,6 @@ export const cosmosGetKey = async (
     // reconstitutes them before the dApp observes the Key.
     sendResponse(
       createCosmosResponse(CosmosResponseExecuteType.GET_COSMOS_KEY, 'success', message.key, {
-        name: currentAccount.name,
         algo: 'secp256k1',
         pubKey: bytesToBase64(Array.from(compressedPubKey)),
         address: bytesToBase64(Array.from(addressBytes)),

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
@@ -1,4 +1,8 @@
-import { GnoMessageInfo, parseGnoMessageInfo } from './gno-connect';
+import {
+  GnoMessageInfo,
+  isAllowedGnoConnectOrigin,
+  parseGnoMessageInfo,
+} from './gno-connect';
 
 describe('parseGnoMessageInfo', () => {
   describe('URL parsing tests', () => {
@@ -223,5 +227,35 @@ describe('parseGnoMessageInfo', () => {
       const result = parseGnoMessageInfo(url);
       console.log(result, 'result');
     });
+  });
+});
+
+describe('isAllowedGnoConnectOrigin', () => {
+  it('returns true for registered gno.land origins', () => {
+    expect(isAllowedGnoConnectOrigin('https://gno.land')).toBe(true);
+    expect(isAllowedGnoConnectOrigin('https://betanet.testnets.gno.land')).toBe(true);
+    expect(isAllowedGnoConnectOrigin('https://staging.gno.land')).toBe(true);
+    expect(isAllowedGnoConnectOrigin('https://test13.testnets.gno.land')).toBe(true);
+  });
+
+  it('returns false for unregistered origins', () => {
+    expect(isAllowedGnoConnectOrigin('https://attacker.example')).toBe(false);
+    expect(isAllowedGnoConnectOrigin('https://evil.gno.land.attacker.example')).toBe(false);
+  });
+
+  it('rejects scheme mismatches', () => {
+    expect(isAllowedGnoConnectOrigin('http://gno.land')).toBe(false);
+  });
+
+  it('rejects origins with explicit non-default port', () => {
+    expect(isAllowedGnoConnectOrigin('https://gno.land:8443')).toBe(false);
+  });
+
+  it('rejects empty origin', () => {
+    expect(isAllowedGnoConnectOrigin('')).toBe(false);
+  });
+
+  it('rejects subdomain takeover patterns', () => {
+    expect(isAllowedGnoConnectOrigin('https://malicious.gno.land')).toBe(false);
   });
 });

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.ts
@@ -1,3 +1,4 @@
+import { GNO_CONNECT_ALLOWED_ORIGINS } from '@common/constants/gno-connect-allowlist.constant';
 import {
   GNO_CHAIN_ID_META_TAG,
   GNO_CONNECT_PREFIX,
@@ -355,6 +356,14 @@ export function shouldInterceptExecForm(target: EventTarget | null): boolean {
   }
 
   return false;
+}
+
+/**
+ * Checks whether the given dApp origin is allowed to declare RPC/chainId via
+ * gnoconnect meta tags. Strict equality on the full origin (scheme + host + port).
+ */
+export function isAllowedGnoConnectOrigin(origin: string): boolean {
+  return GNO_CONNECT_ALLOWED_ORIGINS.includes(origin);
 }
 
 export function getUrlPathWithoutProtocol(url: string): string {

--- a/packages/adena-extension/src/inject/types/cosmos.ts
+++ b/packages/adena-extension/src/inject/types/cosmos.ts
@@ -38,7 +38,6 @@ export interface SerializedDirectSignResponse {
 // Uint8Array at the `window.adena.cosmos` surface; the inject.ts wrapper
 // reconstitutes them from the `SerializedCosmosKey` wire payload.
 export interface CosmosKey {
-  name: string;
   algo: string;
   pubKey: Uint8Array;
   address: Uint8Array;
@@ -50,7 +49,6 @@ export interface CosmosKey {
 // because `chrome.runtime.sendMessage` applies JSON encoding between the
 // background handler and the content script, dropping Uint8Array fidelity.
 export interface SerializedCosmosKey {
-  name: string;
   algo: string;
   pubKey: string;
   address: string;

--- a/packages/adena-extension/src/migrates/migrations/v009/storage-migration-v009.ts
+++ b/packages/adena-extension/src/migrates/migrations/v009/storage-migration-v009.ts
@@ -1,7 +1,11 @@
 import { StorageModel } from '@common/storage';
-import { encryptWalletPassword } from '@common/utils/crypto-utils';
 import { Migration } from '@migrates/migrator';
+import CryptoJS from 'crypto-js';
 import { AdenaWallet, decryptAES, encryptAES, mnemonicToEntropy } from 'adena-module';
+
+const LEGACY_SALT = 'W9+fs3FJ9p5KdR1XzQy2A6ZT4vjN8LvM9J8pVZmN9rU=';
+const legacyEncryptWalletPassword = (password: string): string =>
+  CryptoJS.SHA256(LEGACY_SALT + password).toString();
 import {
   AddressBookModelV008,
   SerializedModelV008,
@@ -118,20 +122,24 @@ export class StorageMigration009 implements Migration<StorageModelDataV009> {
       return keyring;
     });
 
-    let changedWallet = new AdenaWallet({
+    const changedWallet = new AdenaWallet({
       accounts: wallet.accounts,
       keyrings: keyrings,
       currentAccountId: wallet.currentAccountId,
     });
 
-    const sha256Password = encryptWalletPassword(password);
+    const sha256Password = legacyEncryptWalletPassword(password);
 
-    const serializedWallet = await changedWallet.serialize(sha256Password);
+    const plain = {
+      currentAccountId: changedWallet.currentAccountId,
+      accounts: changedWallet.accounts.map((account) => account.toData()),
+      keyrings: changedWallet.keyrings.map((keyring) => keyring.toData()),
+    };
+    const serializedWallet = await encryptAES(JSON.stringify(plain), sha256Password);
 
     keyrings = [];
     wallet = { accounts: [], keyrings: [] };
     decrypted = '';
-    changedWallet = new AdenaWallet();
 
     return serializedWallet;
   }
@@ -150,7 +158,7 @@ export class StorageMigration009 implements Migration<StorageModelDataV009> {
 
     let decrypted = await decryptAES(addressBook, password);
 
-    const sha256Password = encryptWalletPassword(password);
+    const sha256Password = legacyEncryptWalletPassword(password);
     const encryptedAddressBook = await encryptAES(decrypted, sha256Password);
 
     decrypted = '';

--- a/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.spec.ts
+++ b/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * @jest-environment node
+ */
+import { decryptXChacha20, encryptAES } from 'adena-module';
+import CryptoJS from 'crypto-js';
+import sodium from 'libsodium-wrappers-sumo';
+import { StorageMigration018 } from './storage-migration-v018';
+
+const LEGACY_SALT = 'W9+fs3FJ9p5KdR1XzQy2A6ZT4vjN8LvM9J8pVZmN9rU=';
+const RAW_PASSWORD = '123';
+const HASHED_PASSWORD = CryptoJS.SHA256(LEGACY_SALT + RAW_PASSWORD).toString();
+
+const WALLET_JSON = JSON.stringify({
+  accounts: [],
+  keyrings: [],
+  currentAccountId: '',
+});
+
+const ADDRESS_BOOK_JSON = JSON.stringify([
+  { id: 'addr1', name: 'Test', address: 'g1abc', createdAt: '0' },
+]);
+
+const createMockData = (serialized: string, addressBook = '') => ({
+  NETWORKS: [],
+  CURRENT_CHAIN_ID: 'test9.1',
+  CURRENT_NETWORK_ID: 'test9.1',
+  SERIALIZED: serialized,
+  ENCRYPTED_STORED_PASSWORD: '',
+  CURRENT_ACCOUNT_ID: '',
+  ACCOUNT_NAMES: {},
+  ESTABLISH_SITES: {},
+  ADDRESS_BOOK: addressBook,
+  ACCOUNT_TOKEN_METAINFOS: {},
+  QUESTIONNAIRE_EXPIRED_DATE: null,
+  WALLET_CREATION_GUIDE_CONFIRM_DATE: null,
+  ADD_ACCOUNT_GUIDE_CONFIRM_DATE: null,
+  ACCOUNT_GRC721_COLLECTIONS: {},
+  ACCOUNT_GRC721_PINNED_PACKAGES: {},
+});
+
+describe('storage migration V018', () => {
+  // encryptAES uses Argon2id KDF internally, so we prepare test data with it
+  let encryptedSerialized: string;
+  let encryptedAddressBook: string;
+
+  beforeAll(async () => {
+    encryptedSerialized = await encryptAES(WALLET_JSON, HASHED_PASSWORD);
+    encryptedAddressBook = await encryptAES(ADDRESS_BOOK_JSON, HASHED_PASSWORD);
+  });
+
+  it('version', () => {
+    const migration = new StorageMigration018();
+    expect(migration.version).toBe(18);
+  });
+
+  it('up without password throws when SERIALIZED exists', async () => {
+    // Refusing to bump version when we cannot re-encrypt the existing wallet
+    // is what prevents the wallet from being permanently locked after a
+    // login attempt with an empty/missing password.
+    const mockData = {
+      version: 17,
+      data: createMockData(encryptedSerialized),
+    };
+    const migration = new StorageMigration018();
+
+    await expect(migration.up(mockData)).rejects.toThrow(/requires a password/);
+  });
+
+  it('up without password succeeds when SERIALIZED is empty (fresh install)', async () => {
+    const mockData = {
+      version: 17,
+      data: createMockData(''),
+    };
+    const migration = new StorageMigration018();
+    const result = await migration.up(mockData);
+
+    expect(result.version).toBe(18);
+    expect(result.data.SERIALIZED).toBe('');
+    expect(result.data.KDF_SALT).toBeTruthy();
+  });
+
+  it('up with raw password decrypts hashed-password AES data and re-encrypts with XChaCha20', async () => {
+    const mockData = {
+      version: 17,
+      data: createMockData(encryptedSerialized),
+    };
+    const migration = new StorageMigration018();
+    const result = await migration.up(mockData, RAW_PASSWORD);
+
+    expect(result.version).toBe(18);
+    expect(result.data.KDF_SALT).toBeTruthy();
+
+    // SERIALIZED should now be XChaCha20 format
+    const parsed = JSON.parse(result.data.SERIALIZED);
+    expect(parsed.ciphertext).toBeTruthy();
+    expect(parsed.nonce).toBeTruthy();
+
+    // Decrypt with RAW password (new system uses raw password)
+    await sodium.ready;
+    const salt = Uint8Array.from(Buffer.from(result.data.KDF_SALT, 'base64'));
+    const decrypted = await decryptXChacha20(parsed, RAW_PASSWORD, salt);
+    const wallet = JSON.parse(decrypted);
+    expect(wallet).toHaveProperty('accounts');
+    expect(wallet).toHaveProperty('keyrings');
+  });
+
+  it('migrated data cannot be decrypted with hashed password', async () => {
+    const mockData = {
+      version: 17,
+      data: createMockData(encryptedSerialized),
+    };
+    const migration = new StorageMigration018();
+    const result = await migration.up(mockData, RAW_PASSWORD);
+
+    await sodium.ready;
+    const parsed = JSON.parse(result.data.SERIALIZED);
+    const salt = Uint8Array.from(Buffer.from(result.data.KDF_SALT, 'base64'));
+
+    await expect(decryptXChacha20(parsed, HASHED_PASSWORD, salt)).rejects.toThrow();
+  });
+
+  it('up with password also migrates ADDRESS_BOOK', async () => {
+    const mockData = {
+      version: 17,
+      data: createMockData(encryptedSerialized, encryptedAddressBook),
+    };
+    const migration = new StorageMigration018();
+    const result = await migration.up(mockData, RAW_PASSWORD);
+
+    const parsed = JSON.parse(result.data.ADDRESS_BOOK);
+    expect(parsed.ciphertext).toBeTruthy();
+    expect(parsed.nonce).toBeTruthy();
+
+    await sodium.ready;
+    const salt = Uint8Array.from(Buffer.from(result.data.KDF_SALT, 'base64'));
+    const decrypted = await decryptXChacha20(parsed, RAW_PASSWORD, salt);
+    const addressBook = JSON.parse(decrypted);
+    expect(addressBook).toHaveLength(1);
+    expect(addressBook[0].name).toBe('Test');
+  });
+
+  it('up with wrong password throws so caller can preserve v017 state', async () => {
+    // Throwing causes StorageMigrator.migrate to back up and return null,
+    // which keeps chrome.storage at version 17 with the original AES-CBC
+    // ciphertext intact. Critical: prevents version bump on bad password,
+    // which would otherwise lock the wallet after a single typo.
+    const mockData = {
+      version: 17,
+      data: createMockData(encryptedSerialized),
+    };
+    const migration = new StorageMigration018();
+
+    await expect(migration.up(mockData, 'wrong_password')).rejects.toThrow(
+      /cannot decrypt SERIALIZED/,
+    );
+  });
+
+  it('retrying with correct password after a wrong-password failure still succeeds', async () => {
+    // The original v017 state must not be mutated by a failed migration —
+    // the same input must migrate cleanly when the correct password is
+    // supplied on retry.
+    const originalData = createMockData(encryptedSerialized, encryptedAddressBook);
+    const migration = new StorageMigration018();
+
+    await expect(
+      migration.up({ version: 17, data: originalData }, 'wrong_password'),
+    ).rejects.toThrow();
+
+    // The caller (StorageMigrator) preserves the original storage on throw,
+    // so a retry sees the same v017 snapshot.
+    const result = await migration.up({ version: 17, data: originalData }, RAW_PASSWORD);
+    expect(result.version).toBe(18);
+    const parsed = JSON.parse(result.data.SERIALIZED);
+    expect(parsed.ciphertext).toBeTruthy();
+  });
+
+  it('up with wrong password also throws for ADDRESS_BOOK migration', async () => {
+    // SERIALIZED migration runs first; if SERIALIZED is empty but
+    // ADDRESS_BOOK is not, ADDRESS_BOOK migration must independently throw.
+    const mockData = {
+      version: 17,
+      data: createMockData('', encryptedAddressBook),
+    };
+    const migration = new StorageMigration018();
+
+    await expect(migration.up(mockData, 'wrong_password')).rejects.toThrow(
+      /cannot decrypt ADDRESS_BOOK/,
+    );
+  });
+
+  it('up generates unique KDF_SALT per migration', async () => {
+    const mockData1 = { version: 17, data: createMockData(encryptedSerialized) };
+    const mockData2 = { version: 17, data: createMockData(encryptedSerialized) };
+
+    const migration = new StorageMigration018();
+    const result1 = await migration.up(mockData1, RAW_PASSWORD);
+    const result2 = await migration.up(mockData2, RAW_PASSWORD);
+
+    expect(result1.data.KDF_SALT).not.toBe(result2.data.KDF_SALT);
+  });
+
+  it('KDF_SALT round-trips correctly through Buffer (WalletRepository path)', async () => {
+    const mockData = { version: 17, data: createMockData(encryptedSerialized) };
+    const migration = new StorageMigration018();
+    const result = await migration.up(mockData, RAW_PASSWORD);
+
+    // Simulate how WalletRepository.getKdfSalt decodes the stored salt
+    const saltViaBuffer = Uint8Array.from(Buffer.from(result.data.KDF_SALT, 'base64'));
+    const parsed = JSON.parse(result.data.SERIALIZED);
+    const decrypted = await decryptXChacha20(parsed, RAW_PASSWORD, saltViaBuffer);
+
+    const wallet = JSON.parse(decrypted);
+    expect(wallet).toHaveProperty('accounts');
+    expect(wallet).toHaveProperty('keyrings');
+  });
+
+  it('up fails with invalid data structure', async () => {
+    const mockData: any = {
+      version: 17,
+      data: { ...createMockData(encryptedSerialized), SERIALIZED: null },
+    };
+    const migration = new StorageMigration018();
+
+    await expect(migration.up(mockData)).rejects.toThrow(
+      'Storage Data does not match version V017',
+    );
+  });
+});

--- a/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.spec.ts
+++ b/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.spec.ts
@@ -20,12 +20,16 @@ const ADDRESS_BOOK_JSON = JSON.stringify([
   { id: 'addr1', name: 'Test', address: 'g1abc', createdAt: '0' },
 ]);
 
-const createMockData = (serialized: string, addressBook = '') => ({
+const createMockData = (
+  serialized: string,
+  addressBook = '',
+  encryptedStoredPassword = '',
+) => ({
   NETWORKS: [],
   CURRENT_CHAIN_ID: 'test9.1',
   CURRENT_NETWORK_ID: 'test9.1',
   SERIALIZED: serialized,
-  ENCRYPTED_STORED_PASSWORD: '',
+  ENCRYPTED_STORED_PASSWORD: encryptedStoredPassword,
   CURRENT_ACCOUNT_ID: '',
   ACCOUNT_NAMES: {},
   ESTABLISH_SITES: {},
@@ -212,6 +216,34 @@ describe('storage migration V018', () => {
     const wallet = JSON.parse(decrypted);
     expect(wallet).toHaveProperty('accounts');
     expect(wallet).toHaveProperty('keyrings');
+  });
+
+  it('clears ENCRYPTED_STORED_PASSWORD after successful migration', async () => {
+    // The cipher pipeline changed under v018; the cached session password is
+    // forced to clear so the user re-authenticates through the new path.
+    const mockData = {
+      version: 17,
+      data: createMockData(
+        encryptedSerialized,
+        encryptedAddressBook,
+        'previously-cached-session-token',
+      ),
+    };
+    const migration = new StorageMigration018();
+    const result = await migration.up(mockData, RAW_PASSWORD);
+
+    expect(result.data.ENCRYPTED_STORED_PASSWORD).toBe('');
+  });
+
+  it('clears ENCRYPTED_STORED_PASSWORD on fresh-install migration too', async () => {
+    const mockData = {
+      version: 17,
+      data: createMockData('', '', 'leftover-from-v017'),
+    };
+    const migration = new StorageMigration018();
+    const result = await migration.up(mockData);
+
+    expect(result.data.ENCRYPTED_STORED_PASSWORD).toBe('');
   });
 
   it('up fails with invalid data structure', async () => {

--- a/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.ts
+++ b/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.ts
@@ -41,6 +41,10 @@ export class StorageMigration018 implements Migration<StorageModelDataV018> {
           password,
           salt,
         ),
+        // Clear the previously cached session password. The cipher pipeline
+        // changed under this migration, so force the user to re-authenticate
+        // through the new Argon2id + XChaCha20 path.
+        ENCRYPTED_STORED_PASSWORD: '',
         KDF_SALT: saltBase64,
       },
     };

--- a/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.ts
+++ b/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.ts
@@ -134,6 +134,7 @@ export class StorageMigration018 implements Migration<StorageModelDataV018> {
     }
 
     const encrypted = await encryptXChacha20(plaintext, newPassword, salt);
+    plaintext = '';
     return JSON.stringify(encrypted);
   }
 
@@ -165,6 +166,7 @@ export class StorageMigration018 implements Migration<StorageModelDataV018> {
     }
 
     const encrypted = await encryptXChacha20(plaintext, newPassword, salt);
+    plaintext = '';
     return JSON.stringify(encrypted);
   }
 }

--- a/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.ts
+++ b/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.ts
@@ -1,0 +1,155 @@
+import { decryptAES, encryptXChacha20, generateKdfSalt } from 'adena-module';
+import CryptoJS from 'crypto-js';
+import { StorageModel } from '@common/storage';
+import { Migration } from '@migrates/migrator';
+import { StorageModelDataV017 } from '../v017/storage-model-v017';
+import { StorageModelDataV018 } from './storage-model-v018';
+
+const LEGACY_SALT = 'W9+fs3FJ9p5KdR1XzQy2A6ZT4vjN8LvM9J8pVZmN9rU=';
+const legacyHashPassword = (password: string): string =>
+  CryptoJS.SHA256(LEGACY_SALT + password).toString();
+
+export class StorageMigration018 implements Migration<StorageModelDataV018> {
+  public readonly version = 18;
+
+  async up(
+    current: StorageModel<StorageModelDataV017>,
+    password?: string,
+  ): Promise<StorageModel<StorageModelDataV018>> {
+    if (!this.validateModelV017(current.data)) {
+      throw new Error('Storage Data does not match version V017');
+    }
+    const previous: StorageModelDataV017 = current.data;
+    const salt = await generateKdfSalt();
+    const saltBase64 = Buffer.from(salt).toString('base64');
+    // After v009, SERIALIZED is encrypted with SHA256(LEGACY_SALT + rawPassword)
+    // We decrypt with the hashed password but re-encrypt with raw password for the new system
+    const hashedPassword = password ? legacyHashPassword(password) : undefined;
+    return {
+      version: this.version,
+      data: {
+        ...previous,
+        SERIALIZED: await this.migrateSerialized(
+          previous.SERIALIZED,
+          hashedPassword,
+          password,
+          salt,
+        ),
+        ADDRESS_BOOK: await this.migrateAddressBook(
+          previous.ADDRESS_BOOK,
+          hashedPassword,
+          password,
+          salt,
+        ),
+        KDF_SALT: saltBase64,
+      },
+    };
+  }
+
+  private validateModelV017(currentData: StorageModelDataV017): boolean {
+    const storageDataKeys = [
+      'NETWORKS',
+      'CURRENT_CHAIN_ID',
+      'CURRENT_NETWORK_ID',
+      'SERIALIZED',
+      'ENCRYPTED_STORED_PASSWORD',
+      'CURRENT_ACCOUNT_ID',
+      'ESTABLISH_SITES',
+      'ADDRESS_BOOK',
+      'ACCOUNT_TOKEN_METAINFOS',
+      'ACCOUNT_GRC721_COLLECTIONS',
+      'ACCOUNT_GRC721_PINNED_PACKAGES',
+    ];
+    const currentDataKeys = Object.keys(currentData);
+    const hasKeys = storageDataKeys.every((dataKey) => {
+      return currentDataKeys.includes(dataKey);
+    });
+
+    if (!hasKeys) {
+      return false;
+    }
+    if (!Array.isArray(currentData.NETWORKS)) {
+      return false;
+    }
+    if (typeof currentData.CURRENT_CHAIN_ID !== 'string') {
+      return false;
+    }
+    if (typeof currentData.CURRENT_NETWORK_ID !== 'string') {
+      return false;
+    }
+    if (typeof currentData.SERIALIZED !== 'string') {
+      return false;
+    }
+    if (typeof currentData.ENCRYPTED_STORED_PASSWORD !== 'string') {
+      return false;
+    }
+    if (typeof currentData.CURRENT_ACCOUNT_ID !== 'string') {
+      return false;
+    }
+    if (currentData.ACCOUNT_NAMES && typeof currentData.ACCOUNT_NAMES !== 'object') {
+      return false;
+    }
+    if (currentData.ESTABLISH_SITES && typeof currentData.ESTABLISH_SITES !== 'object') {
+      return false;
+    }
+    return true;
+  }
+
+  private async migrateSerialized(
+    serialized: string,
+    oldPassword: string | undefined,
+    newPassword: string | undefined,
+    salt: Uint8Array,
+  ): Promise<string> {
+    // Empty SERIALIZED means there is no wallet to migrate (fresh install).
+    if (!serialized) {
+      return serialized;
+    }
+
+    // Existing wallet exists but caller did not supply a password — refuse
+    // to bump version. Throwing propagates to StorageMigrator.migrate which
+    // backs up and returns null, so chrome.storage stays at v017 untouched.
+    if (!oldPassword || !newPassword) {
+      throw new Error(
+        'V018 migration requires a password to re-encrypt existing SERIALIZED data',
+      );
+    }
+
+    const plaintext = await decryptAES(serialized, oldPassword);
+    if (!plaintext || plaintext.trim() === '') {
+      // Wrong password — decryptAES returns empty string when PKCS#7 padding
+      // check fails. Throw so the migrator preserves the original v017 data
+      // and the version is not bumped to 18.
+      throw new Error('V018 migration failed: cannot decrypt SERIALIZED with given password');
+    }
+
+    const encrypted = await encryptXChacha20(plaintext, newPassword, salt);
+    return JSON.stringify(encrypted);
+  }
+
+  private async migrateAddressBook(
+    addressBook: string,
+    oldPassword: string | undefined,
+    newPassword: string | undefined,
+    salt: Uint8Array,
+  ): Promise<string> {
+    // ADDRESS_BOOK is optional — no entries means nothing to migrate.
+    if (!addressBook) {
+      return addressBook;
+    }
+
+    if (!oldPassword || !newPassword) {
+      throw new Error(
+        'V018 migration requires a password to re-encrypt existing ADDRESS_BOOK data',
+      );
+    }
+
+    const plaintext = await decryptAES(addressBook, oldPassword);
+    if (!plaintext || plaintext.trim() === '') {
+      throw new Error('V018 migration failed: cannot decrypt ADDRESS_BOOK with given password');
+    }
+
+    const encrypted = await encryptXChacha20(plaintext, newPassword, salt);
+    return JSON.stringify(encrypted);
+  }
+}

--- a/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.ts
+++ b/packages/adena-extension/src/migrates/migrations/v018/storage-migration-v018.ts
@@ -115,11 +115,17 @@ export class StorageMigration018 implements Migration<StorageModelDataV018> {
       );
     }
 
-    const plaintext = await decryptAES(serialized, oldPassword);
+    // Wrong password surfaces in two shapes from decryptAES: an empty string
+    // when PKCS#7 padding happens to validate but produces no plaintext, or a
+    // CryptoJS "Malformed UTF-8 data" throw when the bytes cannot be decoded.
+    // Normalize both into a single error so the migrator preserves v017 state.
+    let plaintext: string;
+    try {
+      plaintext = await decryptAES(serialized, oldPassword);
+    } catch {
+      throw new Error('V018 migration failed: cannot decrypt SERIALIZED with given password');
+    }
     if (!plaintext || plaintext.trim() === '') {
-      // Wrong password — decryptAES returns empty string when PKCS#7 padding
-      // check fails. Throw so the migrator preserves the original v017 data
-      // and the version is not bumped to 18.
       throw new Error('V018 migration failed: cannot decrypt SERIALIZED with given password');
     }
 
@@ -144,7 +150,12 @@ export class StorageMigration018 implements Migration<StorageModelDataV018> {
       );
     }
 
-    const plaintext = await decryptAES(addressBook, oldPassword);
+    let plaintext: string;
+    try {
+      plaintext = await decryptAES(addressBook, oldPassword);
+    } catch {
+      throw new Error('V018 migration failed: cannot decrypt ADDRESS_BOOK with given password');
+    }
     if (!plaintext || plaintext.trim() === '') {
       throw new Error('V018 migration failed: cannot decrypt ADDRESS_BOOK with given password');
     }

--- a/packages/adena-extension/src/migrates/migrations/v018/storage-model-v018.ts
+++ b/packages/adena-extension/src/migrates/migrations/v018/storage-model-v018.ts
@@ -1,0 +1,151 @@
+export type StorageModelV018 = {
+  version: 18;
+  data: StorageModelDataV018;
+};
+
+export type StorageModelDataV018 = {
+  NETWORKS: NetworksModelV018;
+  CURRENT_CHAIN_ID: CurrentChainIdModelV018;
+  CURRENT_NETWORK_ID: CurrentNetworkIdModelV018;
+  SERIALIZED: SerializedModelV018;
+  ENCRYPTED_STORED_PASSWORD: EncryptedStoredPasswordModelV018;
+  CURRENT_ACCOUNT_ID: CurrentAccountIdModelV018;
+  ACCOUNT_NAMES: AccountNamesModelV018;
+  ESTABLISH_SITES: EstablishSitesModelV018;
+  ADDRESS_BOOK: AddressBookModelV018;
+  ACCOUNT_TOKEN_METAINFOS: AccountTokenMetainfoModelV018;
+  QUESTIONNAIRE_EXPIRED_DATE: QuestionnaireExpiredDateModelV018;
+  WALLET_CREATION_GUIDE_CONFIRM_DATE: WalletCreationGuideConfirmDateModelV018;
+  ADD_ACCOUNT_GUIDE_CONFIRM_DATE: AddAccountGuideConfirmDateModelV018;
+  ACCOUNT_GRC721_COLLECTIONS: AccountGRC721CollectionsV018;
+  ACCOUNT_GRC721_PINNED_PACKAGES: AccountGRC721PinnedPackagesV018;
+  KDF_SALT: KdfSaltModelV018;
+};
+
+// base64-encoded 16-byte random salt for Argon2id KDF
+export type KdfSaltModelV018 = string;
+
+export type NetworksModelV018 = {
+  id: string;
+  default: boolean;
+  main: boolean;
+  chainId: string;
+  chainName: string;
+  networkId: string;
+  networkName: string;
+  addressPrefix: string;
+  rpcUrl: string;
+  indexerUrl: string;
+  gnoUrl: string;
+  apiUrl: string;
+  linkUrl: string;
+  deleted?: boolean;
+}[];
+
+export type CurrentChainIdModelV018 = string;
+
+export type CurrentNetworkIdModelV018 = string;
+
+// SERIALIZED now stores XChaCha20-Poly1305 encrypted data as JSON string:
+// '{"ciphertext":"...","nonce":"..."}'
+export type SerializedModelV018 = string;
+
+export type QuestionnaireExpiredDateModelV018 = number | null;
+
+export type WalletCreationGuideConfirmDateModelV018 = number | null;
+
+export type AddAccountGuideConfirmDateModelV018 = number | null;
+
+export type WalletModelV018 = {
+  accounts: AccountDataModelV018[];
+  keyrings: KeyringDataModelV018[];
+  currentAccountId?: string;
+};
+
+export type AccountDataModelV018 = {
+  id?: string;
+  index: number;
+  type: 'HD_WALLET' | 'PRIVATE_KEY' | 'LEDGER' | 'WEB3_AUTH' | 'AIRGAP';
+  name: string;
+  keyringId: string;
+  hdPath?: number;
+  publicKey: number[];
+  addressBytes?: number[];
+};
+
+export type KeyringDataModelV018 = {
+  id?: string;
+  type: 'HD_WALLET' | 'PRIVATE_KEY' | 'LEDGER' | 'WEB3_AUTH' | 'AIRGAP';
+  publicKey?: number[];
+  privateKey?: number[];
+  seed?: number[];
+  mnemonic?: string;
+  addressBytes?: number[];
+};
+
+export type EncryptedStoredPasswordModelV018 = string;
+
+export type CurrentAccountIdModelV018 = string;
+
+type AccountId = string;
+type NetworkId = string;
+
+export type AccountNamesModelV018 = { [key in AccountId]: string };
+
+export type EstablishSitesModelV018 = {
+  [key in AccountId]: {
+    hostname: string;
+    chainId: string;
+    account: string;
+    name: string;
+    favicon: string | null;
+    establishedTime: string;
+  }[];
+};
+
+export type AddressBookModelV018 = string;
+
+export type AccountTokenMetainfoModelV018 = {
+  [key in string]: {
+    main: boolean;
+    tokenId: string;
+    networkId: string;
+    display: boolean;
+    type: 'gno-native' | 'grc20' | 'ibc-native' | 'ibc-tokens';
+    name: string;
+    symbol: string;
+    decimals: number;
+    description?: string;
+    websiteUrl?: string;
+    image: string;
+    denom?: string;
+    pkgPath?: string;
+    originChain?: string;
+    originDenom?: string;
+    originType?: string;
+    path?: string;
+    channel?: string;
+    port?: string;
+  }[];
+};
+
+export type AccountGRC721CollectionsV018 = {
+  [key in AccountId]: {
+    [key in NetworkId]: {
+      tokenId: string;
+      networkId: string;
+      display: boolean;
+      type: 'grc721';
+      packagePath: string;
+      name: string;
+      symbol: string;
+      image: string | null;
+      isTokenUri: boolean;
+      isMetadata: boolean;
+    }[];
+  };
+};
+
+export type AccountGRC721PinnedPackagesV018 = {
+  [key in AccountId]: { [key in NetworkId]: string[] };
+};

--- a/packages/adena-extension/src/migrates/storage-migrator.spec.ts
+++ b/packages/adena-extension/src/migrates/storage-migrator.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { StorageModelV001 } from './migrations/v001/storage-model-v001';
 import { StorageMigrator } from './storage-migrator';
 
@@ -67,12 +70,11 @@ describe('StorageMigrator', () => {
     const migrated = await migrator.migrate(current, '123');
 
     expect(migrated).not.toBeNull();
-    expect(migrated?.version).toBe(17);
+    expect(migrated?.version).toBe(18);
     expect(migrated?.data).not.toBeNull();
     expect(migrated?.data.NETWORKS).toHaveLength(4);
     expect(migrated?.data.CURRENT_CHAIN_ID).toBe('');
     expect(migrated?.data.CURRENT_NETWORK_ID).toBe('');
-    expect(migrated?.data.ENCRYPTED_STORED_PASSWORD).toBe('');
     expect(migrated?.data.CURRENT_ACCOUNT_ID).toBe('');
     expect(migrated?.data.ACCOUNT_NAMES).toEqual({});
     expect(migrated?.data.ESTABLISH_SITES).toEqual({});
@@ -85,7 +87,7 @@ describe('StorageMigrator', () => {
     const migrated = await migrator.migrate(current, '123');
 
     expect(migrated).not.toBeNull();
-    expect(migrated?.version).toBe(17);
+    expect(migrated?.version).toBe(18);
     expect(migrated?.data).not.toBeNull();
     expect(migrated?.data.SERIALIZED).not.toBe('');
     expect(migrated?.data.ADDRESS_BOOK).toBe('');

--- a/packages/adena-extension/src/migrates/storage-migrator.ts
+++ b/packages/adena-extension/src/migrates/storage-migrator.ts
@@ -32,6 +32,8 @@ import { StorageMigration016 } from './migrations/v016/storage-migration-v016';
 import { StorageModelV016 } from './migrations/v016/storage-model-v016';
 import { StorageMigration017 } from './migrations/v017/storage-migration-v017';
 import { StorageModelDataV017, StorageModelV017 } from './migrations/v017/storage-model-v017';
+import { StorageMigration018 } from './migrations/v018/storage-migration-v018';
+import { StorageModelDataV018, StorageModelV018 } from './migrations/v018/storage-model-v018';
 import { Migration, Migrator } from './migrator';
 
 const LegacyStorageKeys = [
@@ -39,7 +41,6 @@ const LegacyStorageKeys = [
   'CURRENT_CHAIN_ID',
   'CURRENT_NETWORK_ID',
   'SERIALIZED',
-  'ENCRYPTED_STORED_PASSWORD',
   'CURRENT_ACCOUNT_ID',
   'ACCOUNT_NAMES',
   'ESTABLISH_SITES',
@@ -48,7 +49,7 @@ const LegacyStorageKeys = [
 ];
 
 // The latest storage model type
-export type StorageModelLatest = StorageModelV017;
+export type StorageModelLatest = StorageModelV018;
 
 // Default data structure for version 1 storage model
 const defaultData: StorageModelDataV001 = {
@@ -64,7 +65,7 @@ const defaultData: StorageModelDataV001 = {
   ACCOUNT_TOKEN_METAINFOS: {},
 };
 
-const defaultLegacyData: StorageModelDataV017 = {
+const defaultLegacyData: StorageModelDataV018 = {
   NETWORKS: [],
   CURRENT_CHAIN_ID: '',
   CURRENT_NETWORK_ID: '',
@@ -80,6 +81,7 @@ const defaultLegacyData: StorageModelDataV017 = {
   ADD_ACCOUNT_GUIDE_CONFIRM_DATE: null,
   ACCOUNT_GRC721_COLLECTIONS: {},
   ACCOUNT_GRC721_PINNED_PACKAGES: {},
+  KDF_SALT: '',
 };
 
 // Storage interface with set and get methods
@@ -119,6 +121,7 @@ export class StorageMigrator implements Migrator {
   async deserialize(
     data: string | undefined,
   ): Promise<
+    | StorageModelV018
     | StorageModelV017
     | StorageModelV016
     | StorageModelV015
@@ -150,6 +153,7 @@ export class StorageMigrator implements Migrator {
 
   // Retrieves the current storage data, performing deserialization
   async getCurrent(): Promise<
+    | StorageModelV018
     | StorageModelV017
     | StorageModelV016
     | StorageModelV015
@@ -175,13 +179,13 @@ export class StorageMigrator implements Migrator {
     }
 
     return {
-      version: 17,
+      version: 18,
       data: defaultLegacyData,
     };
   }
 
   // Migrates storage data to the latest version
-  async migrate(current: StorageModel, password: string): Promise<StorageModelV017 | null> {
+  async migrate(current: StorageModel, password: string): Promise<StorageModelV018 | null> {
     let latest = current;
     try {
       const currentVersion = current.version || 1;
@@ -223,6 +227,7 @@ export class StorageMigrator implements Migrator {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     json: any,
   ): Promise<
+    | StorageModelV018
     | StorageModelV017
     | StorageModelV016
     | StorageModelV015
@@ -241,6 +246,9 @@ export class StorageMigrator implements Migrator {
     | StorageModelV002
     | StorageModelV001
   > {
+    if (json?.version === 18) {
+      return json as StorageModelV018;
+    }
     if (json?.version === 17) {
       return json as StorageModelV017;
     }
@@ -337,6 +345,7 @@ export class StorageMigrator implements Migrator {
       new StorageMigration015(),
       new StorageMigration016(),
       new StorageMigration017(),
+      new StorageMigration018(),
     ];
   }
 }

--- a/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
@@ -43,6 +43,8 @@ const AddAddress = (): JSX.Element => {
   const addressList: AddressBookItem[] = params.addressList;
   const [chainGroup, setChainGroup] = useState<string>('gno');
   const chain = useChain(chainGroup);
+  // Bech32 length: prefix + "1" separator + 32 data chars + 6 checksum chars.
+  const addressMaxLength = chain.bech32Prefix.length + 39;
   const { chainRegistry } = useAdenaContext();
   const chainOptions = React.useMemo(
     () => chainOptionsFromRegistry(chainRegistry),
@@ -197,7 +199,7 @@ const AddAddress = (): JSX.Element => {
         onChange={onChangeAddress}
         onKeyDown={onKeyDown}
         rows={1}
-        maxLength={40}
+        maxLength={addressMaxLength}
         autoComplete='off'
         error={addressError}
       />

--- a/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
@@ -30,6 +30,7 @@ import { AddressBookItem } from '@repositories/wallet';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { RoutePath } from '@types';
 import { useAddressBook } from '@hooks/use-address-book';
+import { inferChainGroup } from '@common/utils/address-chain';
 
 const specialPatternCheck = /\W|\s/g;
 const ACCOUNT_NAME_LENGTH_LIMIT = 23;
@@ -41,15 +42,24 @@ const AddAddress = (): JSX.Element => {
   const isAdd = params.status === 'add';
 
   const addressList: AddressBookItem[] = params.addressList;
-  const [chainGroup, setChainGroup] = useState<string>('gno');
-  const chain = useChain(chainGroup);
-  // Bech32 length: prefix + "1" separator + 32 data chars + 6 checksum chars.
-  const addressMaxLength = chain.bech32Prefix.length + 39;
   const { chainRegistry } = useAdenaContext();
+  const [chainGroup, setChainGroup] = useState<string>(() =>
+    inferChainGroup(params.curr?.address ?? '', chainRegistry),
+  );
+  const chain = useChain(chainGroup);
   const chainOptions = React.useMemo(
     () => chainOptionsFromRegistry(chainRegistry),
     [chainRegistry],
   );
+  // Bech32 length: prefix + "1" separator + 32 data chars + 6 checksum chars.
+  // Use the longest registered prefix so pasting an address whose chain
+  // differs from the current selection isn't truncated before useEffect
+  // re-syncs chainGroup from the new prefix.
+  const addressMaxLength = React.useMemo(() => {
+    const prefixes = chainRegistry.listChains().map((c) => c.bech32Prefix.length);
+    const maxPrefix = prefixes.length > 0 ? Math.max(...prefixes) : chain.bech32Prefix.length;
+    return maxPrefix + 39;
+  }, [chainRegistry, chain.bech32Prefix.length]);
   const [name, setName] = useState(() => params.curr?.name ?? '');
   const [address, setAddress] = useState(() => params.curr?.address ?? '');
   const [nameError, setNameError] = useState<boolean>(false);
@@ -154,7 +164,8 @@ const AddAddress = (): JSX.Element => {
   useEffect(() => {
     setAddressError(false);
     setErrorMsg('');
-  }, [address]);
+    setChainGroup(inferChainGroup(address, chainRegistry));
+  }, [address, chainRegistry]);
 
   useEffect(() => {
     setNameError(false);
@@ -173,44 +184,46 @@ const AddAddress = (): JSX.Element => {
         <LeftArrowBtn onClick={goBack} />
         <Text type='header4'>{isAdd ? 'Add Address' : 'Edit Address'}</Text>
       </TopSection>
-      <img
-        className='symbol-image'
-        src={isAdd ? add : edit}
-        alt={isAdd ? 'add icon' : 'edit icon'}
-      />
-      <ChainDropdown
-        value={chainGroup}
-        onChange={setChainGroup}
-        options={chainOptions}
-        disabled={!isAdd}
-      />
-      <DefaultInput
-        value={name}
-        placeholder='Label'
-        onChange={onChangeName}
-        type='text'
-        error={nameError}
-        ref={nameInputRef}
-        margin='12px 0 0'
-      />
-      <AddressInput
-        value={address}
-        placeholder='Address'
-        onChange={onChangeAddress}
-        onKeyDown={onKeyDown}
-        rows={1}
-        maxLength={addressMaxLength}
-        autoComplete='off'
-        error={addressError}
-      />
-      <ErrorText text={errorMsg} />
-      {!isAdd && (
-        <RemoveAddressBtn error={Boolean(errorMsg)} onClick={removeHandler}>
-          <Text type='body1Reg' color={theme.neutral.a}>
-            Remove Address
-          </Text>
-        </RemoveAddressBtn>
-      )}
+      <ScrollableContent>
+        <img
+          className='symbol-image'
+          src={isAdd ? add : edit}
+          alt={isAdd ? 'add icon' : 'edit icon'}
+        />
+        <ChainDropdown
+          value={chainGroup}
+          onChange={setChainGroup}
+          options={chainOptions}
+          disabled={!isAdd}
+        />
+        <DefaultInput
+          value={name}
+          placeholder='Label'
+          onChange={onChangeName}
+          type='text'
+          error={nameError}
+          ref={nameInputRef}
+          margin='12px 0 0'
+        />
+        <AddressInput
+          value={address}
+          placeholder='Address'
+          onChange={onChangeAddress}
+          onKeyDown={onKeyDown}
+          rows={1}
+          maxLength={addressMaxLength}
+          autoComplete='off'
+          error={addressError}
+        />
+        <ErrorText text={errorMsg} />
+        {!isAdd && (
+          <RemoveAddressBtn error={Boolean(errorMsg)} onClick={removeHandler}>
+            <Text type='body1Reg' color={theme.neutral.a}>
+              Remove Address
+            </Text>
+          </RemoveAddressBtn>
+        )}
+      </ScrollableContent>
       <CancelAndConfirmButton
         cancelButtonProps={{ onClick: goBack }}
         confirmButtonProps={{
@@ -228,15 +241,18 @@ const RemoveAddressBtn = styled.button<{ error: boolean }>`
   text-underline-offset: 2px;
   text-decoration-thickness: 1px;
   text-decoration-color: ${getTheme('neutral', 'a')};
-  position: absolute;
-  bottom: 91px;
+  align-self: center;
+  margin-top: ${({ error }): string => (error ? '8px' : '16px')};
+  margin-bottom: 24px;
 `;
 
 const AddressInput = styled.textarea<{ error: boolean }>`
   ${inputStyle};
-  height: 70px;
+  min-height: 70px;
+  height: auto;
   overflow: hidden;
   resize: none;
+  word-break: break-all;
   border: 1px solid ${({ error, theme }): string => (error ? theme.red._5 : theme.neutral._7)};
   margin-top: 12px;
 `;
@@ -246,10 +262,20 @@ const Wrapper = styled.main`
   padding-top: 24px;
   width: 100%;
   height: 100%;
+  overflow: hidden;
   .symbol-image {
     margin: 24px auto;
     display: block;
   }
+`;
+
+const ScrollableContent = styled.div`
+  ${mixins.flex({ justify: 'flex-start' })};
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: 16px;
 `;
 
 const TopSection = styled.div`

--- a/packages/adena-extension/src/pages/popup/certify/address-book/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/address-book/index.tsx
@@ -11,12 +11,9 @@ import mixins from '@styles/mixins';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { AddressBookItem } from '@repositories/wallet';
 import { useAddressBook } from '@hooks/use-address-book';
+import { useAdenaContext } from '@hooks/use-context';
+import { inferChainGroup } from '@common/utils/address-chain';
 import LoadingAddressBook from './loading-address-book';
-
-function inferChainGroup(address: string): string {
-  if (address.startsWith('atone1')) return 'atomone';
-  return 'gno';
-}
 
 type navigateStatus = 'add' | 'edit';
 
@@ -24,6 +21,7 @@ const AddressBook = (): JSX.Element => {
   const theme = useTheme();
   const { navigate, goBack } = useAppNavigate();
   const { loading, addressBook } = useAddressBook();
+  const { chainRegistry } = useAdenaContext();
   const addAddressHandler = (status: navigateStatus, curr?: AddressBookItem): void =>
     navigate<RoutePath.AddAddress>(RoutePath.AddAddress, {
       state: {
@@ -46,7 +44,7 @@ const AddressBook = (): JSX.Element => {
       <>
         {addressBook.length > 0 ? (
           addressBook.map((item, i) => {
-            const chainGroup = inferChainGroup(item.address);
+            const chainGroup = inferChainGroup(item.address, chainRegistry);
             const chainIcon = CHAIN_ICON_BY_GROUP[chainGroup];
             return (
               <ListBox

--- a/packages/adena-extension/src/pages/popup/certify/auto-lock-timer/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/auto-lock-timer/index.tsx
@@ -1,0 +1,125 @@
+import styled, { useTheme } from 'styled-components';
+
+import { DefaultInput, ErrorText, Text } from '@components/atoms';
+import { CancelAndConfirmButton } from '@components/molecules';
+import { useAutoLockTimer } from '@hooks/certify/use-auto-lock-timer';
+import { MAX_AUTO_LOCK_TIMEOUT_MINUTES } from '@repositories/wallet';
+import mixins from '@styles/mixins';
+
+const Wrapper = styled.main`
+  ${mixins.flex({ align: 'flex-start', justify: 'flex-start' })};
+  width: 100%;
+  height: 100%;
+  padding-top: 24px;
+`;
+
+const Description = styled(Text)`
+  margin-top: 12px;
+`;
+
+const FormBox = styled.div`
+  width: 100%;
+  margin-top: 24px;
+  margin-bottom: auto;
+
+  & > * {
+    margin-bottom: 12px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+`;
+
+const InputRow = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+// Reserve enough right padding for the "Minutes" suffix so the typed value
+// never overlaps the label.
+const MinutesInput = styled(DefaultInput)`
+  padding-right: 80px;
+`;
+
+const MinutesSuffix = styled.span`
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 21px;
+  color: ${({ theme }): string => theme.neutral._1};
+  pointer-events: none;
+`;
+
+const DisabledNotice = styled(Text)`
+  margin-top: 8px;
+`;
+
+export const AutoLockTimer = (): JSX.Element => {
+  const theme = useTheme();
+  const { value, onChange, errorMessage, saveDisabled, onSave, onCancel } = useAutoLockTimer();
+
+  const showDisabledNotice = !errorMessage && value === '0';
+
+  return (
+    <Wrapper>
+      <Text type='header4'>Auto-Lock Timer</Text>
+      <Description type='body2Reg' color={theme.neutral.a}>
+        Set a time it takes Adena to automatically lock your wallet. Use 0 to disable auto-lock.
+      </Description>
+      <FormBox>
+        <InputRow>
+          <MinutesInput
+            type='text'
+            inputMode='numeric'
+            pattern='[0-9]*'
+            name='autoLockMinutes'
+            value={value}
+            onChange={onChange}
+            // Defensive against keys that some browsers still surface even on
+            // type=text: arrow up/down (no-op on single-line, but matches the
+            // BalanceInput pattern), and characters we never want regardless
+            // of paste/IME behavior.
+            onKeyDown={(event): void => {
+              if (
+                event.key === '-' ||
+                event.key === '.' ||
+                event.key === 'e' ||
+                event.key === 'E' ||
+                event.key === 'ArrowUp' ||
+                event.key === 'ArrowDown'
+              ) {
+                event.preventDefault();
+              }
+            }}
+            // Wheel scrolling on a focused number input nudges the value in
+            // some browsers; blurring on wheel matches BalanceInput.
+            onWheel={(event): void => event.currentTarget.blur()}
+            error={Boolean(errorMessage)}
+            maxLength={String(MAX_AUTO_LOCK_TIMEOUT_MINUTES).length}
+            autoComplete='off'
+          />
+          <MinutesSuffix>Minutes</MinutesSuffix>
+        </InputRow>
+        {Boolean(errorMessage) && <ErrorText text={errorMessage} />}
+        {showDisabledNotice && (
+          <DisabledNotice type='body2Reg' color={theme.red._4}>
+            Auto-lock is disabled. The wallet will stay unlocked until you lock it manually or
+            close the browser.
+          </DisabledNotice>
+        )}
+      </FormBox>
+      <CancelAndConfirmButton
+        cancelButtonProps={{ onClick: onCancel }}
+        confirmButtonProps={{
+          onClick: onSave,
+          text: 'Save',
+          props: { disabled: saveDisabled },
+        }}
+      />
+    </Wrapper>
+  );
+};

--- a/packages/adena-extension/src/pages/popup/certify/login/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/login/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
 
-import { encryptWalletPassword } from '@common/utils/crypto-utils';
 import { validateEmptyPassword } from '@common/validation';
 import { Button, DefaultInput, Text } from '@components/atoms';
 import useAppNavigate from '@hooks/use-app-navigate';
@@ -83,13 +82,12 @@ export const Login = (): JSX.Element => {
 
     try {
       if (validateEmptyPassword(password)) {
-        const encryptedPassword = encryptWalletPassword(password);
         const result = await walletService.equalsPassword(password);
         if (!result) {
           setValidateState(false);
           return;
         }
-        await walletService.updatePassword(encryptedPassword);
+        await walletService.updatePassword(password);
         await setPassword('');
         await loadAccounts();
         navigate(RoutePath.Wallet);

--- a/packages/adena-extension/src/pages/popup/certify/security-privacy/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/security-privacy/index.tsx
@@ -18,6 +18,7 @@ import {
 
 type MenuType =
   | RoutePath.SettingChangePassword
+  | RoutePath.SettingAutoLockTimer
   | RoutePath.RemoveAccount
   | RoutePath.ResetWallet
   | 'EXPORT_SEED_PHRASE'
@@ -35,6 +36,12 @@ const getMenuMakerInfo = (
   {
     title: 'Change Password',
     navigatePath: RoutePath.SettingChangePassword,
+    mode: 'DEFAULT',
+    disabled: false,
+  },
+  {
+    title: 'Auto-Lock Timer',
+    navigatePath: RoutePath.SettingAutoLockTimer,
     mode: 'DEFAULT',
     disabled: false,
   },

--- a/packages/adena-extension/src/pages/popup/wallet/approve-get-cosmos-key/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-get-cosmos-key/index.tsx
@@ -106,7 +106,6 @@ const ApproveGetCosmosKeyContainer: React.FC = () => {
             'success',
             key,
             {
-              name: currentAccount.name,
               algo: 'secp256k1',
               pubKey: bytesToBase64(Array.from(compressedPubKey)),
               address: bytesToBase64(Array.from(addressBytes)),

--- a/packages/adena-extension/src/pages/popup/wallet/approve-login/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-login/index.tsx
@@ -18,7 +18,6 @@ import { WalletState } from '@states';
 import mixins from '@styles/mixins';
 import { RoutePath } from '@types';
 
-import { encryptWalletPassword } from '@common/utils/crypto-utils';
 import LoadingApproveTransaction from './loading-approve-transaction';
 
 const text = 'Enter\nYour Password';
@@ -95,10 +94,9 @@ export const ApproveLogin = (): JSX.Element => {
     try {
       validateEmptyPassword(password);
 
-      const encryptedPassword = encryptWalletPassword(password);
       const equalPassword = await walletService.equalsPassword(password);
       if (equalPassword) {
-        await walletService.updatePassword(encryptedPassword);
+        await walletService.updatePassword(password);
         await initWallet();
         setPassword('');
         setState('FINISH');

--- a/packages/adena-extension/src/pages/popup/wallet/approve-sign-cosmos/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-sign-cosmos/index.tsx
@@ -9,11 +9,21 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { decodeParameter, getSiteName, parseParameters } from '@common/utils/client-utils';
+import UnknownLogo from '@assets/common-unknown-logo.svg';
+import { Text } from '@components/atoms';
+import { BottomFixedLoadingButtonGroup } from '@components/molecules';
+import {
+  createFaviconByHostname,
+  decodeParameter,
+  getSiteName,
+  parseParameters,
+} from '@common/utils/client-utils';
 import {
   deserializeSignDoc,
   serializeSignDoc,
 } from '@common/utils/cosmos-serialize';
+import mixins from '@styles/mixins';
+import { fonts, getTheme } from '@styles/theme';
 import { useAdenaContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { InjectionMessage, InjectionMessageInstance } from '@inject/message';
@@ -56,6 +66,7 @@ const ApproveSignCosmosContainer: React.FC = () => {
   const [key, setKey] = useState<string>('');
   const [hostname, setHostname] = useState<string>('');
   const [protocol, setProtocol] = useState<string>('');
+  const [favicon, setFavicon] = useState<string | null>(null);
   const [mode, setMode] = useState<CosmosSignMode | null>(null);
   const [chainId, setChainId] = useState<string>('');
   const [signer, setSigner] = useState<string>('');
@@ -98,6 +109,13 @@ const ApproveSignCosmosContainer: React.FC = () => {
     }
   }, [location]);
 
+  useEffect(() => {
+    if (!hostname) return;
+    createFaviconByHostname(`${protocol}//${hostname}`)
+      .then(setFavicon)
+      .catch(() => setFavicon(null));
+  }, [hostname, protocol]);
+
   const siteName = useMemo(() => getSiteName(protocol, hostname), [protocol, hostname]);
   const responseType = useMemo<CosmosResponseExecuteType>(
     () =>
@@ -106,6 +124,12 @@ const ApproveSignCosmosContainer: React.FC = () => {
         : CosmosResponseExecuteType.SIGN_COSMOS_AMINO,
     [mode],
   );
+
+  const modeLabel = useMemo(() => {
+    if (mode === 'direct') return 'SIGN_MODE_DIRECT';
+    if (mode === 'amino') return 'SIGN_MODE_LEGACY_AMINO_JSON';
+    return '—';
+  }, [mode]);
 
   const sendFailure = useCallback(
     (failureType: string, detail?: string) => {
@@ -215,37 +239,61 @@ const ApproveSignCosmosContainer: React.FC = () => {
     }
   }, [rawSignDoc]);
 
+  const approveDisabled = processing || !mode || !currentAccount;
+
   return (
     <Wrapper>
-      <Header>
-        <Title>Sign Cosmos Transaction</Title>
-        <SiteLine>{siteName || hostname}</SiteLine>
-      </Header>
-      <Section>
-        <Label>Mode</Label>
-        <Value>{mode === 'direct' ? 'SIGN_MODE_DIRECT' : mode === 'amino' ? 'SIGN_MODE_LEGACY_AMINO_JSON' : '—'}</Value>
-      </Section>
-      <Section>
-        <Label>Chain</Label>
-        <Value>{chainId || '—'}</Value>
-      </Section>
-      <Section>
-        <Label>Signer</Label>
-        <Value>{signer || '—'}</Value>
-      </Section>
-      <Section>
-        <Label>SignDoc (raw)</Label>
-        <Pre>{prettySignDoc}</Pre>
-      </Section>
-      {errorMessage && <ErrorBox>{errorMessage}</ErrorBox>}
-      <Actions>
-        <ActionButton onClick={onClickCancel} disabled={processing}>
-          Cancel
-        </ActionButton>
-        <ActionButton primary onClick={onClickApprove} disabled={processing || !mode || !currentAccount}>
-          {processing ? 'Signing…' : 'Approve'}
-        </ActionButton>
-      </Actions>
+      <Text className='main-title' type='header4'>
+        Sign Cosmos Transaction
+      </Text>
+
+      <div className='domain-wrapper'>
+        <img className='logo' src={favicon || UnknownLogo} alt='logo img' />
+        <span>{siteName || hostname}</span>
+      </div>
+
+      <div className='info-table'>
+        <div className='row'>
+          <span className='key'>Mode</span>
+          <span className='value'>{modeLabel}</span>
+        </div>
+        <div className='row'>
+          <span className='key'>Chain</span>
+          <span className='value'>{chainId || '—'}</span>
+        </div>
+      </div>
+
+      <div className='block'>
+        <span className='block-key'>Signer</span>
+        <span className='block-value'>{signer || '—'}</span>
+      </div>
+
+      <div className='block'>
+        <span className='block-key'>SignDoc (raw)</span>
+        <pre className='raw-pre'>{prettySignDoc}</pre>
+      </div>
+
+      {errorMessage && (
+        <div className='error-banner'>
+          <span className='error-label'>ERROR:&nbsp;</span>
+          <span className='error-text'>{errorMessage}</span>
+        </div>
+      )}
+
+      <BottomFixedLoadingButtonGroup
+        filled
+        leftButton={{
+          text: 'Cancel',
+          onClick: onClickCancel,
+        }}
+        rightButton={{
+          primary: true,
+          text: 'Approve',
+          loading: processing,
+          disabled: approveDisabled,
+          onClick: onClickApprove,
+        }}
+      />
     </Wrapper>
   );
 };
@@ -253,88 +301,131 @@ const ApproveSignCosmosContainer: React.FC = () => {
 export default ApproveSignCosmosContainer;
 
 const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  overflow-y: auto;
-  max-height: 100vh;
-`;
+  ${mixins.flex({ justify: 'flex-start' })};
+  width: 100%;
+  padding: 0 20px 96px 20px;
+  align-self: center;
 
-const Header = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-`;
+  .main-title {
+    text-overflow: ellipsis;
+    margin-top: 24px;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 100%;
+    text-align: center;
+  }
 
-const Title = styled.h2`
-  font-size: 16px;
-  margin: 0;
-`;
+  .domain-wrapper {
+    ${mixins.flex({ direction: 'row', align: 'center', justify: 'center' })};
+    width: 100%;
+    min-height: 41px;
+    border-radius: 24px;
+    padding: 10px 18px;
+    margin: 24px auto 12px auto;
+    gap: 7px;
+    background-color: ${getTheme('neutral', '_9')};
+    ${fonts.body2Reg};
 
-const SiteLine = styled.span`
-  font-size: 12px;
-  opacity: 0.7;
-`;
+    .logo {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+    }
+  }
 
-const Section = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
+  .info-table {
+    width: 100%;
+    height: auto;
+    border-radius: 18px;
+    margin-bottom: 8px;
+    background-color: ${getTheme('neutral', '_9')};
+  }
 
-const Label = styled.span`
-  font-size: 11px;
-  opacity: 0.6;
-  text-transform: uppercase;
-`;
+  .row {
+    ${mixins.flex({ direction: 'row' })};
+    position: relative;
+    padding: 10px 18px;
+    justify-content: space-between;
+    border-bottom: 2px solid ${getTheme('neutral', '_8')};
+    ${fonts.body1Reg};
 
-const Value = styled.span`
-  font-size: 13px;
-  word-break: break-all;
-`;
+    &:last-child {
+      border-bottom: none;
+    }
 
-const Pre = styled.pre`
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
-  font-size: 11px;
-  background: rgba(255, 255, 255, 0.04);
-  padding: 8px;
-  border-radius: 6px;
-  white-space: pre-wrap;
-  word-break: break-all;
-  max-height: 240px;
-  overflow-y: auto;
-  margin: 0;
-`;
+    .key {
+      display: inline-flex;
+      width: fit-content;
+      flex-shrink: 0;
+      color: ${getTheme('neutral', 'a')};
+    }
 
-const ErrorBox = styled.div`
-  font-size: 12px;
-  color: #ff6b6b;
-  background: rgba(255, 107, 107, 0.08);
-  padding: 8px;
-  border-radius: 6px;
-  word-break: break-all;
-`;
+    .value {
+      display: block;
+      max-width: 204px;
+      text-align: right;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+  }
 
-const Actions = styled.div`
-  display: flex;
-  gap: 8px;
-  margin-top: auto;
-`;
+  .block {
+    ${mixins.flex({ direction: 'column', align: 'flex-start' })};
+    width: 100%;
+    padding: 12px 18px;
+    border-radius: 18px;
+    background-color: ${getTheme('neutral', '_9')};
+    margin-bottom: 8px;
+    gap: 6px;
 
-const ActionButton = styled.button<{ primary?: boolean }>`
-  flex: 1;
-  padding: 12px;
-  border-radius: 8px;
-  border: none;
-  font-weight: 600;
-  cursor: pointer;
-  background: ${({ primary }) => (primary ? '#3b82f6' : 'rgba(255,255,255,0.08)')};
-  color: #fff;
-  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
-  &:disabled {
-    cursor: not-allowed;
+    .block-key {
+      ${fonts.body2Reg};
+      color: ${getTheme('neutral', 'a')};
+    }
+
+    .block-value {
+      ${fonts.body2Reg};
+      width: 100%;
+      word-break: break-all;
+      color: ${getTheme('neutral', '_1')};
+    }
+
+    .raw-pre {
+      width: 100%;
+      max-height: 240px;
+      overflow-y: auto;
+      margin: 0;
+      padding: 10px 12px;
+      border-radius: 12px;
+      background-color: ${getTheme('neutral', '_8')};
+      border: 1px solid ${getTheme('neutral', '_7')};
+      font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 11px;
+      line-height: 16px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: ${getTheme('neutral', '_1')};
+    }
+  }
+
+  .error-banner {
+    width: 100%;
+    min-height: 40px;
+    padding: 10px 16px;
+    border-radius: 18px;
+    background-color: rgba(239, 45, 33, 0.08);
+    border: 1px solid ${getTheme('red', '_5')};
+    margin-bottom: 8px;
+    font-family: 'Inter', sans-serif;
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 20px;
+    color: ${getTheme('red', '_5')};
+    word-break: break-word;
+
+    .error-label {
+      font-weight: 700;
+    }
   }
 `;

--- a/packages/adena-extension/src/pages/popup/wallet/deposit/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/deposit/index.tsx
@@ -126,7 +126,7 @@ export const Deposit = (): JSX.Element => {
       <CopyInputBox>
         {currentAccount && (
           <Text type='body2Reg' display='inline-flex'>
-            {formatNickname(accountNames[currentAccount.id], 12)}
+            {formatNickname(accountNames[currentAccount.id] || currentAccount.name, 12)}
             <Text type='body2Reg' color={theme.neutral.a}>
               {` (${displayAddr})`}
             </Text>

--- a/packages/adena-extension/src/pages/web/wallet-export-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-export-screen/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { View, WebMain } from '@components/atoms';
 import useWalletExportScreen from '@hooks/web/wallet-export/use-wallet-export-screen';
+import { useAccountName } from '@hooks/use-account-name';
 import WalletExportCheckPassword from './check-password';
 import WalletExportResult from './result';
 import SensitiveInfoStep from '@components/pages/web/sensitive-info-step';
@@ -21,10 +22,16 @@ const WalletExportScreen: React.FC = () => {
     checkPassword,
     moveExport,
   } = useWalletExportScreen();
+  const { accountNames } = useAccountName();
 
   const spacing = useMemo(() => {
     return null;
   }, [])
+
+  const currentAccountDisplayName = useMemo(() => {
+    if (!currentAccount) return '';
+    return accountNames[currentAccount.id] || currentAccount.name;
+  }, [accountNames, currentAccount]);
 
   const description = useMemo(() => {
     if (exportType === 'PRIVATE_KEY') {
@@ -47,6 +54,7 @@ const WalletExportScreen: React.FC = () => {
         {walletExportState !== 'INIT' && (
           <WebMainAccountHeader
             account={currentAccount}
+            displayName={currentAccountDisplayName}
             onClickGoBack={backStep}
           />
         )}

--- a/packages/adena-extension/src/repositories/wallet/wallet-address.ts
+++ b/packages/adena-extension/src/repositories/wallet/wallet-address.ts
@@ -1,7 +1,11 @@
 import { StorageManager } from '@common/storage/storage-manager';
-import { decryptAES, encryptAES } from 'adena-module';
+import {
+  decryptXChacha20,
+  EncryptedData,
+  encryptXChacha20,
+} from 'adena-module';
 
-type LocalValueType = 'ADDRESS_BOOK' | 'ENCRYPTED_STORED_PASSWORD';
+type LocalValueType = 'ADDRESS_BOOK';
 
 export interface AddressBookItem {
   id: string;
@@ -17,14 +21,18 @@ export class WalletAddressRepository {
     this.localStorage = localStorage;
   }
 
-  public getAddressBook = async (password: string): Promise<AddressBookItem[]> => {
+  public getAddressBook = async (
+    password: string,
+    salt: Uint8Array,
+  ): Promise<AddressBookItem[]> => {
     const encryptedAddressBook = await this.localStorage.get('ADDRESS_BOOK');
     if (!encryptedAddressBook) {
       return [];
     }
-    const addressBookRaw = await decryptAES(encryptedAddressBook, password);
 
     try {
+      const encryptedData: EncryptedData = JSON.parse(encryptedAddressBook);
+      const addressBookRaw = await decryptXChacha20(encryptedData, password, salt);
       return JSON.parse(addressBookRaw) as AddressBookItem[];
     } catch {
       return [];
@@ -34,11 +42,12 @@ export class WalletAddressRepository {
   public updateAddressBook = async (
     addressBook: AddressBookItem[],
     password: string,
+    salt: Uint8Array,
   ): Promise<void> => {
     const addressBookRaw = JSON.stringify(addressBook);
-    const encryptedAddressBook = await encryptAES(addressBookRaw, password);
+    const encrypted = await encryptXChacha20(addressBookRaw, password, salt);
 
-    await this.localStorage.set('ADDRESS_BOOK', encryptedAddressBook);
+    await this.localStorage.set('ADDRESS_BOOK', JSON.stringify(encrypted));
   };
 
   public deleteAddress = async (): Promise<void> => {

--- a/packages/adena-extension/src/repositories/wallet/wallet.ts
+++ b/packages/adena-extension/src/repositories/wallet/wallet.ts
@@ -7,7 +7,11 @@ type LocalValueType =
   | 'QUESTIONNAIRE_EXPIRED_DATE'
   | 'WALLET_CREATION_GUIDE_CONFIRM_DATE'
   | 'ADD_ACCOUNT_GUIDE_CONFIRM_DATE'
-  | 'KDF_SALT';
+  | 'KDF_SALT'
+  | 'AUTO_LOCK_TIMEOUT_MINUTES';
+
+export const DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES = 5;
+export const MAX_AUTO_LOCK_TIMEOUT_MINUTES = 1440;
 type SessionValueType = 'ENCRYPTED_KEY' | 'ENCRYPTED_PASSWORD';
 
 export class WalletRepository {
@@ -156,6 +160,22 @@ export class WalletRepository {
 
   public updateAddAccountGuideConfirmDate = async (confirmDate: number): Promise<void> => {
     await this.localStorage.set('ADD_ACCOUNT_GUIDE_CONFIRM_DATE', confirmDate);
+  };
+
+  public getAutoLockTimeoutMinutes = async (): Promise<number> => {
+    const value = await this.localStorage.get('AUTO_LOCK_TIMEOUT_MINUTES');
+    if (value === null || value === undefined || value === '') {
+      return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+    }
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+    }
+    return parsed;
+  };
+
+  public updateAutoLockTimeoutMinutes = async (minutes: number): Promise<void> => {
+    await this.localStorage.set('AUTO_LOCK_TIMEOUT_MINUTES', minutes);
   };
 
   public getKdfSalt = async (): Promise<Uint8Array | null> => {

--- a/packages/adena-extension/src/repositories/wallet/wallet.ts
+++ b/packages/adena-extension/src/repositories/wallet/wallet.ts
@@ -4,10 +4,10 @@ import { clearInMemoryKey, decryptPassword, encryptPassword } from '@common/util
 
 type LocalValueType =
   | 'SERIALIZED'
-  | 'ENCRYPTED_STORED_PASSWORD'
   | 'QUESTIONNAIRE_EXPIRED_DATE'
   | 'WALLET_CREATION_GUIDE_CONFIRM_DATE'
-  | 'ADD_ACCOUNT_GUIDE_CONFIRM_DATE';
+  | 'ADD_ACCOUNT_GUIDE_CONFIRM_DATE'
+  | 'KDF_SALT';
 type SessionValueType = 'ENCRYPTED_KEY' | 'ENCRYPTED_PASSWORD';
 
 export class WalletRepository {
@@ -37,7 +37,6 @@ export class WalletRepository {
 
   public deleteSerializedWallet = async (): Promise<boolean> => {
     await this.localStorage.remove('SERIALIZED');
-    await this.localStorage.remove('ENCRYPTED_STORED_PASSWORD');
     await this.localStorage.remove('QUESTIONNAIRE_EXPIRED_DATE');
 
     return true;
@@ -98,18 +97,12 @@ export class WalletRepository {
       const { encryptedKey, encryptedPassword } = await encryptPassword(password);
       await this.sessionStorage.set('ENCRYPTED_KEY', encryptedKey);
       await this.sessionStorage.set('ENCRYPTED_PASSWORD', encryptedPassword);
-      await this.localStorage.remove('ENCRYPTED_STORED_PASSWORD');
     } catch (e) {
       console.warn('Failed to update wallet password', e);
 
       return false;
     }
 
-    return true;
-  };
-
-  public updateStoredPassword = async (encryptedStoredPassword: string): Promise<boolean> => {
-    await this.localStorage.set('ENCRYPTED_STORED_PASSWORD', encryptedStoredPassword);
     return true;
   };
 
@@ -120,11 +113,6 @@ export class WalletRepository {
     await this.sessionStorage.remove('ENCRYPTED_PASSWORD');
 
     return true;
-  };
-
-  public getEncryptedPassword = async (): Promise<string> => {
-    const encryptedPassword = await this.localStorage.get('ENCRYPTED_STORED_PASSWORD');
-    return encryptedPassword;
   };
 
   public updateStoragePassword = async (password: string): Promise<void> => {
@@ -168,6 +156,18 @@ export class WalletRepository {
 
   public updateAddAccountGuideConfirmDate = async (confirmDate: number): Promise<void> => {
     await this.localStorage.set('ADD_ACCOUNT_GUIDE_CONFIRM_DATE', confirmDate);
+  };
+
+  public getKdfSalt = async (): Promise<Uint8Array | null> => {
+    const saltB64 = await this.localStorage.get('KDF_SALT');
+    if (!saltB64) {
+      return null;
+    }
+    return Uint8Array.from(Buffer.from(saltB64, 'base64'));
+  };
+
+  public updateKdfSalt = async (salt: Uint8Array): Promise<void> => {
+    await this.localStorage.set('KDF_SALT', Buffer.from(salt).toString('base64'));
   };
 
   public migrate = async (password: string): Promise<void> => {

--- a/packages/adena-extension/src/router/popup/header/approve-menu/index.tsx
+++ b/packages/adena-extension/src/router/popup/header/approve-menu/index.tsx
@@ -1,11 +1,18 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
+import { RoutePath } from '@types';
 import { getTheme } from '@styles/theme';
-import { Text, CopyTooltip, StatusDot, Row } from '@components/atoms';
+import mixins from '@styles/mixins';
 import {
-  formatAddress,
+  AccountSelectorButton,
+  NetworkIconButton,
+} from '@components/atoms';
+import IconCopy from '@assets/icon-copy';
+import { AccountAddressesPopover } from '@components/pages/router/top-menu/account-addresses-popover';
+import {
+  decodeParameter,
   formatNickname,
   getSiteName,
   parseParameters,
@@ -13,36 +20,94 @@ import {
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { useAdenaContext } from '@hooks/use-context';
 import { useAccountName } from '@hooks/use-account-name';
-import { useChain } from '@hooks/use-chain';
+import { useAccountChainAddresses } from '@hooks/use-account-chain-addresses';
 import { useNetwork } from '@hooks/use-network';
 
-const StyledContainer = styled(Row)`
+const COSMOS_APPROVE_PATHS: string[] = [
+  RoutePath.ApproveEstablishCosmos,
+  RoutePath.ApproveSignCosmos,
+  RoutePath.ApproveGetCosmosKey,
+];
+
+const extractCosmosChainId = (encodedData: string | undefined): string | undefined => {
+  if (!encodedData) return undefined;
+  const decoded = decodeParameter(encodedData);
+  const data = decoded?.data;
+  if (typeof data?.chainId === 'string' && data.chainId) {
+    return data.chainId;
+  }
+  if (Array.isArray(data?.chainIds) && typeof data.chainIds[0] === 'string') {
+    return data.chainIds[0];
+  }
+  return undefined;
+};
+
+const Wrapper = styled.div`
   width: 100%;
   height: 100%;
   padding: 0px 20px;
-  justify-content: center;
-  align-items: center;
   border-bottom: 1px solid ${getTheme('neutral', '_7')};
 `;
 
-const StyledCenterWrapper = styled(Row)`
-  width: auto;
+const Header = styled.div`
+  ${mixins.flex({ direction: 'row', justify: 'space-between' })};
+  width: 100%;
   height: 100%;
+`;
+
+const StyledLeftSideWrapper = styled.div`
+  ${mixins.flex({ direction: 'row', align: 'center', justify: 'flex-start' })};
   gap: 8px;
+  height: 100%;
+`;
+
+const StyledRightSideWrapper = styled.div`
+  ${mixins.flex({ direction: 'row', align: 'center', justify: 'flex-start' })};
+  gap: 12px;
+  height: 100%;
+`;
+
+const StyledCopyIconButton = styled.button.withConfig({
+  shouldForwardProp: (prop) => prop !== 'isActive',
+})<{ isActive?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: ${({ isActive, theme }): string => (isActive ? theme.neutral._1 : theme.neutral.a)};
+  flex-shrink: 0;
+
+  &:hover {
+    color: ${getTheme('neutral', '_1')};
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
 `;
 
 const ApproveMenu = (): JSX.Element => {
-  const theme = useTheme();
-  const { establishService } = useAdenaContext();
-  const { currentAccount, getCurrentAddress } = useCurrentAccount();
-  const [address, setAddress] = useState('');
+  const { establishService, establishAtomOneService } = useAdenaContext();
+  const { currentAccount } = useCurrentAccount();
   const [accountName, setAccountName] = useState('');
   const [isEstablished, setIsEstablished] = useState(false);
   const location = useLocation();
   const [requestData, setRequestData] = useState<any>();
   const { accountNames } = useAccountName();
   const { currentNetwork } = useNetwork();
-  const chain = useChain();
+
+  const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [popoverX, setPopoverX] = useState(0);
+  const [popoverY, setPopoverY] = useState(0);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const chainAddressEntries = useAccountChainAddresses();
 
   useEffect(() => {
     if (location.search) {
@@ -58,54 +123,121 @@ const ApproveMenu = (): JSX.Element => {
   }, [requestData, currentAccount, currentNetwork]);
 
   useEffect(() => {
-    initAddress();
-  }, [currentAccount]);
+    if (!currentAccount) return;
+    setAccountName(accountNames[currentAccount.id] || currentAccount.name);
+  }, [currentAccount, accountNames]);
 
-  const initAddress = async (): Promise<void> => {
-    if (!currentAccount) {
-      return;
-    }
-    const address = (await getCurrentAddress(chain.bech32Prefix)) || '';
-    const currentAccountName = accountNames[currentAccount.id] || currentAccount.name;
-    setAddress(address);
-    setAccountName(currentAccountName);
-  };
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!popoverOpen) return;
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setPopoverOpen(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [popoverOpen]);
+
+  const isCosmosApproveRoute = useMemo(
+    () => COSMOS_APPROVE_PATHS.includes(location.pathname),
+    [location.pathname],
+  );
 
   const updateEstablishState = async (): Promise<void> => {
-    if (requestData?.hostname) {
-      const id = currentAccount?.id ?? '';
-      const siteName = getSiteName(requestData.protocol, requestData.hostname);
-      const currentIsEstablished = await establishService.isEstablishedBy(id, siteName);
-      setIsEstablished(currentIsEstablished);
+    if (!requestData?.hostname) return;
+    const id = currentAccount?.id ?? '';
+    const siteName = getSiteName(requestData.protocol, requestData.hostname);
+
+    if (isCosmosApproveRoute) {
+      const chainId = extractCosmosChainId(requestData.data);
+      if (!chainId) {
+        setIsEstablished(false);
+        return;
+      }
+      try {
+        const established = await establishAtomOneService.isEstablishedBy(id, siteName, chainId);
+        setIsEstablished(established);
+      } catch {
+        setIsEstablished(false);
+      }
+      return;
     }
+
+    const currentIsEstablished = await establishService.isEstablishedBy(id, siteName);
+    setIsEstablished(currentIsEstablished);
   };
 
-  const getTooltipText = (): string => {
-    let currentHostname = requestData?.hostname ?? '';
-    if (currentHostname.startsWith('chrome-extension') || !currentHostname.includes('.')) {
-      currentHostname = 'chrome-extension';
+  const scheduleClose = useCallback(() => {
+    closeTimerRef.current = setTimeout(() => setPopoverOpen(false), 120);
+  }, []);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
     }
-    return isEstablished
-      ? `You are connected to ${currentHostname}`
-      : `You are not connected to ${currentHostname}`;
-  };
+  }, []);
+
+  const handleCopyIconMouseEnter = useCallback(() => {
+    cancelClose();
+    if (copyButtonRef.current) {
+      const rect = copyButtonRef.current.getBoundingClientRect();
+      const POPOVER_WIDTH = 220;
+      const iconCenterX = rect.left + rect.width / 2;
+      const popoverLeft = (window.innerWidth - POPOVER_WIDTH) / 2;
+      setPopoverX(iconCenterX - popoverLeft);
+      setPopoverY(rect.bottom + 16);
+    }
+    setPopoverOpen(true);
+  }, [cancelClose]);
+
+  const handleCopyIconMouseLeave = useCallback(() => {
+    scheduleClose();
+  }, [scheduleClose]);
+
+  const displayHostname = useMemo(() => {
+    const h = requestData?.hostname ?? '';
+    if (!h || h.startsWith('chrome-extension') || !h.includes('.')) {
+      return 'chrome-extension';
+    }
+    return h;
+  }, [requestData?.hostname]);
 
   return (
-    <StyledContainer>
-      {address && (
-        <StyledCenterWrapper>
-          <StatusDot status={isEstablished} tooltipText={getTooltipText()} />
-          <CopyTooltip copyText={address} className='t-approve'>
-            <Text type='body1Bold' display='inline-flex' style={{ whiteSpace: 'pre' }}>
-              {formatNickname(accountName, 12)}
-              <Text type='body1Reg' color={theme.neutral.a} style={{ whiteSpace: 'pre' }}>
-                {` (${formatAddress(address)})`}
-              </Text>
-            </Text>
-          </CopyTooltip>
-        </StyledCenterWrapper>
-      )}
-    </StyledContainer>
+    <Wrapper>
+      <Header>
+        <StyledLeftSideWrapper>
+          <AccountSelectorButton name={formatNickname(accountName, 12)} />
+          <StyledCopyIconButton
+            ref={copyButtonRef}
+            type='button'
+            isActive={popoverOpen}
+            onMouseEnter={handleCopyIconMouseEnter}
+            onMouseLeave={handleCopyIconMouseLeave}
+            aria-label='Copy address'
+          >
+            <IconCopy />
+          </StyledCopyIconButton>
+        </StyledLeftSideWrapper>
+        <StyledRightSideWrapper>
+          <NetworkIconButton isConnected={isEstablished} hostname={displayHostname} />
+        </StyledRightSideWrapper>
+      </Header>
+      <AccountAddressesPopover
+        open={popoverOpen}
+        positionX={popoverX}
+        positionY={popoverY}
+        onMouseEnter={cancelClose}
+        onMouseLeave={scheduleClose}
+        entries={chainAddressEntries}
+      />
+    </Wrapper>
   );
 };
 

--- a/packages/adena-extension/src/router/popup/header/index.tsx
+++ b/packages/adena-extension/src/router/popup/header/index.tsx
@@ -40,6 +40,9 @@ export const Header = (): JSX.Element => {
   const approveSign = useMatch(RoutePath.ApproveSign);
   const approveTransaction = useMatch(RoutePath.ApproveTransaction);
   const approveSignFailed = useMatch(RoutePath.ApproveSignFailed);
+  const approveEstablishCosmos = useMatch(RoutePath.ApproveEstablishCosmos);
+  const approveSignCosmos = useMatch(RoutePath.ApproveSignCosmos);
+  const approveGetCosmosKey = useMatch(RoutePath.ApproveGetCosmosKey);
   const wallet = useMatch('/wallet/*');
   const nft = useMatch(RoutePath.Nft);
 
@@ -73,7 +76,15 @@ export const Header = (): JSX.Element => {
       }
       return <ProgressMenu progressLevel={'first'} />;
     }
-    if (approveEstablish || approveTransaction || approveSign || approveSignFailed) {
+    if (
+      approveEstablish ||
+      approveTransaction ||
+      approveSign ||
+      approveSignFailed ||
+      approveEstablishCosmos ||
+      approveSignCosmos ||
+      approveGetCosmosKey
+    ) {
       return <ApproveMenu />;
     }
     if (createPassword) {

--- a/packages/adena-extension/src/router/popup/index.tsx
+++ b/packages/adena-extension/src/router/popup/index.tsx
@@ -6,6 +6,7 @@ import { RoutePath } from '../../types/router';
 import { AboutAdena } from '@pages/popup/certify/about-adena';
 import AddAddress from '@pages/popup/certify/add-address';
 import AddressBook from '@pages/popup/certify/address-book';
+import { AutoLockTimer } from '@pages/popup/certify/auto-lock-timer';
 import ChangeNetwork from '@pages/popup/certify/change-network';
 import { ChangePassword } from '@pages/popup/certify/change-password';
 import { ConnectedApps } from '@pages/popup/certify/connected-apps';
@@ -174,6 +175,7 @@ export const PopupRouter = (): JSX.Element => {
         <Route path={RoutePath.AddressBook} element={<AddressBook />} />
         <Route path={RoutePath.AddAddress} element={<AddAddress />} />
         <Route path={RoutePath.SecurityPrivacy} element={<SecurityPrivacy />} />
+        <Route path={RoutePath.SettingAutoLockTimer} element={<AutoLockTimer />} />
         <Route path={RoutePath.AboutAdena} element={<AboutAdena />} />
         <Route path={RoutePath.RemoveAccount} element={<RemoveAccount />} />
         <Route path={RoutePath.ResetWallet} element={<ResetWallet />} />

--- a/packages/adena-extension/src/services/wallet/index.ts
+++ b/packages/adena-extension/src/services/wallet/index.ts
@@ -1,4 +1,5 @@
 export * from './wallet';
+export * from './pending-wallet-store';
 export * from './wallet-account';
 export * from './wallet-establish';
 export * from './wallet-establish-atomone';

--- a/packages/adena-extension/src/services/wallet/pending-wallet-store.spec.ts
+++ b/packages/adena-extension/src/services/wallet/pending-wallet-store.spec.ts
@@ -1,0 +1,67 @@
+import { AdenaWallet } from 'adena-module';
+
+import { pendingWalletStore } from './pending-wallet-store';
+
+function makeWalletStub(): { wallet: AdenaWallet; destroy: jest.Mock } {
+  const destroy = jest.fn();
+  const wallet = { destroy } as unknown as AdenaWallet;
+  return { wallet, destroy };
+}
+
+describe('pendingWalletStore', () => {
+  beforeEach(() => {
+    pendingWalletStore.clear();
+  });
+
+  it('starts empty', () => {
+    expect(pendingWalletStore.has()).toBe(false);
+    expect(pendingWalletStore.consume()).toBeNull();
+  });
+
+  it('set then consume returns the wallet and empties the store', () => {
+    const { wallet } = makeWalletStub();
+
+    pendingWalletStore.set(wallet);
+    expect(pendingWalletStore.has()).toBe(true);
+
+    expect(pendingWalletStore.consume()).toBe(wallet);
+    expect(pendingWalletStore.has()).toBe(false);
+    expect(pendingWalletStore.consume()).toBeNull();
+  });
+
+  it('overwriting a pending wallet destroys the previous one', () => {
+    const first = makeWalletStub();
+    const second = makeWalletStub();
+
+    pendingWalletStore.set(first.wallet);
+    pendingWalletStore.set(second.wallet);
+
+    expect(first.destroy).toHaveBeenCalledTimes(1);
+    expect(second.destroy).not.toHaveBeenCalled();
+    expect(pendingWalletStore.consume()).toBe(second.wallet);
+  });
+
+  it('clear destroys the pending wallet and empties the store', () => {
+    const { wallet, destroy } = makeWalletStub();
+    pendingWalletStore.set(wallet);
+
+    pendingWalletStore.clear();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(pendingWalletStore.has()).toBe(false);
+  });
+
+  it('clear is a no-op when empty', () => {
+    expect(() => pendingWalletStore.clear()).not.toThrow();
+    expect(pendingWalletStore.has()).toBe(false);
+  });
+
+  it('consume does not call destroy — caller owns the lifetime', () => {
+    const { wallet, destroy } = makeWalletStub();
+    pendingWalletStore.set(wallet);
+
+    pendingWalletStore.consume();
+
+    expect(destroy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adena-extension/src/services/wallet/pending-wallet-store.ts
+++ b/packages/adena-extension/src/services/wallet/pending-wallet-store.ts
@@ -1,0 +1,32 @@
+import { AdenaWallet } from 'adena-module';
+
+// Single-shot in-memory handoff for an unencrypted wallet between an onboarding
+// entry flow and the create-password screen. The wallet is never serialized to
+// history.state, storage, or any other channel that survives in heap snapshots
+// or DevTools introspection. On consume/clear/overwrite, the wallet's keyring
+// buffers are zeroized via AdenaWallet.destroy() (sodium.memzero).
+
+let pending: AdenaWallet | null = null;
+
+export const pendingWalletStore = {
+  set(wallet: AdenaWallet): void {
+    if (pending) {
+      pending.destroy();
+    }
+    pending = wallet;
+  },
+  consume(): AdenaWallet | null {
+    const current = pending;
+    pending = null;
+    return current;
+  },
+  clear(): void {
+    if (pending) {
+      pending.destroy();
+      pending = null;
+    }
+  },
+  has(): boolean {
+    return pending !== null;
+  },
+};

--- a/packages/adena-extension/src/services/wallet/wallet-address-book.ts
+++ b/packages/adena-extension/src/services/wallet/wallet-address-book.ts
@@ -14,9 +14,18 @@ export class WalletAddressBookService {
     this.walletAddressRepository = walletAddressRepository;
   }
 
-  public getAddressBook = async (): Promise<AddressBookItem[]> => {
+  private getPasswordAndSalt = async (): Promise<{ password: string; salt: Uint8Array }> => {
     const password = await this.walletRepository.getWalletPassword();
-    const addressBook = await this.walletAddressRepository.getAddressBook(password);
+    const salt = await this.walletRepository.getKdfSalt();
+    if (!salt) {
+      throw new Error('KDF salt not found');
+    }
+    return { password, salt };
+  };
+
+  public getAddressBook = async (): Promise<AddressBookItem[]> => {
+    const { password, salt } = await this.getPasswordAndSalt();
+    const addressBook = await this.walletAddressRepository.getAddressBook(password, salt);
     return addressBook;
   };
 
@@ -24,8 +33,8 @@ export class WalletAddressBookService {
     name: string;
     address: string;
   }): Promise<void> => {
-    const password = await this.walletRepository.getWalletPassword();
-    const addressBook = await this.walletAddressRepository.getAddressBook(password);
+    const { password, salt } = await this.getPasswordAndSalt();
+    const addressBook = await this.walletAddressRepository.getAddressBook(password, salt);
     await this.walletAddressRepository.updateAddressBook(
       [
         ...addressBook,
@@ -37,6 +46,7 @@ export class WalletAddressBookService {
         },
       ],
       password,
+      salt,
     );
   };
 
@@ -45,8 +55,8 @@ export class WalletAddressBookService {
     name: string;
     address: string;
   }): Promise<void> => {
-    const password = await this.walletRepository.getWalletPassword();
-    const addressBook = await this.walletAddressRepository.getAddressBook(password);
+    const { password, salt } = await this.getPasswordAndSalt();
+    const addressBook = await this.walletAddressRepository.getAddressBook(password, salt);
     const changedAddressBook = addressBook.map((item) => {
       if (item.id === addressBookItem.id) {
         return {
@@ -57,20 +67,20 @@ export class WalletAddressBookService {
       }
       return item;
     });
-    await this.walletAddressRepository.updateAddressBook(changedAddressBook, password);
+    await this.walletAddressRepository.updateAddressBook(changedAddressBook, password, salt);
   };
 
   public removeAddressBookItemByAccountId = async (
     accountId: string,
     addressBookId: string,
   ): Promise<void> => {
-    const password = await this.walletRepository.getWalletPassword();
-    const addressBook = await this.walletAddressRepository.getAddressBook(password);
+    const { password, salt } = await this.getPasswordAndSalt();
+    const addressBook = await this.walletAddressRepository.getAddressBook(password, salt);
 
     const changedAddressBook = addressBook.filter(
       (item: AddressBookItem) => item.id !== addressBookId,
     );
-    await this.walletAddressRepository.updateAddressBook(changedAddressBook, password);
+    await this.walletAddressRepository.updateAddressBook(changedAddressBook, password, salt);
   };
 
   public clear = async (): Promise<boolean> => {

--- a/packages/adena-extension/src/services/wallet/wallet.ts
+++ b/packages/adena-extension/src/services/wallet/wallet.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { QUESTIONNAIRE_EXPIRATION_MIN } from '@common/constants/storage.constant';
 import { WalletError } from '@common/errors/wallet/wallet-error';
+import { CommandMessage } from '@inject/message/command-message';
 import { WalletRepository } from '@repositories/wallet';
 
 export class WalletService {
@@ -315,6 +316,21 @@ export class WalletService {
       ? this.walletRepository.updateAddAccountGuideConfirmDate.bind(this.walletRepository)
       : this.walletRepository.updateWalletCreationGuideConfirmDate.bind(this.walletRepository);
     await updateGuideConfirmDate(confirmDate);
+  };
+
+  public getAutoLockTimeoutMinutes = async (): Promise<number> => {
+    return this.walletRepository.getAutoLockTimeoutMinutes();
+  };
+
+  public updateAutoLockTimeoutMinutes = async (minutes: number): Promise<void> => {
+    await this.walletRepository.updateAutoLockTimeoutMinutes(minutes);
+    try {
+      await chrome.runtime.sendMessage(
+        CommandMessage.command('updateAutoLockTimer', { minutes }),
+      );
+    } catch (e) {
+      console.warn('Failed to notify background of auto-lock timer update', e);
+    }
   };
 
   public clear = async (): Promise<boolean> => {

--- a/packages/adena-extension/src/services/wallet/wallet.ts
+++ b/packages/adena-extension/src/services/wallet/wallet.ts
@@ -5,13 +5,13 @@ import {
   Wallet,
   MultisigConfig,
   SignerPublicKeyInfo,
+  generateKdfSalt,
 } from 'adena-module';
 import dayjs from 'dayjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { QUESTIONNAIRE_EXPIRATION_MIN } from '@common/constants/storage.constant';
 import { WalletError } from '@common/errors/wallet/wallet-error';
-import { encryptSha256Password, encryptWalletPassword } from '@common/utils/crypto-utils';
 import { WalletRepository } from '@repositories/wallet';
 
 export class WalletService {
@@ -131,10 +131,13 @@ export class WalletService {
    * @param password wallet's password
    */
   public saveWallet = async (wallet: Wallet, password: string): Promise<void> => {
-    const encryptedPassword = encryptWalletPassword(password);
-
-    const serializedWallet = await wallet.serialize(encryptedPassword);
-    await this.walletRepository.updateWalletPassword(encryptedPassword);
+    let salt = await this.walletRepository.getKdfSalt();
+    if (!salt) {
+      salt = await generateKdfSalt();
+      await this.walletRepository.updateKdfSalt(salt);
+    }
+    const serializedWallet = await wallet.serialize(password, salt);
+    await this.walletRepository.updateWalletPassword(password);
     await this.walletRepository.updateSerializedWallet(serializedWallet);
     try {
       chrome?.action?.setPopup({ popup: 'popup.html' });
@@ -144,9 +147,12 @@ export class WalletService {
   };
 
   public updateWallet = async (wallet: Wallet): Promise<void> => {
-    let encryptedWallet = await this.walletRepository.getWalletPassword();
-    const serializedWallet = await wallet.serialize(encryptedWallet);
-    encryptedWallet = '';
+    const password = await this.walletRepository.getWalletPassword();
+    const salt = await this.walletRepository.getKdfSalt();
+    if (!salt) {
+      throw new WalletError('FAILED_TO_LOAD');
+    }
+    const serializedWallet = await wallet.serialize(password, salt);
 
     await this.walletRepository.updateSerializedWallet(serializedWallet);
     try {
@@ -228,8 +234,12 @@ export class WalletService {
   public deserializeWallet = async (password: string): Promise<AdenaWallet> => {
     try {
       const serializedWallet = await this.walletRepository.getSerializedWallet();
+      const salt = await this.walletRepository.getKdfSalt();
+      if (!salt) {
+        throw new WalletError('FAILED_TO_LOAD');
+      }
 
-      const walletInstance = await AdenaWallet.deserialize(serializedWallet, password);
+      const walletInstance = await AdenaWallet.deserialize(serializedWallet, password, salt);
 
       return walletInstance;
     } catch (e) {
@@ -240,6 +250,12 @@ export class WalletService {
 
   public lockWallet = async (): Promise<void> => {
     try {
+      const wallet = await this.loadWallet();
+      wallet.destroy();
+    } catch {
+      // Wallet may not be loadable (e.g. password already cleared)
+    }
+    try {
       await this.walletRepository.deleteWalletPassword();
     } catch (e) {
       throw new WalletError('FAILED_TO_LOAD');
@@ -247,32 +263,18 @@ export class WalletService {
   };
 
   public equalsPassword = async (password: string): Promise<boolean> => {
-    const storedPassword = await this.walletRepository.getEncryptedPassword();
-
     try {
-      if (encryptSha256Password(password) === storedPassword) {
-        await this.walletRepository.migrate(password);
-        return this.updatePassword(password);
-      }
-
-      const encryptedPassword = encryptWalletPassword(password);
-      const wallet = await this.deserializeWallet(encryptedPassword);
-      if (wallet) {
-        return this.updatePassword(password);
-      }
+      // Trigger migration (v018: AES-CBC → XChaCha20) before deserialization
+      await this.walletRepository.updateStoragePassword(password);
+      await this.deserializeWallet(password);
+      return true;
     } catch (e) {
-      console.error(e);
+      return false;
     }
-    return false;
   };
 
   public updatePassword = async (password: string): Promise<boolean> => {
     return this.walletRepository.updateWalletPassword(password);
-  };
-
-  public updatePasswordWithEncrypt = async (password: string): Promise<boolean> => {
-    const encryptedPassword = encryptWalletPassword(password);
-    return this.updatePassword(encryptedPassword);
   };
 
   public changePassword = async (password: string): Promise<boolean> => {

--- a/packages/adena-extension/src/types/router.ts
+++ b/packages/adena-extension/src/types/router.ts
@@ -89,6 +89,7 @@ export enum RoutePath {
   AboutAdena = '/settings/about-adena',
   RemoveAccount = '/settings/security-privacy/remove-account',
   ResetWallet = '/settings/security-privacy/reset-wallet',
+  SettingAutoLockTimer = '/settings/security-privacy/auto-lock-timer',
 
   // web
   WebNotFound = '/web/not-found',
@@ -270,6 +271,7 @@ export type RouteParams = {
   [RoutePath.ResetWallet]: {
     from: 'forgot-password';
   } | null;
+  [RoutePath.SettingAutoLockTimer]: null;
 
   [RoutePath.WebNotFound]: null;
   [RoutePath.WebConnectLedger]: null;

--- a/packages/adena-extension/src/types/router.ts
+++ b/packages/adena-extension/src/types/router.ts
@@ -280,10 +280,7 @@ export type RouteParams = {
   [RoutePath.WebSelectHardWallet]: null;
   [RoutePath.WebConnectLedger]: null;
   [RoutePath.WebAdvancedOption]: null;
-  [RoutePath.WebCreatePassword]: {
-    serializedWallet: string;
-    stepLength: number;
-  };
+  [RoutePath.WebCreatePassword]: null;
   [RoutePath.WebGoogleLogin]: {
     doneQuestionnaire: boolean;
   } | null;

--- a/packages/adena-module/src/wallet/keyring/address-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/address-keyring.ts
@@ -23,6 +23,10 @@ export class AddressKeyring implements Keyring {
     this.addressBytes = Uint8Array.from(addressBytes);
   }
 
+  destroy() {
+    // No sensitive key material to clear
+  }
+
   toData() {
     return {
       id: this.id,

--- a/packages/adena-module/src/wallet/keyring/hd-wallet-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/hd-wallet-keyring.ts
@@ -6,6 +6,7 @@ import {
   TxSignature,
   Wallet as Tm2Wallet,
 } from '@gnolang/tm2-js-client';
+import sodium from 'libsodium-wrappers-sumo';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Bip39, EnglishMnemonic, entropyToMnemonic, mnemonicToEntropy } from '../../crypto';
@@ -48,6 +49,11 @@ export class HDWalletKeyring implements Keyring {
     return publicKey;
   }
 
+  destroy() {
+    sodium.memzero(this.seed);
+    sodium.memzero(this.mnemonicEntropy);
+  }
+
   toData() {
     return {
       id: this.id,
@@ -60,7 +66,13 @@ export class HDWalletKeyring implements Keyring {
   async signRaw(bytes: Uint8Array, opts?: SignRawOptions): Promise<Uint8Array> {
     const hdPath = opts?.hdPath ?? 0;
     const privateKey = await this.getPrivateKey(hdPath);
-    return signRawWithPrivateKey(bytes, privateKey);
+    try {
+      return await signRawWithPrivateKey(bytes, privateKey);
+    } finally {
+      // Wipe the per-call derived private key from memory; the long-lived
+      // seed/entropy can re-derive it on the next call.
+      sodium.memzero(privateKey);
+    }
   }
 
   async sign(

--- a/packages/adena-module/src/wallet/keyring/keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/keyring.ts
@@ -35,6 +35,11 @@ export interface Keyring {
   // Decouples keyring from chain-specific serialization rules so that Gno,
   // Cosmos AMINO, and Cosmos DIRECT pipelines can share one signing primitive.
   signRaw: (bytes: Uint8Array, opts?: SignRawOptions) => Promise<Uint8Array>;
+  // Zeroes any sensitive key material held by the keyring so it cannot be
+  // recovered from the JS heap after the wallet is locked. Implementations
+  // must call sodium.memzero on every Uint8Array holding keys, seeds, or
+  // mnemonic entropy.
+  destroy: () => void;
   sign: (
     provider: Provider,
     document: Document,

--- a/packages/adena-module/src/wallet/keyring/ledger-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/ledger-keyring.ts
@@ -22,6 +22,10 @@ export class LedgerKeyring implements Keyring {
     this.connector = null;
   }
 
+  destroy() {
+    this.connector = null;
+  }
+
   setConnector(connector: LedgerConnector) {
     this.connector = connector;
   }

--- a/packages/adena-module/src/wallet/keyring/multisig-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/multisig-keyring.ts
@@ -52,6 +52,10 @@ export class MultisigKeyring implements Keyring {
     this.signerPublicKeys = keyringData.signerPublicKeys;
   }
 
+  destroy() {
+    // No sensitive key material to clear
+  }
+
   toData(): KeyringData {
     return {
       id: this.id,

--- a/packages/adena-module/src/wallet/keyring/private-key-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/private-key-keyring.ts
@@ -5,6 +5,7 @@ import {
   TxSignature,
   Wallet as Tm2Wallet,
 } from '@gnolang/tm2-js-client';
+import sodium from 'libsodium-wrappers-sumo';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Document } from './../..';
@@ -25,6 +26,10 @@ export class PrivateKeyKeyring implements Keyring {
     this.id = id || uuidv4();
     this.publicKey = Uint8Array.from(publicKey);
     this.privateKey = Uint8Array.from(privateKey);
+  }
+
+  destroy() {
+    sodium.memzero(this.privateKey);
   }
 
   toData() {

--- a/packages/adena-module/src/wallet/keyring/web3-auth-keyring.ts
+++ b/packages/adena-module/src/wallet/keyring/web3-auth-keyring.ts
@@ -5,6 +5,7 @@ import {
   TxSignature,
   Wallet as Tm2Wallet,
 } from '@gnolang/tm2-js-client';
+import sodium from 'libsodium-wrappers-sumo';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Document } from './../..';
@@ -26,6 +27,10 @@ export class Web3AuthKeyring implements Keyring {
     this.id = id || uuidv4();
     this.publicKey = Uint8Array.from(publicKey);
     this.privateKey = Uint8Array.from(privateKey);
+  }
+
+  destroy() {
+    sodium.memzero(this.privateKey);
   }
 
   toData() {

--- a/packages/adena-module/src/wallet/wallet-crypto-util.spec.ts
+++ b/packages/adena-module/src/wallet/wallet-crypto-util.spec.ts
@@ -1,9 +1,15 @@
+import sodium from 'libsodium-wrappers-sumo';
+
 import {
   decryptAES,
+  decryptXChacha20,
   encryptAES,
   encryptSha256,
+  encryptXChacha20,
   executeKdf,
+  generateKdfSalt,
   makeCryptKey,
+  makeCryptKeyBytes,
 } from './wallet-crypto-util';
 import { toHex } from '../encoding';
 
@@ -68,5 +74,73 @@ describe('encrypt/decrypt AES', () => {
     const result = await decryptAES(encryptedValue, password);
 
     expect(result).toBe('CURRENT_VALUE');
+  });
+});
+
+describe('makeCryptKeyBytes', () => {
+  it('returns 32-byte Uint8Array', async () => {
+    const salt = await generateKdfSalt();
+    const result = await makeCryptKeyBytes('PASSWORD', salt);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(32);
+  });
+});
+
+describe('encrypt/decrypt XChaCha20-Poly1305', () => {
+  const testPassword = 'TEST_PASSWORD';
+  let testSalt: Uint8Array;
+
+  beforeAll(async () => {
+    testSalt = await generateKdfSalt();
+  });
+
+  it('result contains ciphertext and nonce', async () => {
+    const result = await encryptXChacha20('hello world', testPassword, testSalt);
+    expect(result.ciphertext).toBeTruthy();
+    expect(result.nonce).toBeTruthy();
+  });
+
+  it('round-trip encrypt then decrypt recovers original', async () => {
+    const original = '{"accounts":[],"keyrings":[]}';
+    const encrypted = await encryptXChacha20(original, testPassword, testSalt);
+    const decrypted = await decryptXChacha20(encrypted, testPassword, testSalt);
+    expect(decrypted).toBe(original);
+  });
+
+  it('encrypting same plaintext twice produces different ciphertexts', async () => {
+    const plain = 'same plaintext';
+    const enc1 = await encryptXChacha20(plain, testPassword, testSalt);
+    const enc2 = await encryptXChacha20(plain, testPassword, testSalt);
+    expect(enc1.ciphertext).not.toBe(enc2.ciphertext);
+    expect(enc1.nonce).not.toBe(enc2.nonce);
+  });
+
+  it('tampered ciphertext throws on decrypt', async () => {
+    await sodium.ready;
+    const encrypted = await encryptXChacha20('secret data', testPassword, testSalt);
+    const bytes = sodium.from_base64(encrypted.ciphertext);
+    bytes[0] ^= 0xff;
+    const tampered = { ciphertext: sodium.to_base64(bytes), nonce: encrypted.nonce };
+
+    await expect(decryptXChacha20(tampered, testPassword, testSalt)).rejects.toThrow();
+  });
+
+  it('wrong password throws on decrypt', async () => {
+    const encrypted = await encryptXChacha20('secret', testPassword, testSalt);
+    await expect(decryptXChacha20(encrypted, 'WRONG_PASSWORD', testSalt)).rejects.toThrow();
+  });
+
+  it('handles unicode correctly', async () => {
+    const original = 'mnemonic seed phrase test \u{1F510}';
+    const encrypted = await encryptXChacha20(original, testPassword, testSalt);
+    const decrypted = await decryptXChacha20(encrypted, testPassword, testSalt);
+    expect(decrypted).toBe(original);
+  });
+
+  it('handles large data (64KB)', async () => {
+    const largeData = 'x'.repeat(65536);
+    const encrypted = await encryptXChacha20(largeData, testPassword, testSalt);
+    const decrypted = await decryptXChacha20(encrypted, testPassword, testSalt);
+    expect(decrypted).toBe(largeData);
   });
 });

--- a/packages/adena-module/src/wallet/wallet-crypto-util.ts
+++ b/packages/adena-module/src/wallet/wallet-crypto-util.ts
@@ -1,6 +1,7 @@
 import CryptoJS from 'crypto-js';
+import sodium from 'libsodium-wrappers-sumo';
 
-import { Argon2id, isArgon2idOptions } from '../crypto';
+import { Argon2id, isArgon2idOptions, Xchacha20poly1305Ietf, xchacha20NonceLength } from '../crypto';
 import { toAscii, toHex } from '../encoding';
 
 interface KdfConfiguration {
@@ -58,4 +59,74 @@ export const decryptAES = (encryptedValue: string, password: string) => {
   return Promise.resolve(makeCryptKey(password)).then((cryptKey) =>
     CryptoJS.AES.decrypt(encryptedValue, cryptKey).toString(CryptoJS.enc.Utf8),
   );
+};
+
+// --- XChaCha20-Poly1305 AEAD encryption (replacement for AES-CBC) ---
+
+export interface EncryptedData {
+  ciphertext: string; // base64
+  nonce: string; // base64
+}
+
+/**
+ * Generates a random 16-byte salt for Argon2id KDF.
+ * Called once when creating a new wallet, then stored in storage.
+ */
+export const generateKdfSalt = async (): Promise<Uint8Array> => {
+  await sodium.ready;
+  return sodium.randombytes_buf(16);
+};
+
+/**
+ * Derives a 32-byte key from password + salt using Argon2id.
+ * Returns raw Uint8Array bytes for use as an AEAD key.
+ */
+export const makeCryptKeyBytes = async (
+  password: string,
+  salt: Uint8Array,
+): Promise<Uint8Array> => {
+  return Argon2id.execute(password, salt, {
+    outputLength: 32,
+    opsLimit: 24,
+    memLimitKib: 12 * 1024,
+  });
+};
+
+/**
+ * Encrypts a string using XChaCha20-Poly1305 AEAD.
+ * Generates a random 24-byte nonce for each encryption.
+ * Returns ciphertext and nonce, both base64-encoded.
+ */
+export const encryptXChacha20 = async (
+  value: string,
+  password: string,
+  salt: Uint8Array,
+): Promise<EncryptedData> => {
+  await sodium.ready;
+  const cryptKey = await makeCryptKeyBytes(password, salt);
+  const nonce = sodium.randombytes_buf(xchacha20NonceLength);
+  const message = new TextEncoder().encode(value);
+  const ciphertext = await Xchacha20poly1305Ietf.encrypt(message, cryptKey, nonce);
+  return {
+    ciphertext: sodium.to_base64(ciphertext),
+    nonce: sodium.to_base64(nonce),
+  };
+};
+
+/**
+ * Decrypts data encrypted with encryptXChacha20.
+ * Verifies the Poly1305 authentication tag before returning plaintext.
+ * Throws if the ciphertext has been tampered with or the key is wrong.
+ */
+export const decryptXChacha20 = async (
+  encryptedData: EncryptedData,
+  password: string,
+  salt: Uint8Array,
+): Promise<string> => {
+  await sodium.ready;
+  const cryptKey = await makeCryptKeyBytes(password, salt);
+  const ciphertext = sodium.from_base64(encryptedData.ciphertext);
+  const nonce = sodium.from_base64(encryptedData.nonce);
+  const decrypted = await Xchacha20poly1305Ietf.decrypt(ciphertext, cryptKey, nonce);
+  return new TextDecoder().decode(decrypted);
 };

--- a/packages/adena-module/src/wallet/wallet.spec.ts
+++ b/packages/adena-module/src/wallet/wallet.spec.ts
@@ -1,5 +1,6 @@
 import { MockLedgerConnector } from './../test-utils/mock-ledgerconnector';
 import { AdenaWallet } from './wallet';
+import { generateKdfSalt } from './wallet-crypto-util';
 
 const mnemonic =
   'source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast';
@@ -73,32 +74,107 @@ describe('create wallet by ledger', () => {
 });
 
 describe('serialize', () => {
-  // SALT_KEY: TESTTESTTESTTEST
-  // PASSWORD: PASSWORD
+  let salt: Uint8Array;
+
+  beforeAll(async () => {
+    salt = await generateKdfSalt();
+  });
+
   it('serialize success', async () => {
     const wallet = await AdenaWallet.createByMnemonic(mnemonic);
-    const serialized = await wallet.serialize('PASSWORD');
+    const serialized = await wallet.serialize('PASSWORD', salt);
 
     expect(serialized).toBeTruthy();
+    const parsed = JSON.parse(serialized);
+    expect(parsed.ciphertext).toBeTruthy();
+    expect(parsed.nonce).toBeTruthy();
   });
 
-  it('deserialize success', async () => {
-    const serialized =
-      'U2FsdGVkX1/E9wVYaJL0UGOKTC0nxbdu1Jd0qdCqsjErlbEw4ruhRw+9Bxx1rVEMV20Gv86YRRprVZGTUHmuwU5gKcX/3DE0j9cvUn781WMff81DZcczqQMj1C0hhknmz/D/t34G7UWUeQyMQrSr7k6gyNo/KVyNVkAAlNuWCIkZGkzKkH+wPJdvliFLgxUaVbTuBKcO6fuZ1vvB2hbUZ0vE10/dIF3H5BTRYt6I64IbHNXEoQiz0ZzU+LItNMFbGELYLqi9xJKPaJY6T1fejibc6qxq0hhHvdSXT28rOciavvHGKi5lYpWWfQVl31WxmNZPmE8Hu21qF0P9rmY+x+t0jCtTOSmg+2r3WJOmHorOWChxVoCrob6qyGEZS7WSJ/nKo04IuroxO7xpnWXiyQvxv4TcsDSTtu298MRN4USViRodchJCe7mvvXO9yxEbXf3YcOQ7MF/tjyIXHd3cm4mcchbA4jQ2JPvlbb5+6kejThYqkHna3K8h1X2Pi9LFwdgDXZuajW2JtINPEpDxKx/yuMjrJaqtubzi2FIRTtC9NJauf5XizWDAN22m7rMbuV6KRNwwkleEB67CjdlOnJx7f0KxdopPT/XRlXivimUTf8nABAc7egWcaUmbvhtTnxOs9RYjIfq9Mid2AGk4Ehpsq8mLujOPVBLDdS5o+BUt4xTRV1/+ZIJKa/3m5bhWZWU2/pUMhXnxg8YKg6lba2cFwHu15KvE5+gjofNIgnXkwNCMRtEpaCgODBnz25RWcq+ktpiQI6nn6e9jIc9jPNtTX5mxuWC5G7yx7oSsGR4fbKd0xJZaZrn+I+1wyR39L7FFszWXOyCvyDDq0FxH7M0PiAVZbO+440XtRTEvblwEeJWlrR6Jze8XPjjfy/ehwYXNHfOoocP3SO/NYR7AuPxskDVoIdW9ZYu+FT4tL3yK8ew43MJqKYBWL483aUSEF9IofQr+9qOFSimWxCHzPmTRUvkf4gu1pHUoNU0o+oKN7CYw4UMJ1G0crXMBPwCKPWIgD0NGed2vJKjdYgAzApazXmc3s5DH2Jn2rO6fsU8c7egEm6CzUYO6rg2Eq9xvC6sscgbbpP3rEhTVCwc9ESd6p0htM+oq7I8AfNDBH8HUrLrkht4WoiHAZJZjo27FV+EWVcz+TtH6BoZ6jPbqB+zkeUbGFEcNuLK6IRvAAZEoCPDGNJSgJZLf7ULxMTAr4k9aJwh827gjEp9tw586rKAGC//AYG1FzyLVupvA7kQ=';
-    const wallet = await AdenaWallet.deserialize(serialized, 'PASSWORD');
+  it('serialize then deserialize round-trip success', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const serialized = await wallet.serialize('PASSWORD', salt);
+    const deserialized = await AdenaWallet.deserialize(serialized, 'PASSWORD', salt);
 
-    expect(wallet).toBeTruthy();
-    expect(wallet.accounts.length).toBe(1);
+    expect(deserialized).toBeTruthy();
+    expect(deserialized.accounts.length).toBe(1);
+    expect(deserialized.getMnemonic()).toBe(mnemonic);
   });
 
-  it('deserialize invalid password', async () => {
-    const serialized =
-      'U2FsdGVkX1/1NOyr0ePUNNNzXcR0lN4p5nHveepGqc0048xBRarEAHuUOCMh41qXmMxMZMTnNq0xrV3zd5COb2aa2ETbzW57rHcwTdVU11kvbkcFuKb8Vqghv0fGauy+/BxetqL+8VzqTAL8u5DQg29N0HUtSGPc5cFGBPDJ/TZBiDh43/fYi0mR75cG397eVxOMKJcKbWf6jNke9E2xp9QOlLAf6iZeqRitLlT20P7qw2UycoOmmg6Lfj7Z1o5xyyHe2rvt2BYQkC8ny3C2j7stFNRXcB0B8EZyQRwECkvRSmSBmnwX7PjHMQoqVSi/HxG/oLZNFhUcwHxFWpKF24So0iv+nkiLU4LEwjOZrbgpv8CFI1KXAGf442iOLvO+j5e5sRyCJqt53+U219UF1dbCtT7pr7WyeCfsAR6Eb3qoejUVR92m+PAfi/JWaYm2V7fDKflpnRVTzo7Eqn3+aQdUHZqjFXLo6k2sTw8hdZULA017sAe4WffOHL8XfRmi1m4SJUfBw3QrHNvdGYHmLX7rVMPDDGKMfbhk5W/H+e/7UX3Cz8rbS5mYcJNwOXNCgX6YYAxljdGR7HzRPKFIzBgOEOr4R3h7wibiq9hHrPKm0mDJYRkscRVQFvy78ko91KcE2NDkzyWwwXA7WAiWtlg3m0FlZxm/4DzmOVz5t7Kw2ln36W+xnT3qCbq37j/xii4PQDPCPuurMCa122BYOHYeuC/6Jd0l1GBuo5Vk2GQ4vNUq9YG55kCeI5cVznwLjEMBYDtlBb54uwxJgpBGHYYK1CQW+aVEl8AJihMrNuEesjznTSTNj9ZWXuVwnXIbRo9UjaEydlcfXpsew0WMFC8J2Brl08rrnX6N9wPWZ1V3ZO+ccGN5X3MsFIOADuNzYtyZdXrpeJxUChsiRKXIihu3qyjJp4OkaIqYSi/WoRpSL6CzmvhzPStRwU8yxIEZE8dnoUJroyQDrQRUhtYqB+PobWL7rjenwpAtCsUfu220N4XfuM/GGwkpg8jiepvToYWPzy9vJXBT9WZigsce6EPun2RieGRvq7FoCBExJnUPqWzFr3yew7ThwxxWcgtaX25Ej9ChFRl3YtrXuFg+d9vvzlA4OZcjoowT3BSVHfQJcJEL/f97fu24aIa2LKM6aNKcTsU/3YTYtxupLoK1v+xwLaT3R7rCMXyw+58u3grOweFEWtRjpmcIzvVDR/UZ';
-    let wallet;
-    try {
-      wallet = await AdenaWallet.deserialize(serialized, 'INVALID_PASSWORD');
-    } catch (e) {}
+  it('deserialize with invalid password throws', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const serialized = await wallet.serialize('PASSWORD', salt);
 
-    expect(wallet).toBeFalsy();
+    await expect(
+      AdenaWallet.deserialize(serialized, 'INVALID_PASSWORD', salt),
+    ).rejects.toThrow();
+  });
+
+  it('deserialize with different salt throws', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const serialized = await wallet.serialize('PASSWORD', salt);
+    const differentSalt = await generateKdfSalt();
+
+    await expect(
+      AdenaWallet.deserialize(serialized, 'PASSWORD', differentSalt),
+    ).rejects.toThrow();
+  });
+});
+
+describe('toJSON / fromJSON', () => {
+  it('round-trip preserves wallet data', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const json = wallet.toJSON();
+    const restored = AdenaWallet.fromJSON(json);
+
+    expect(restored.accounts.length).toBe(1);
+    expect(restored.getMnemonic()).toBe(mnemonic);
+  });
+
+  it('toJSON produces valid JSON with wallet fields', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const json = wallet.toJSON();
+    const parsed = JSON.parse(json);
+
+    expect(parsed).toHaveProperty('accounts');
+    expect(parsed).toHaveProperty('keyrings');
+    expect(parsed).toHaveProperty('currentAccountId');
+  });
+
+  it('toJSON is not encrypted (no ciphertext/nonce)', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const json = wallet.toJSON();
+    const parsed = JSON.parse(json);
+
+    expect(parsed).not.toHaveProperty('ciphertext');
+    expect(parsed).not.toHaveProperty('nonce');
+  });
+
+  it('fromJSON with invalid JSON throws', () => {
+    expect(() => AdenaWallet.fromJSON('invalid')).toThrow();
+  });
+});
+
+describe('destroy', () => {
+  it('clears keyrings and accounts after destroy', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    expect(wallet.keyrings.length).toBeGreaterThan(0);
+    expect(wallet.accounts.length).toBeGreaterThan(0);
+
+    wallet.destroy();
+
+    expect(wallet.keyrings.length).toBe(0);
+    expect(wallet.accounts.length).toBe(0);
+  });
+
+  it('keyring seed is zeroed after destroy', async () => {
+    const wallet = await AdenaWallet.createByMnemonic(mnemonic);
+    const keyring = wallet.keyrings[0] as any;
+    const seedBefore = new Uint8Array(keyring.seed);
+
+    wallet.destroy();
+
+    // Original buffer should be zeroed
+    expect(seedBefore.every((b: number) => b === 0)).toBe(false);
+    expect(keyring.seed.every((b: number) => b === 0)).toBe(true);
   });
 });

--- a/packages/adena-module/src/wallet/wallet.ts
+++ b/packages/adena-module/src/wallet/wallet.ts
@@ -48,7 +48,13 @@ import {
   makeKeyring,
   Web3AuthKeyring,
 } from './keyring';
-import { decryptAES, encryptAES } from './wallet-crypto-util';
+import {
+  decryptAES,
+  decryptXChacha20,
+  encryptAES,
+  EncryptedData,
+  encryptXChacha20,
+} from './wallet-crypto-util';
 
 export interface Wallet {
   accounts: Account[];
@@ -121,7 +127,8 @@ export interface Wallet {
     signedTx: SignedCosmosTx,
     cosmosProvider: CosmosProvider,
   ) => Promise<CosmosTxBroadcastResponse>;
-  serialize: (password: string) => Promise<string>;
+  serialize: (password: string, salt: Uint8Array) => Promise<string>;
+  destroy: () => void;
   clone: () => AdenaWallet;
 }
 export interface WalletData {
@@ -471,15 +478,15 @@ export class AdenaWallet implements Wallet {
     return cosmosProvider.broadcastTx(signedTx.txBytes, 'BROADCAST_MODE_SYNC');
   }
 
-  async serialize(password: string) {
+  async serialize(password: string, salt: Uint8Array) {
     const plain: WalletData = {
       currentAccountId: this._currentAccountId,
       accounts: this._accounts.map((account) => account.toData()),
       keyrings: this._keyrings.map((keyring) => keyring.toData()),
     };
     const serialized = JSON.stringify(plain);
-    const encryptedSerialize = await encryptAES(serialized, password);
-    return encryptedSerialize;
+    const encrypted = await encryptXChacha20(serialized, password, salt);
+    return JSON.stringify(encrypted);
   }
 
   /**
@@ -495,6 +502,29 @@ export class AdenaWallet implements Wallet {
     return addresses.includes(address);
   }
 
+  destroy() {
+    for (const keyring of this._keyrings) {
+      keyring.destroy();
+    }
+    this._keyrings = [];
+    this._accounts = [];
+    this._currentAccountId = undefined;
+  }
+
+  toJSON(): string {
+    const plain: WalletData = {
+      currentAccountId: this._currentAccountId,
+      accounts: this._accounts.map((account) => account.toData()),
+      keyrings: this._keyrings.map((keyring) => keyring.toData()),
+    };
+    return JSON.stringify(plain);
+  }
+
+  static fromJSON(json: string): AdenaWallet {
+    const plain: WalletData = JSON.parse(json);
+    return new AdenaWallet(plain);
+  }
+
   clone() {
     return new AdenaWallet({
       accounts: this._accounts.map((account) => account.toData()),
@@ -503,8 +533,9 @@ export class AdenaWallet implements Wallet {
     });
   }
 
-  public static async deserialize(encryptedSerialize: string, password: string) {
-    const serialized = await decryptAES(encryptedSerialize, password);
+  public static async deserialize(encryptedSerialize: string, password: string, salt: Uint8Array) {
+    const encryptedData: EncryptedData = JSON.parse(encryptedSerialize);
+    const serialized = await decryptXChacha20(encryptedData, password, salt);
     const plain: WalletData = JSON.parse(serialized);
     return new AdenaWallet(plain);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6197,6 +6197,7 @@ __metadata:
     qrcode.react: 3.1.0
     react: 18.2.0
     react-dom: 18.2.0
+    react-idle-timer: 5.7.2
     react-router-dom: 6.22.1
     recoil: 0.7.7
     storybook: 8.5.8
@@ -14999,6 +15000,16 @@ __metadata:
   peerDependencies:
     react: ^19.2.3
   checksum: cb1f95df052802f5332cae78303b7fc6f58092d5c7f8d01f0401188b2e0157c1d273a041b900fcc4801f730c70ed17249bd5af170038692878ebe257f641488b
+  languageName: node
+  linkType: hard
+
+"react-idle-timer@npm:5.7.2":
+  version: 5.7.2
+  resolution: "react-idle-timer@npm:5.7.2"
+  peerDependencies:
+    react: ">=16"
+    react-dom: ">=16"
+  checksum: 6faf3cfa87c9d65ae7a87078a2d82db5b821936a45565a98d69e7341e4b4acd5610b1f26cf1a6809b5551e4c30357f2ab5ce729c4c33751f66cb9ce6072dfb02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Addresses six findings from the recent security review of the wallet
keyring, storage, and dApp connection paths.

- **Finding 01** — Replace AES-CBC with XChaCha20-Poly1305 AEAD for wallet
  serialization (`02c18984`). Adds the `v018` storage migration alongside
  per-user salt and AEAD nonce handling.
- **Finding 02 / 03 / 04** — Replace SHA-256 password hashing with
  Argon2id KDF + per-user salt, and verify passwords by attempting AEAD
  decryption rather than comparing stored hashes (`87e9fc34`).
- **Finding 05** — Clear sensitive key material from in-memory keyring
  state on wallet lock (`f2a0063a`).
- **Finding 06** — Restrict the `<meta name="gnoconnect:rpc">` meta-tag
  RPC injection path to a hardcoded dApp origin allowlist sourced from
  `chains.json` `gnoUrl` values, and remove the `UNADDED_NETWORK`
  fall-through in the content handler so an unknown chain ID can no
  longer slip through origin approval (`827c4e3f`).

The infrastructure commit `479b80da` introduces the `v018` storage model
and extends the storage migrator to support per-user salts required by
Finding 01.

### Trust model alignment

For Finding 06, the new origin allowlist mirrors the curated trust list
patterns used by Keplr (`EmbedChainInfos`) and MetaMask (`FEATURED_RPCS`):
the page is only allowed to influence the RPC endpoint when it is itself
served from a maintainer-approved origin. Adding a new gno.land
deployment requires updating
`packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts`.

The check is scoped to the meta-tag injection path
(`CommandHandler.createContentHandler`); standard injected-provider dApp
flows go through `CommandHandler.createHandler` and are unaffected. All
other `new GnoProvider(...)` call sites consume RPC URLs from the user's
saved `NetworkMetainfo` rather than page-supplied data.

## Findings deliberately not included in this PR

- **07 — Timing side-channel in password comparison.** Made obsolete by
  Findings 02/03/04 in this PR. `WalletService.equalsPassword` now
  verifies the password by attempting AEAD decryption, and the prior
  `encryptSha256Password(password) === storedPassword` site at
  `wallet.ts:253` is gone. The remaining string-equality uses in
  `validation-password.ts` either compare two client-side inputs
  (confirm-password, change-password equality) or are dead code, neither
  of which is exploitable. Both Keplr and MetaMask rely on KDF-gated
  decryption rather than constant-time hash comparison.
- **08 — Plaintext intermediate values during wallet serialization.**
  Out of scope for this PR. Eliminating the intermediate plaintext
  requires redesigning `Wallet.serialize` to encrypt per keyring instead
  of building a single JSON blob, which is a non-trivial refactor that
  should land separately. Finding 05's memzero on lock already shortens
  the residency window for the same key material.
- **09 — Background script does not validate message sender.** Worth
  fixing, but unrelated to the keyring/crypto cluster on this branch.
  Will be addressed in a focused follow-up that adds
  `sender.id`/`sender.frameId` checks with dedicated regression tests.
- **10 — 5-minute post-disconnect session timeout.** Marked Info by the
  reviewer; product/UX decision rather than a vulnerability. A
  user-configurable timeout is feature work, not a fix.
- **11 — `web_accessible_resources` exposes `resources/*` to all
  origins.** Info-level fingerprinting risk. Needs an audit of which
  resources are actually consumed by external pages versus only by the
  extension itself before tightening `matches`; deferred to avoid
  breaking dApp-facing assets.
- **12 — Content script runs on `<all_urls>`.** The reviewer explicitly
  notes this is expected wallet-extension behavior (same as MetaMask)
  and recommends no change. Acknowledged, no action required.
- **13 — Unused Web3Auth/Torus stub code and dependencies.** Product
  decision on whether Web3Auth integration is still planned. Removing
  the package belongs in a chore PR once that direction is confirmed; it
  is not a security regression caused by this branch.

## Test plan

- [ ] `npm test` in `packages/adena-extension`
- [ ] `npm test` in `packages/adena-module`
- [ ] Manual: existing wallet locked with the previous AES-CBC scheme
      successfully migrates to v018 on next unlock
- [ ] Manual: password change / login / wallet export / approve-login
      flows all succeed with the Argon2id-based verification
- [ ] Manual: lock the wallet and confirm sensitive material is cleared
      from keyring instances
- [ ] Manual: `https://gno.land`, `https://betanet.testnets.gno.land`,
      `https://staging.gno.land`, `https://test13.testnets.gno.land`
      gnoweb action triggers open the transaction modal as expected
- [ ] Manual: a page on an unlisted origin that declares
      `<meta name="gnoconnect:rpc" content="https://attacker.example/rpc">`
      does **not** open the transaction modal
- [ ] Manual: standard injected-provider dApp interactions
      (`window.adena.*`) continue to work without change
