### PR TITLE
[ADN-745] feat: customizable auto-lock timer

### DIFF
--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -93,6 +93,7 @@
     "qrcode.react": "3.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-idle-timer": "5.7.2",
     "react-router-dom": "6.22.1",
     "recoil": "0.7.7",
     "styled-components": "6.1.14",

--- a/packages/adena-extension/src/App/use-app.ts
+++ b/packages/adena-extension/src/App/use-app.ts
@@ -1,13 +1,17 @@
-import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect } from 'react';
+import { useIdleTimer } from 'react-idle-timer';
 import { useLocation } from 'react-router-dom';
 
-import { ADENA_WALLET_EXTENSION_ID } from '@common/constants/storage.constant';
+import { isAutoLockTriggeredMessage } from '@common/utils/auto-lock-timer';
+import { CommandMessage } from '@inject/message/command-message';
 import { useAccountName } from '@hooks/use-account-name';
 import { useWalletContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { useNetwork } from '@hooks/use-network';
 import useScrollHistory from '@hooks/use-scroll-history';
 import { useTokenMetainfo } from '@hooks/use-token-metainfo';
+import { useWallet } from '@hooks/use-wallet';
 
 const useApp = (): void => {
   const { wallet } = useWalletContext();
@@ -17,14 +21,49 @@ const useApp = (): void => {
   const { initTokenMetainfos } = useTokenMetainfo();
   const { pathname, key } = useLocation();
   const { scrollMove } = useScrollHistory();
+  const { lockedWallet } = useWallet();
+  const queryClient = useQueryClient();
 
+  // Listen for the AUTO_LOCK_TRIGGERED broadcast from background. Without
+  // this, the popup keeps rendering the unlocked screen until the next user
+  // interaction nudges react-query to refetch — invalidating the cached
+  // `wallet/locked` query forces an immediate re-evaluation, which the
+  // existing routing logic in use-init-wallet picks up.
   useEffect(() => {
-    try {
-      chrome?.runtime?.connect({ name: ADENA_WALLET_EXTENSION_ID });
-    } catch (error) {
-      console.warn('Failed to connect to chrome runtime:', error);
-    }
+    const handler = (message: unknown): void => {
+      if (isAutoLockTriggeredMessage(message)) {
+        queryClient.invalidateQueries({ queryKey: ['wallet/locked'] });
+      }
+    };
+    chrome.runtime.onMessage.addListener(handler);
+    return (): void => {
+      chrome.runtime.onMessage.removeListener(handler);
+    };
+  }, [queryClient]);
+
+  const sendActivityPing = useCallback(() => {
+    chrome.runtime
+      .sendMessage(CommandMessage.command('resetAutoLockTimer'))
+      .catch(() => undefined);
   }, []);
+
+  // Send an activity ping whenever a real user input is detected. The throttle
+  // collapses bursts (mouse moves, keystrokes) into one message every 5s so we
+  // don't flood the background with sendMessage calls.
+  useIdleTimer({
+    throttle: 5000,
+    onAction: sendActivityPing,
+    disabled: lockedWallet !== false,
+  });
+
+  // Mounting any UI surface (popup, separate window, web page) counts as
+  // activity, so reset the timer on first render too — otherwise a user who
+  // opens the popup without moving the mouse would see no reset event.
+  useEffect(() => {
+    if (lockedWallet === false) {
+      sendActivityPing();
+    }
+  }, [lockedWallet, sendActivityPing]);
 
   useEffect(() => {
     checkNetworkState();

--- a/packages/adena-extension/src/background.ts
+++ b/packages/adena-extension/src/background.ts
@@ -1,8 +1,8 @@
 import { AlarmKey, SCHEDULE_ALARMS } from '@common/constants/alarm-key.constant';
-import { ADENA_WALLET_EXTENSION_ID } from '@common/constants/storage.constant';
 import { TransactionEventStore } from '@common/event-store';
 import { MemoryProvider } from '@common/provider/memory/memory-provider';
 import { ChromeLocalStorage } from '@common/storage';
+import { AUTO_LOCK_TRIGGERED_MESSAGE } from '@common/utils/auto-lock-timer';
 import { CommandHandler } from '@inject/message/command-handler';
 import {
   CommandMessage,
@@ -329,42 +329,22 @@ chrome.action.onClicked.addListener(async () => {
   });
 });
 
-chrome.runtime.onConnect.addListener(async (port) => {
-  if (port.name !== ADENA_WALLET_EXTENSION_ID) {
-    return;
-  }
-
-  inMemoryProvider.addConnection();
-  inMemoryProvider.updateExpiredTimeBy(null);
-
-  port.onDisconnect.addListener(async () => {
-    inMemoryProvider.removeConnection();
-
-    if (!inMemoryProvider.isActive()) {
-      const expiredTime = new Date().getTime() + inMemoryProvider.getExpiredPasswordDurationTime();
-      inMemoryProvider.updateExpiredTimeBy(expiredTime);
-
-      console.info('Password Expired time:', new Date(expiredTime));
-    }
-  });
-});
-
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   try {
     const currentTime = new Date().getTime();
     chrome.storage.local.set({ SESSION: currentTime });
 
     switch (alarm?.name) {
-      case AlarmKey.EXPIRED_PASSWORD:
-        if (!inMemoryProvider.isExpired(currentTime)) {
-          return;
-        }
-
+      case AlarmKey.AUTO_LOCK_TIMER:
         await chrome.storage.session.clear();
         await clearInMemoryKey(inMemoryProvider);
-
-        inMemoryProvider.updateExpiredTimeBy(null);
-        console.info('Password Expired');
+        // Tell any open UI surface that auto-lock just fired so it can
+        // invalidate cached lock state and route to Login immediately.
+        // The send rejects when no UI is listening — that's expected.
+        chrome.runtime
+          .sendMessage({ type: AUTO_LOCK_TRIGGERED_MESSAGE })
+          .catch(() => undefined);
+        console.info('Auto-lock fired');
         break;
       default:
         break;

--- a/packages/adena-extension/src/common/constants/alarm-key.constant.ts
+++ b/packages/adena-extension/src/common/constants/alarm-key.constant.ts
@@ -1,5 +1,5 @@
 export enum AlarmKey {
-  EXPIRED_PASSWORD = 'EXPIRED_PASSWORD',
+  AUTO_LOCK_TIMER = 'AUTO_LOCK_TIMER',
   WAKE_ALARM = 'WAKE_ALARM',
   WAKE_ALARM_DELAY_15S = 'WAKE_ALARM_DELAY_15S',
   WAKE_ALARM_DELAY_30S = 'WAKE_ALARM_DELAY_30S',
@@ -7,7 +7,6 @@ export enum AlarmKey {
 }
 
 export const SCHEDULE_ALARMS: { key: string; periodInMinutes: number; delay: number }[] = [
-  { key: AlarmKey.EXPIRED_PASSWORD, periodInMinutes: 1, delay: 0 },
   { key: AlarmKey.WAKE_ALARM, periodInMinutes: 1, delay: 0 },
   { key: AlarmKey.WAKE_ALARM_DELAY_15S, periodInMinutes: 1, delay: 15_000 },
   { key: AlarmKey.WAKE_ALARM_DELAY_30S, periodInMinutes: 1, delay: 30_000 },

--- a/packages/adena-extension/src/common/constants/command-key.constant.ts
+++ b/packages/adena-extension/src/common/constants/command-key.constant.ts
@@ -4,6 +4,8 @@ export const COMMAND_KEYS = {
   clearEncryptKey: 'CLEAR_ENCRYPT_KEY',
   clearPopup: 'CLEAR_POPUP',
   checkMetadata: 'CHECK_METADATA',
+  resetAutoLockTimer: 'RESET_AUTO_LOCK_TIMER',
+  updateAutoLockTimer: 'UPDATE_AUTO_LOCK_TIMER',
 } as const;
 export type CommandKeyType = keyof typeof COMMAND_KEYS;
 export type CommandValueType = (typeof COMMAND_KEYS)[keyof typeof COMMAND_KEYS];

--- a/packages/adena-extension/src/common/provider/memory/memory-provider.ts
+++ b/packages/adena-extension/src/common/provider/memory/memory-provider.ts
@@ -1,10 +1,5 @@
-const EXPIRED_PASSWORD_DURATION_MIN = 5;
-
 export class MemoryProvider {
   private memory: Map<string, any> = new Map();
-  private activeConnections = 0;
-  private expiredPasswordDuration = EXPIRED_PASSWORD_DURATION_MIN;
-  private expiredTime: number | null = null;
 
   public get = <T = any>(key: string): T | null => {
     if (!this.memory.get(key)) {
@@ -20,41 +15,5 @@ export class MemoryProvider {
 
   public async init(): Promise<void> {
     this.memory = new Map();
-  }
-
-  public addConnection(): void {
-    this.activeConnections++;
-  }
-
-  public removeConnection(): void {
-    this.activeConnections--;
-  }
-
-  public isActive(): boolean {
-    return this.activeConnections > 0;
-  }
-
-  public getExpiredPasswordDurationTime(): number {
-    return this.expiredPasswordDuration * 60 * 1000;
-  }
-
-  public setExpiredPasswordDurationMinutes(duration: number): void {
-    this.expiredPasswordDuration = duration;
-  }
-
-  public isExpired(time: number): boolean {
-    if (this.isActive()) {
-      return false;
-    }
-
-    if (!this.expiredTime) {
-      return false;
-    }
-
-    return this.expiredTime < time;
-  }
-
-  public updateExpiredTimeBy(time: number | null): void {
-    this.expiredTime = time;
   }
 }

--- a/packages/adena-extension/src/common/storage/chrome-local-storage.ts
+++ b/packages/adena-extension/src/common/storage/chrome-local-storage.ts
@@ -22,7 +22,8 @@ type StorageKeyTypes =
   | 'ADD_ACCOUNT_GUIDE_CONFIRM_DATE'
   | 'ACCOUNT_GRC721_COLLECTIONS'
   | 'ACCOUNT_GRC721_PINNED_PACKAGES'
-  | 'KDF_SALT';
+  | 'KDF_SALT'
+  | 'AUTO_LOCK_TIMEOUT_MINUTES';
 
 // List of all available storage keys
 const StorageKeys: StorageKeyTypes[] = [
@@ -45,6 +46,7 @@ const StorageKeys: StorageKeyTypes[] = [
   'ACCOUNT_GRC721_COLLECTIONS',
   'ACCOUNT_GRC721_PINNED_PACKAGES',
   'KDF_SALT',
+  'AUTO_LOCK_TIMEOUT_MINUTES',
 ];
 
 // Function to validate if a given key is a valid storage key

--- a/packages/adena-extension/src/common/utils/auto-lock-timer.spec.ts
+++ b/packages/adena-extension/src/common/utils/auto-lock-timer.spec.ts
@@ -1,0 +1,82 @@
+import { readAutoLockMinutes } from './auto-lock-timer';
+
+type StorageGet = (key: string) => Promise<{ ADENA_DATA?: string | object }>;
+
+const mockChromeStorage = (get: StorageGet): void => {
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: {
+      local: { get },
+    },
+  };
+};
+
+const dataBlob = (autoLockValue: unknown): string =>
+  JSON.stringify({ data: { AUTO_LOCK_TIMEOUT_MINUTES: autoLockValue } });
+
+describe('readAutoLockMinutes', () => {
+  afterEach(() => {
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+  });
+
+  it('returns the default 5 minutes when ADENA_DATA is absent', async () => {
+    mockChromeStorage(async () => ({}));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('returns the default when the AUTO_LOCK_TIMEOUT_MINUTES key is missing', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: JSON.stringify({ data: {} }) }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('returns the default when the value is an empty string', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('') }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('returns the configured number for valid stringified integers', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('15') }));
+
+    expect(await readAutoLockMinutes()).toBe(15);
+  });
+
+  it('returns 0 to honor the explicit "auto-lock disabled" setting', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('0') }));
+
+    expect(await readAutoLockMinutes()).toBe(0);
+  });
+
+  it('falls back to the default for non-numeric strings', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('abc') }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('falls back to the default for negative values', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: dataBlob('-3') }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('falls back to the default when ADENA_DATA contains malformed JSON', async () => {
+    mockChromeStorage(async () => ({ ADENA_DATA: 'not-json' }));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('falls back to the default when chrome.storage rejects', async () => {
+    mockChromeStorage(() => Promise.reject(new Error('storage unavailable')));
+
+    expect(await readAutoLockMinutes()).toBe(5);
+  });
+
+  it('accepts an already-parsed object payload', async () => {
+    mockChromeStorage(async () => ({
+      ADENA_DATA: { data: { AUTO_LOCK_TIMEOUT_MINUTES: '30' } },
+    }));
+
+    expect(await readAutoLockMinutes()).toBe(30);
+  });
+});

--- a/packages/adena-extension/src/common/utils/auto-lock-timer.ts
+++ b/packages/adena-extension/src/common/utils/auto-lock-timer.ts
@@ -1,0 +1,94 @@
+import { AlarmKey } from '@common/constants/alarm-key.constant';
+
+const STORAGE_KEY = 'ADENA_DATA';
+const DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES = 5;
+
+// Broadcast type used by background to notify any open UI surface that the
+// auto-lock alarm just fired. The UI reacts by invalidating the cached
+// `wallet/locked` query so the lock screen renders immediately, instead of
+// waiting for the next user interaction to trigger a refetch.
+export const AUTO_LOCK_TRIGGERED_MESSAGE = 'AUTO_LOCK_TRIGGERED';
+
+export interface AutoLockTriggeredMessage {
+  type: typeof AUTO_LOCK_TRIGGERED_MESSAGE;
+}
+
+export const isAutoLockTriggeredMessage = (
+  message: unknown,
+): message is AutoLockTriggeredMessage => {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    (message as { type?: unknown }).type === AUTO_LOCK_TRIGGERED_MESSAGE
+  );
+};
+
+/**
+ * Read the user-configured auto-lock duration from chrome.storage.local.
+ *
+ * Bypasses the StorageManager / ChromeLocalStorage abstraction on purpose:
+ * those go through the storage migrator on every access, which is
+ * heavyweight for a hot path that fires on every UI activity ping in the
+ * background service worker. We only need a single key lookup here, so a
+ * raw read against the ADENA_DATA blob is the right tradeoff.
+ *
+ * Returns DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES when the value is missing or unparsable.
+ * Returns 0 when the user has explicitly disabled auto-lock.
+ */
+export async function readAutoLockMinutes(): Promise<number> {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY);
+    const raw = result?.[STORAGE_KEY];
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    const value = parsed?.data?.AUTO_LOCK_TIMEOUT_MINUTES;
+    if (value === null || value === undefined || value === '') {
+      return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+    }
+    const minutes = Number(value);
+    if (!Number.isFinite(minutes) || minutes < 0) {
+      return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+    }
+    return minutes;
+  } catch {
+    return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+  }
+}
+
+/**
+ * Wallet is considered unlocked when both encrypted password fragments
+ * exist in chrome.storage.session.
+ */
+export async function isWalletUnlocked(): Promise<boolean> {
+  try {
+    const session = await chrome.storage.session.get(['ENCRYPTED_KEY', 'ENCRYPTED_PASSWORD']);
+    return !!session.ENCRYPTED_KEY && !!session.ENCRYPTED_PASSWORD;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Replace any pending auto-lock alarm with a fresh one matching the user's
+ * configured duration. Skips creation when the wallet is locked or the
+ * duration is zero (auto-lock disabled).
+ *
+ * chrome.alarms persists across service worker restarts and laptop sleep,
+ * so a single one-shot alarm is enough — no in-memory bookkeeping needed.
+ */
+export async function resetAutoLockAlarm(): Promise<void> {
+  await chrome.alarms.clear(AlarmKey.AUTO_LOCK_TIMER);
+  if (!(await isWalletUnlocked())) {
+    return;
+  }
+  const minutes = await readAutoLockMinutes();
+  if (minutes <= 0) {
+    return;
+  }
+  // Chrome enforces a 1-minute floor on delayInMinutes in production builds.
+  const delayInMinutes = Math.max(minutes, 1);
+  chrome.alarms.create(AlarmKey.AUTO_LOCK_TIMER, { delayInMinutes });
+}
+
+export async function clearAutoLockAlarm(): Promise<void> {
+  await chrome.alarms.clear(AlarmKey.AUTO_LOCK_TIMER);
+}

--- a/packages/adena-extension/src/hooks/certify/use-auto-lock-timer.ts
+++ b/packages/adena-extension/src/hooks/certify/use-auto-lock-timer.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES,
+  MAX_AUTO_LOCK_TIMEOUT_MINUTES,
+} from '@repositories/wallet';
+import useAppNavigate from '@hooks/use-app-navigate';
+import { useAdenaContext } from '@hooks/use-context';
+
+export type UseAutoLockTimerReturn = {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  errorMessage: string;
+  isLoading: boolean;
+  saveDisabled: boolean;
+  onSave: () => Promise<void>;
+  onCancel: () => void;
+};
+
+const RANGE_ERROR_MESSAGE = `Please set a time between 0 ~ ${MAX_AUTO_LOCK_TIMEOUT_MINUTES} minutes (a day).`;
+
+const validate = (raw: string): { minutes: number | null; errorMessage: string } => {
+  const trimmed = raw.trim();
+  // Empty / non-digit inputs are rejected at the input layer, but guard here
+  // anyway — the input filter is the UX, this is the safety net.
+  if (trimmed === '' || !/^\d+$/.test(trimmed)) {
+    return { minutes: null, errorMessage: RANGE_ERROR_MESSAGE };
+  }
+  const minutes = Number(trimmed);
+  if (!Number.isFinite(minutes) || minutes < 0 || minutes > MAX_AUTO_LOCK_TIMEOUT_MINUTES) {
+    return { minutes: null, errorMessage: RANGE_ERROR_MESSAGE };
+  }
+  return { minutes, errorMessage: '' };
+};
+
+export const useAutoLockTimer = (): UseAutoLockTimerReturn => {
+  const { walletService } = useAdenaContext();
+  const { goBack } = useAppNavigate();
+
+  const [value, setValue] = useState<string>(`${DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES}`);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    walletService
+      .getAutoLockTimeoutMinutes()
+      .then((minutes) => {
+        if (!cancelled) {
+          setValue(`${minutes}`);
+          setIsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [walletService]);
+
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    // Only accept digit-only strings (or empty for backspacing). Reject any
+    // keystroke that introduces "-", ".", "e", letters, etc. so the user
+    // cannot enter a non-natural-number in the first place.
+    if (next !== '' && !/^\d+$/.test(next)) {
+      return;
+    }
+    setValue(next);
+    setErrorMessage('');
+  }, []);
+
+  const onSave = useCallback(async () => {
+    const { minutes, errorMessage: validationError } = validate(value);
+    if (minutes === null) {
+      setErrorMessage(validationError);
+      return;
+    }
+    await walletService.updateAutoLockTimeoutMinutes(minutes);
+    goBack();
+  }, [value, walletService, goBack]);
+
+  const { errorMessage: previewError } = validate(value);
+  const saveDisabled = isLoading || previewError !== '';
+
+  return {
+    value,
+    onChange,
+    errorMessage,
+    isLoading,
+    saveDisabled,
+    onSave,
+    onCancel: goBack,
+  };
+};

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -4,6 +4,7 @@ import { GnoDocumentInfo } from '@common/provider/gno';
 import { GnoProvider } from '@common/provider/gno/gno-provider';
 import { isInterRealmParameter } from '@common/provider/gno/utils';
 import { MemoryProvider } from '@common/provider/memory/memory-provider';
+import { clearAutoLockAlarm, resetAutoLockAlarm } from '@common/utils/auto-lock-timer';
 import { AdenaExecutor } from '@inject/executor';
 import { ContractMessage, TransactionParams } from '@inject/types';
 import { CheckMetadataMessageData, CommandMessageData } from './command-message';
@@ -75,6 +76,20 @@ export class CommandHandler {
         sendResponse(makeSuccessResponse(message));
         return;
       }
+
+      if (message.command === 'resetAutoLockTimer') {
+        await resetAutoLockAlarm();
+        sendResponse(makeSuccessResponse(message));
+        return;
+      }
+
+      if (message.command === 'updateAutoLockTimer') {
+        // The new duration is already persisted by the service layer; the
+        // helper re-reads from storage so we don't need to trust the payload.
+        await resetAutoLockAlarm();
+        sendResponse(makeSuccessResponse(message));
+        return;
+      }
     } catch (error) {
       console.info(error);
       sendResponse(makeInternalErrorResponse(message));
@@ -82,6 +97,7 @@ export class CommandHandler {
 
     if (message.command === 'clearPopup') {
       await clearInMemoryKey(inMemoryProvider);
+      await clearAutoLockAlarm();
       await clearPopup();
       sendResponse({ ...message, code: 200 });
       return;

--- a/packages/adena-extension/src/pages/popup/certify/auto-lock-timer/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/auto-lock-timer/index.tsx
@@ -1,0 +1,125 @@
+import styled, { useTheme } from 'styled-components';
+
+import { DefaultInput, ErrorText, Text } from '@components/atoms';
+import { CancelAndConfirmButton } from '@components/molecules';
+import { useAutoLockTimer } from '@hooks/certify/use-auto-lock-timer';
+import { MAX_AUTO_LOCK_TIMEOUT_MINUTES } from '@repositories/wallet';
+import mixins from '@styles/mixins';
+
+const Wrapper = styled.main`
+  ${mixins.flex({ align: 'flex-start', justify: 'flex-start' })};
+  width: 100%;
+  height: 100%;
+  padding-top: 24px;
+`;
+
+const Description = styled(Text)`
+  margin-top: 12px;
+`;
+
+const FormBox = styled.div`
+  width: 100%;
+  margin-top: 24px;
+  margin-bottom: auto;
+
+  & > * {
+    margin-bottom: 12px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+`;
+
+const InputRow = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+// Reserve enough right padding for the "Minutes" suffix so the typed value
+// never overlaps the label.
+const MinutesInput = styled(DefaultInput)`
+  padding-right: 80px;
+`;
+
+const MinutesSuffix = styled.span`
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 21px;
+  color: ${({ theme }): string => theme.neutral._1};
+  pointer-events: none;
+`;
+
+const DisabledNotice = styled(Text)`
+  margin-top: 8px;
+`;
+
+export const AutoLockTimer = (): JSX.Element => {
+  const theme = useTheme();
+  const { value, onChange, errorMessage, saveDisabled, onSave, onCancel } = useAutoLockTimer();
+
+  const showDisabledNotice = !errorMessage && value === '0';
+
+  return (
+    <Wrapper>
+      <Text type='header4'>Auto-Lock Timer</Text>
+      <Description type='body2Reg' color={theme.neutral.a}>
+        Set a time it takes Adena to automatically lock your wallet. Use 0 to disable auto-lock.
+      </Description>
+      <FormBox>
+        <InputRow>
+          <MinutesInput
+            type='text'
+            inputMode='numeric'
+            pattern='[0-9]*'
+            name='autoLockMinutes'
+            value={value}
+            onChange={onChange}
+            // Defensive against keys that some browsers still surface even on
+            // type=text: arrow up/down (no-op on single-line, but matches the
+            // BalanceInput pattern), and characters we never want regardless
+            // of paste/IME behavior.
+            onKeyDown={(event): void => {
+              if (
+                event.key === '-' ||
+                event.key === '.' ||
+                event.key === 'e' ||
+                event.key === 'E' ||
+                event.key === 'ArrowUp' ||
+                event.key === 'ArrowDown'
+              ) {
+                event.preventDefault();
+              }
+            }}
+            // Wheel scrolling on a focused number input nudges the value in
+            // some browsers; blurring on wheel matches BalanceInput.
+            onWheel={(event): void => event.currentTarget.blur()}
+            error={Boolean(errorMessage)}
+            maxLength={String(MAX_AUTO_LOCK_TIMEOUT_MINUTES).length}
+            autoComplete='off'
+          />
+          <MinutesSuffix>Minutes</MinutesSuffix>
+        </InputRow>
+        {Boolean(errorMessage) && <ErrorText text={errorMessage} />}
+        {showDisabledNotice && (
+          <DisabledNotice type='body2Reg' color={theme.red._4}>
+            Auto-lock is disabled. The wallet will stay unlocked until you lock it manually or
+            close the browser.
+          </DisabledNotice>
+        )}
+      </FormBox>
+      <CancelAndConfirmButton
+        cancelButtonProps={{ onClick: onCancel }}
+        confirmButtonProps={{
+          onClick: onSave,
+          text: 'Save',
+          props: { disabled: saveDisabled },
+        }}
+      />
+    </Wrapper>
+  );
+};

--- a/packages/adena-extension/src/pages/popup/certify/security-privacy/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/security-privacy/index.tsx
@@ -18,6 +18,7 @@ import {
 
 type MenuType =
   | RoutePath.SettingChangePassword
+  | RoutePath.SettingAutoLockTimer
   | RoutePath.RemoveAccount
   | RoutePath.ResetWallet
   | 'EXPORT_SEED_PHRASE'
@@ -35,6 +36,12 @@ const getMenuMakerInfo = (
   {
     title: 'Change Password',
     navigatePath: RoutePath.SettingChangePassword,
+    mode: 'DEFAULT',
+    disabled: false,
+  },
+  {
+    title: 'Auto-Lock Timer',
+    navigatePath: RoutePath.SettingAutoLockTimer,
     mode: 'DEFAULT',
     disabled: false,
   },

--- a/packages/adena-extension/src/repositories/wallet/wallet.ts
+++ b/packages/adena-extension/src/repositories/wallet/wallet.ts
@@ -7,7 +7,11 @@ type LocalValueType =
   | 'QUESTIONNAIRE_EXPIRED_DATE'
   | 'WALLET_CREATION_GUIDE_CONFIRM_DATE'
   | 'ADD_ACCOUNT_GUIDE_CONFIRM_DATE'
-  | 'KDF_SALT';
+  | 'KDF_SALT'
+  | 'AUTO_LOCK_TIMEOUT_MINUTES';
+
+export const DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES = 5;
+export const MAX_AUTO_LOCK_TIMEOUT_MINUTES = 1440;
 type SessionValueType = 'ENCRYPTED_KEY' | 'ENCRYPTED_PASSWORD';
 
 export class WalletRepository {
@@ -156,6 +160,22 @@ export class WalletRepository {
 
   public updateAddAccountGuideConfirmDate = async (confirmDate: number): Promise<void> => {
     await this.localStorage.set('ADD_ACCOUNT_GUIDE_CONFIRM_DATE', confirmDate);
+  };
+
+  public getAutoLockTimeoutMinutes = async (): Promise<number> => {
+    const value = await this.localStorage.get('AUTO_LOCK_TIMEOUT_MINUTES');
+    if (value === null || value === undefined || value === '') {
+      return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+    }
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return DEFAULT_AUTO_LOCK_TIMEOUT_MINUTES;
+    }
+    return parsed;
+  };
+
+  public updateAutoLockTimeoutMinutes = async (minutes: number): Promise<void> => {
+    await this.localStorage.set('AUTO_LOCK_TIMEOUT_MINUTES', minutes);
   };
 
   public getKdfSalt = async (): Promise<Uint8Array | null> => {

--- a/packages/adena-extension/src/router/popup/index.tsx
+++ b/packages/adena-extension/src/router/popup/index.tsx
@@ -6,6 +6,7 @@ import { RoutePath } from '../../types/router';
 import { AboutAdena } from '@pages/popup/certify/about-adena';
 import AddAddress from '@pages/popup/certify/add-address';
 import AddressBook from '@pages/popup/certify/address-book';
+import { AutoLockTimer } from '@pages/popup/certify/auto-lock-timer';
 import ChangeNetwork from '@pages/popup/certify/change-network';
 import { ChangePassword } from '@pages/popup/certify/change-password';
 import { ConnectedApps } from '@pages/popup/certify/connected-apps';
@@ -174,6 +175,7 @@ export const PopupRouter = (): JSX.Element => {
         <Route path={RoutePath.AddressBook} element={<AddressBook />} />
         <Route path={RoutePath.AddAddress} element={<AddAddress />} />
         <Route path={RoutePath.SecurityPrivacy} element={<SecurityPrivacy />} />
+        <Route path={RoutePath.SettingAutoLockTimer} element={<AutoLockTimer />} />
         <Route path={RoutePath.AboutAdena} element={<AboutAdena />} />
         <Route path={RoutePath.RemoveAccount} element={<RemoveAccount />} />
         <Route path={RoutePath.ResetWallet} element={<ResetWallet />} />

--- a/packages/adena-extension/src/services/wallet/wallet.ts
+++ b/packages/adena-extension/src/services/wallet/wallet.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { QUESTIONNAIRE_EXPIRATION_MIN } from '@common/constants/storage.constant';
 import { WalletError } from '@common/errors/wallet/wallet-error';
+import { CommandMessage } from '@inject/message/command-message';
 import { WalletRepository } from '@repositories/wallet';
 
 export class WalletService {
@@ -315,6 +316,21 @@ export class WalletService {
       ? this.walletRepository.updateAddAccountGuideConfirmDate.bind(this.walletRepository)
       : this.walletRepository.updateWalletCreationGuideConfirmDate.bind(this.walletRepository);
     await updateGuideConfirmDate(confirmDate);
+  };
+
+  public getAutoLockTimeoutMinutes = async (): Promise<number> => {
+    return this.walletRepository.getAutoLockTimeoutMinutes();
+  };
+
+  public updateAutoLockTimeoutMinutes = async (minutes: number): Promise<void> => {
+    await this.walletRepository.updateAutoLockTimeoutMinutes(minutes);
+    try {
+      await chrome.runtime.sendMessage(
+        CommandMessage.command('updateAutoLockTimer', { minutes }),
+      );
+    } catch (e) {
+      console.warn('Failed to notify background of auto-lock timer update', e);
+    }
   };
 
   public clear = async (): Promise<boolean> => {

--- a/packages/adena-extension/src/types/router.ts
+++ b/packages/adena-extension/src/types/router.ts
@@ -89,6 +89,7 @@ export enum RoutePath {
   AboutAdena = '/settings/about-adena',
   RemoveAccount = '/settings/security-privacy/remove-account',
   ResetWallet = '/settings/security-privacy/reset-wallet',
+  SettingAutoLockTimer = '/settings/security-privacy/auto-lock-timer',
 
   // web
   WebNotFound = '/web/not-found',
@@ -270,6 +271,7 @@ export type RouteParams = {
   [RoutePath.ResetWallet]: {
     from: 'forgot-password';
   } | null;
+  [RoutePath.SettingAutoLockTimer]: null;
 
   [RoutePath.WebNotFound]: null;
   [RoutePath.WebConnectLedger]: null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6197,6 +6197,7 @@ __metadata:
     qrcode.react: 3.1.0
     react: 18.2.0
     react-dom: 18.2.0
+    react-idle-timer: 5.7.2
     react-router-dom: 6.22.1
     recoil: 0.7.7
     storybook: 8.5.8
@@ -14999,6 +15000,16 @@ __metadata:
   peerDependencies:
     react: ^19.2.3
   checksum: cb1f95df052802f5332cae78303b7fc6f58092d5c7f8d01f0401188b2e0157c1d273a041b900fcc4801f730c70ed17249bd5af170038692878ebe257f641488b
+  languageName: node
+  linkType: hard
+
+"react-idle-timer@npm:5.7.2":
+  version: 5.7.2
+  resolution: "react-idle-timer@npm:5.7.2"
+  peerDependencies:
+    react: ">=16"
+    react-dom: ">=16"
+  checksum: 6faf3cfa87c9d65ae7a87078a2d82db5b821936a45565a98d69e7341e4b4acd5610b1f26cf1a6809b5551e4c30357f2ab5ce729c4c33751f66cb9ce6072dfb02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Replace the hard-coded 5-minute password expiry with a `chrome.alarms` one-shot idle timer that survives SW restarts and laptop sleep.
- Add **Settings → Security & Privacy → Auto-Lock Timer** page (0 ~ 1440 min, digit-only input, Figma error copy). 0 disables auto-lock.
- Background broadcasts `AUTO_LOCK_TRIGGERED` on lock; UI invalidates the cached `['wallet/locked']` query so Login renders immediately.

## Test plan
- [ ] 1-min timer → popup idle for 1 min auto-routes to Login
- [ ] SW terminate / laptop sleep → wallet still locks on time
- [ ] 0 → never auto-locks; red "disabled" notice shown
- [ ] `-`, `.`, `e`, arrow keys, wheel, paste `1.5` → all rejected
- [ ] `1441` → range error; Save disabled
- [ ] Existing user (no key) → defaults to 5
- [ ] `yarn test:ci` and `yarn build` pass

## Notes
Based on `fix/ADN-747`. Set the PR base to `fix/ADN-747` so only the four ADN-745 commits show up; rebase onto `main` after that branch merges.