### PR TITLE
fix: auto-detect chain from address prefix in address book (ADN-765)

### DIFF
--- a/packages/adena-extension/src/common/utils/address-chain.spec.ts
+++ b/packages/adena-extension/src/common/utils/address-chain.spec.ts
@@ -1,0 +1,29 @@
+import { createChainRegistry } from 'adena-module';
+import { inferChainGroup } from './address-chain';
+
+describe('inferChainGroup', () => {
+  const registry = createChainRegistry();
+
+  it('returns "gno" for a gno bech32 address (g1...)', () => {
+    expect(inferChainGroup('g1abc1234567890abcdefghijklmnopqr', registry)).toBe('gno');
+  });
+
+  it('returns "atomone" for an atomone bech32 address (atone1...)', () => {
+    expect(inferChainGroup('atone1abc1234567890abcdefghijklmnopqrstuvwx', registry)).toBe(
+      'atomone',
+    );
+  });
+
+  it('falls back to "gno" for an unknown chain prefix', () => {
+    expect(inferChainGroup('cosmos1abc1234567890abcdefghijklmnopqrstuvwx', registry)).toBe('gno');
+  });
+
+  it('falls back to "gno" for an empty string', () => {
+    expect(inferChainGroup('', registry)).toBe('gno');
+  });
+
+  it('falls back to "gno" for partial input that has not reached a separator yet', () => {
+    expect(inferChainGroup('at', registry)).toBe('gno');
+    expect(inferChainGroup('atone', registry)).toBe('gno');
+  });
+});

--- a/packages/adena-extension/src/common/utils/address-chain.ts
+++ b/packages/adena-extension/src/common/utils/address-chain.ts
@@ -1,7 +1,15 @@
+import type { ChainRegistry } from 'adena-module';
+
 // Returns the chainGroup that owns the given bech32 address prefix.
+// Sorts registered chains by prefix length (longest first) so a chain
+// with a longer prefix wins over one whose prefix is a substring of it.
 // Falls back to 'gno' for unknown or partial input so the form keeps a
 // usable default while the user is still typing.
-export function inferChainGroup(address: string): string {
-  if (address.startsWith('atone')) return 'atomone';
-  return 'gno';
+export function inferChainGroup(address: string, chainRegistry: ChainRegistry): string {
+  const matched = chainRegistry
+    .listChains()
+    .slice()
+    .sort((a, b) => b.bech32Prefix.length - a.bech32Prefix.length)
+    .find((chain) => address.startsWith(chain.bech32Prefix + '1'));
+  return matched?.chainGroup ?? 'gno';
 }

--- a/packages/adena-extension/src/common/utils/address-chain.ts
+++ b/packages/adena-extension/src/common/utils/address-chain.ts
@@ -1,0 +1,7 @@
+// Returns the chainGroup that owns the given bech32 address prefix.
+// Falls back to 'gno' for unknown or partial input so the form keeps a
+// usable default while the user is still typing.
+export function inferChainGroup(address: string): string {
+  if (address.startsWith('atone')) return 'atomone';
+  return 'gno';
+}

--- a/packages/adena-extension/src/components/pages/web/main-account-header/index.tsx
+++ b/packages/adena-extension/src/components/pages/web/main-account-header/index.tsx
@@ -22,11 +22,13 @@ const StyledBlank = styled(Row)`
 
 export type WebMainAccountHeaderProps = {
   account: Account | null;
+  displayName?: string;
   onClickGoBack: () => void;
 };
 
 export const WebMainAccountHeader = ({
   account,
+  displayName,
   onClickGoBack,
 }: WebMainAccountHeaderProps): ReactElement => {
   const theme = useTheme();
@@ -59,7 +61,7 @@ export const WebMainAccountHeader = ({
           <WebText
             type='title4'
           >
-            {account.name}
+            {displayName || account.name}
           </WebText>
           <WebText
             type='body4'

--- a/packages/adena-extension/src/hooks/use-address-book-input.ts
+++ b/packages/adena-extension/src/hooks/use-address-book-input.ts
@@ -1,6 +1,7 @@
 import { validateCosmosAddress } from 'adena-module';
 import { useCallback, useEffect, useState } from 'react';
 
+import { inferChainGroup } from '@common/utils/address-chain';
 import { formatAddress, formatNickname } from '@common/utils/client-utils';
 import { AddressBookItem } from '@repositories/wallet';
 
@@ -75,13 +76,14 @@ export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHook
       if (address !== currentAddress) {
         currentAccountInfos.push({
           addressBookId: account.id,
-          name: formatNickname(accountNames[account.id], 12),
+          name: formatNickname(accountNames[account.id] || account.name, 12),
           description: `(${formatAddress(address)})`,
         });
       }
     }
     const addressBookInfos = addressBooks
       .filter((addressBook) => addressBook.address !== currentAddress)
+      .filter((addressBook) => inferChainGroup(addressBook.address) === chainGroup)
       .map((addressBook) => {
         return {
           addressBookId: addressBook.id,
@@ -91,7 +93,7 @@ export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHook
       });
 
     return [...currentAccountInfos, ...addressBookInfos];
-  }, [addressBooks, wallet?.accounts, addressPrefix]);
+  }, [addressBooks, wallet?.accounts, addressPrefix, chainGroup, accountNames]);
 
   const getSelectedAddressBookInfos = useCallback(() => {
     if (selectedAddressBook === null) {
@@ -161,14 +163,14 @@ export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHook
         const address = await selectedAccount.getAddress(addressPrefix);
         setSelectedAddressBook({
           id: selectedAccount.id,
-          name: selectedAccount.name,
+          name: accountNames[selectedAccount.id] || selectedAccount.name,
           address,
           createdAt: `${new Date().getTime()}`,
         });
         return;
       }
     },
-    [addressBooks, wallet?.accounts, addressPrefix],
+    [addressBooks, wallet?.accounts, addressPrefix, accountNames],
   );
 
   const validateAddressBookInput = useCallback(() => {

--- a/packages/adena-extension/src/hooks/use-address-book-input.ts
+++ b/packages/adena-extension/src/hooks/use-address-book-input.ts
@@ -37,7 +37,7 @@ export type UseAddressBookInputHookReturn = {
 };
 
 export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHookReturn => {
-  const { addressBookService } = useAdenaContext();
+  const { addressBookService, chainRegistry } = useAdenaContext();
   const { wallet } = useWalletContext();
   const { getCurrentAddress } = useCurrentAccount();
   const chain = useChain(chainGroup);
@@ -83,7 +83,7 @@ export const useAddressBookInput = (chainGroup = 'gno'): UseAddressBookInputHook
     }
     const addressBookInfos = addressBooks
       .filter((addressBook) => addressBook.address !== currentAddress)
-      .filter((addressBook) => inferChainGroup(addressBook.address) === chainGroup)
+      .filter((addressBook) => inferChainGroup(addressBook.address, chainRegistry) === chainGroup)
       .map((addressBook) => {
         return {
           addressBookId: addressBook.id,

--- a/packages/adena-extension/src/inject/cosmos/offline-signer.spec.ts
+++ b/packages/adena-extension/src/inject/cosmos/offline-signer.spec.ts
@@ -39,7 +39,6 @@ beforeEach(() => {
 describe('decodeCosmosKey', () => {
   it('decodes base64 pubKey and address back to Uint8Array', () => {
     const wire: SerializedCosmosKey = {
-      name: 'account',
       algo: 'secp256k1',
       pubKey: bytesToBase64([1, 2, 3]),
       address: bytesToBase64([4, 5]),
@@ -66,7 +65,6 @@ describe('createOfflineSigner', () => {
     mockExecutorInstance.getCosmosKey.mockResolvedValue({
       status: 'success',
       data: {
-        name: 'account',
         algo: 'secp256k1',
         pubKey: bytesToBase64([7, 8, 9]),
         address: bytesToBase64([10, 11]),

--- a/packages/adena-extension/src/inject/cosmos/offline-signer.ts
+++ b/packages/adena-extension/src/inject/cosmos/offline-signer.ts
@@ -18,7 +18,6 @@ import { AdenaExecutor } from '../executor/executor';
 
 export function decodeCosmosKey(wire: SerializedCosmosKey): CosmosKey {
   return {
-    name: wire.name,
     algo: wire.algo,
     bech32Address: wire.bech32Address,
     isNanoLedger: wire.isNanoLedger,

--- a/packages/adena-extension/src/inject/message/methods/cosmos.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/cosmos.spec.ts
@@ -71,9 +71,6 @@ type FakeCore = {
   getCurrentAccount: jest.Mock;
   getInMemoryKey: jest.Mock;
   isLockedBy: jest.Mock;
-  accountService: {
-    getAccountNames: jest.Mock;
-  };
 };
 
 const ATOMONE_CHAIN = { chainGroup: 'atomone', bech32Prefix: 'atone' };
@@ -112,9 +109,6 @@ function makeCore(overrides?: Partial<FakeCore>): FakeCore {
     })),
     getInMemoryKey: jest.fn(async () => null),
     isLockedBy: jest.fn(async () => false),
-    accountService: {
-      getAccountNames: jest.fn(async () => ({})),
-    },
     ...overrides,
   };
   return core;

--- a/packages/adena-extension/src/inject/message/methods/cosmos.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/cosmos.spec.ts
@@ -71,6 +71,9 @@ type FakeCore = {
   getCurrentAccount: jest.Mock;
   getInMemoryKey: jest.Mock;
   isLockedBy: jest.Mock;
+  accountService: {
+    getAccountNames: jest.Mock;
+  };
 };
 
 const ATOMONE_CHAIN = { chainGroup: 'atomone', bech32Prefix: 'atone' };
@@ -109,6 +112,9 @@ function makeCore(overrides?: Partial<FakeCore>): FakeCore {
     })),
     getInMemoryKey: jest.fn(async () => null),
     isLockedBy: jest.fn(async () => false),
+    accountService: {
+      getAccountNames: jest.fn(async () => ({})),
+    },
     ...overrides,
   };
   return core;

--- a/packages/adena-extension/src/inject/message/methods/cosmos.ts
+++ b/packages/adena-extension/src/inject/message/methods/cosmos.ts
@@ -230,17 +230,11 @@ export const cosmosGetKey = async (
     // clients) sees the canonical format.
     const compressedPubKey = compressPubkeyIfNeeded(currentAccount.publicKey);
 
-    // Mirror the popup-side display: prefer the user-edited nickname stored
-    // in the account-name map and fall back to the auto-generated default.
-    const accountNames = await core.accountService.getAccountNames();
-    const displayName = accountNames[currentAccount.id] || currentAccount.name;
-
     // Binary fields are emitted as base64 because Uint8Array does not survive
     // `chrome.runtime.sendMessage`'s JSON encoding. Stage 4's inject wrapper
     // reconstitutes them before the dApp observes the Key.
     sendResponse(
       createCosmosResponse(CosmosResponseExecuteType.GET_COSMOS_KEY, 'success', message.key, {
-        name: displayName,
         algo: 'secp256k1',
         pubKey: bytesToBase64(Array.from(compressedPubKey)),
         address: bytesToBase64(Array.from(addressBytes)),

--- a/packages/adena-extension/src/inject/message/methods/cosmos.ts
+++ b/packages/adena-extension/src/inject/message/methods/cosmos.ts
@@ -230,12 +230,17 @@ export const cosmosGetKey = async (
     // clients) sees the canonical format.
     const compressedPubKey = compressPubkeyIfNeeded(currentAccount.publicKey);
 
+    // Mirror the popup-side display: prefer the user-edited nickname stored
+    // in the account-name map and fall back to the auto-generated default.
+    const accountNames = await core.accountService.getAccountNames();
+    const displayName = accountNames[currentAccount.id] || currentAccount.name;
+
     // Binary fields are emitted as base64 because Uint8Array does not survive
     // `chrome.runtime.sendMessage`'s JSON encoding. Stage 4's inject wrapper
     // reconstitutes them before the dApp observes the Key.
     sendResponse(
       createCosmosResponse(CosmosResponseExecuteType.GET_COSMOS_KEY, 'success', message.key, {
-        name: currentAccount.name,
+        name: displayName,
         algo: 'secp256k1',
         pubKey: bytesToBase64(Array.from(compressedPubKey)),
         address: bytesToBase64(Array.from(addressBytes)),

--- a/packages/adena-extension/src/inject/types/cosmos.ts
+++ b/packages/adena-extension/src/inject/types/cosmos.ts
@@ -38,7 +38,6 @@ export interface SerializedDirectSignResponse {
 // Uint8Array at the `window.adena.cosmos` surface; the inject.ts wrapper
 // reconstitutes them from the `SerializedCosmosKey` wire payload.
 export interface CosmosKey {
-  name: string;
   algo: string;
   pubKey: Uint8Array;
   address: Uint8Array;
@@ -50,7 +49,6 @@ export interface CosmosKey {
 // because `chrome.runtime.sendMessage` applies JSON encoding between the
 // background handler and the content script, dropping Uint8Array fidelity.
 export interface SerializedCosmosKey {
-  name: string;
   algo: string;
   pubKey: string;
   address: string;

--- a/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
@@ -30,6 +30,7 @@ import { AddressBookItem } from '@repositories/wallet';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { RoutePath } from '@types';
 import { useAddressBook } from '@hooks/use-address-book';
+import { inferChainGroup } from '@common/utils/address-chain';
 
 const specialPatternCheck = /\W|\s/g;
 const ACCOUNT_NAME_LENGTH_LIMIT = 23;
@@ -41,15 +42,24 @@ const AddAddress = (): JSX.Element => {
   const isAdd = params.status === 'add';
 
   const addressList: AddressBookItem[] = params.addressList;
-  const [chainGroup, setChainGroup] = useState<string>('gno');
+  const [chainGroup, setChainGroup] = useState<string>(() =>
+    inferChainGroup(params.curr?.address ?? ''),
+  );
   const chain = useChain(chainGroup);
-  // Bech32 length: prefix + "1" separator + 32 data chars + 6 checksum chars.
-  const addressMaxLength = chain.bech32Prefix.length + 39;
   const { chainRegistry } = useAdenaContext();
   const chainOptions = React.useMemo(
     () => chainOptionsFromRegistry(chainRegistry),
     [chainRegistry],
   );
+  // Bech32 length: prefix + "1" separator + 32 data chars + 6 checksum chars.
+  // Use the longest registered prefix so pasting an address whose chain
+  // differs from the current selection isn't truncated before useEffect
+  // re-syncs chainGroup from the new prefix.
+  const addressMaxLength = React.useMemo(() => {
+    const prefixes = chainRegistry.listChains().map((c) => c.bech32Prefix.length);
+    const maxPrefix = prefixes.length > 0 ? Math.max(...prefixes) : chain.bech32Prefix.length;
+    return maxPrefix + 39;
+  }, [chainRegistry, chain.bech32Prefix.length]);
   const [name, setName] = useState(() => params.curr?.name ?? '');
   const [address, setAddress] = useState(() => params.curr?.address ?? '');
   const [nameError, setNameError] = useState<boolean>(false);
@@ -154,6 +164,7 @@ const AddAddress = (): JSX.Element => {
   useEffect(() => {
     setAddressError(false);
     setErrorMsg('');
+    setChainGroup(inferChainGroup(address));
   }, [address]);
 
   useEffect(() => {
@@ -173,44 +184,46 @@ const AddAddress = (): JSX.Element => {
         <LeftArrowBtn onClick={goBack} />
         <Text type='header4'>{isAdd ? 'Add Address' : 'Edit Address'}</Text>
       </TopSection>
-      <img
-        className='symbol-image'
-        src={isAdd ? add : edit}
-        alt={isAdd ? 'add icon' : 'edit icon'}
-      />
-      <ChainDropdown
-        value={chainGroup}
-        onChange={setChainGroup}
-        options={chainOptions}
-        disabled={!isAdd}
-      />
-      <DefaultInput
-        value={name}
-        placeholder='Label'
-        onChange={onChangeName}
-        type='text'
-        error={nameError}
-        ref={nameInputRef}
-        margin='12px 0 0'
-      />
-      <AddressInput
-        value={address}
-        placeholder='Address'
-        onChange={onChangeAddress}
-        onKeyDown={onKeyDown}
-        rows={1}
-        maxLength={addressMaxLength}
-        autoComplete='off'
-        error={addressError}
-      />
-      <ErrorText text={errorMsg} />
-      {!isAdd && (
-        <RemoveAddressBtn error={Boolean(errorMsg)} onClick={removeHandler}>
-          <Text type='body1Reg' color={theme.neutral.a}>
-            Remove Address
-          </Text>
-        </RemoveAddressBtn>
-      )}
+      <ScrollableContent>
+        <img
+          className='symbol-image'
+          src={isAdd ? add : edit}
+          alt={isAdd ? 'add icon' : 'edit icon'}
+        />
+        <ChainDropdown
+          value={chainGroup}
+          onChange={setChainGroup}
+          options={chainOptions}
+          disabled={!isAdd}
+        />
+        <DefaultInput
+          value={name}
+          placeholder='Label'
+          onChange={onChangeName}
+          type='text'
+          error={nameError}
+          ref={nameInputRef}
+          margin='12px 0 0'
+        />
+        <AddressInput
+          value={address}
+          placeholder='Address'
+          onChange={onChangeAddress}
+          onKeyDown={onKeyDown}
+          rows={1}
+          maxLength={addressMaxLength}
+          autoComplete='off'
+          error={addressError}
+        />
+        <ErrorText text={errorMsg} />
+        {!isAdd && (
+          <RemoveAddressBtn error={Boolean(errorMsg)} onClick={removeHandler}>
+            <Text type='body1Reg' color={theme.neutral.a}>
+              Remove Address
+            </Text>
+          </RemoveAddressBtn>
+        )}
+      </ScrollableContent>
       <CancelAndConfirmButton
         cancelButtonProps={{ onClick: goBack }}
         confirmButtonProps={{
@@ -228,15 +241,18 @@ const RemoveAddressBtn = styled.button<{ error: boolean }>`
   text-underline-offset: 2px;
   text-decoration-thickness: 1px;
   text-decoration-color: ${getTheme('neutral', 'a')};
-  position: absolute;
-  bottom: 91px;
+  align-self: center;
+  margin-top: ${({ error }): string => (error ? '8px' : '16px')};
+  margin-bottom: 24px;
 `;
 
 const AddressInput = styled.textarea<{ error: boolean }>`
   ${inputStyle};
-  height: 70px;
+  min-height: 70px;
+  height: auto;
   overflow: hidden;
   resize: none;
+  word-break: break-all;
   border: 1px solid ${({ error, theme }): string => (error ? theme.red._5 : theme.neutral._7)};
   margin-top: 12px;
 `;
@@ -246,10 +262,20 @@ const Wrapper = styled.main`
   padding-top: 24px;
   width: 100%;
   height: 100%;
+  overflow: hidden;
   .symbol-image {
     margin: 24px auto;
     display: block;
   }
+`;
+
+const ScrollableContent = styled.div`
+  ${mixins.flex({ justify: 'flex-start' })};
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: 16px;
 `;
 
 const TopSection = styled.div`

--- a/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/add-address/index.tsx
@@ -42,11 +42,11 @@ const AddAddress = (): JSX.Element => {
   const isAdd = params.status === 'add';
 
   const addressList: AddressBookItem[] = params.addressList;
+  const { chainRegistry } = useAdenaContext();
   const [chainGroup, setChainGroup] = useState<string>(() =>
-    inferChainGroup(params.curr?.address ?? ''),
+    inferChainGroup(params.curr?.address ?? '', chainRegistry),
   );
   const chain = useChain(chainGroup);
-  const { chainRegistry } = useAdenaContext();
   const chainOptions = React.useMemo(
     () => chainOptionsFromRegistry(chainRegistry),
     [chainRegistry],
@@ -164,8 +164,8 @@ const AddAddress = (): JSX.Element => {
   useEffect(() => {
     setAddressError(false);
     setErrorMsg('');
-    setChainGroup(inferChainGroup(address));
-  }, [address]);
+    setChainGroup(inferChainGroup(address, chainRegistry));
+  }, [address, chainRegistry]);
 
   useEffect(() => {
     setNameError(false);

--- a/packages/adena-extension/src/pages/popup/certify/address-book/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/address-book/index.tsx
@@ -11,6 +11,7 @@ import mixins from '@styles/mixins';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { AddressBookItem } from '@repositories/wallet';
 import { useAddressBook } from '@hooks/use-address-book';
+import { useAdenaContext } from '@hooks/use-context';
 import { inferChainGroup } from '@common/utils/address-chain';
 import LoadingAddressBook from './loading-address-book';
 
@@ -20,6 +21,7 @@ const AddressBook = (): JSX.Element => {
   const theme = useTheme();
   const { navigate, goBack } = useAppNavigate();
   const { loading, addressBook } = useAddressBook();
+  const { chainRegistry } = useAdenaContext();
   const addAddressHandler = (status: navigateStatus, curr?: AddressBookItem): void =>
     navigate<RoutePath.AddAddress>(RoutePath.AddAddress, {
       state: {
@@ -42,7 +44,7 @@ const AddressBook = (): JSX.Element => {
       <>
         {addressBook.length > 0 ? (
           addressBook.map((item, i) => {
-            const chainGroup = inferChainGroup(item.address);
+            const chainGroup = inferChainGroup(item.address, chainRegistry);
             const chainIcon = CHAIN_ICON_BY_GROUP[chainGroup];
             return (
               <ListBox

--- a/packages/adena-extension/src/pages/popup/certify/address-book/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/address-book/index.tsx
@@ -11,12 +11,8 @@ import mixins from '@styles/mixins';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { AddressBookItem } from '@repositories/wallet';
 import { useAddressBook } from '@hooks/use-address-book';
+import { inferChainGroup } from '@common/utils/address-chain';
 import LoadingAddressBook from './loading-address-book';
-
-function inferChainGroup(address: string): string {
-  if (address.startsWith('atone1')) return 'atomone';
-  return 'gno';
-}
 
 type navigateStatus = 'add' | 'edit';
 

--- a/packages/adena-extension/src/pages/popup/wallet/approve-get-cosmos-key/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-get-cosmos-key/index.tsx
@@ -46,7 +46,7 @@ function createCosmosResponse(
 const ApproveGetCosmosKeyContainer: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { walletService, accountService } = useAdenaContext();
+  const { walletService } = useAdenaContext();
   const { currentAccount } = useCurrentAccount();
   const sentRef = useRef(false);
 
@@ -100,18 +100,12 @@ const ApproveGetCosmosKeyContainer: React.FC = () => {
 
         const compressedPubKey = compressPubkeyIfNeeded(currentAccount.publicKey);
 
-        // Mirror the popup display: prefer the user-edited nickname stored in
-        // the account-name map and fall back to the auto-generated default.
-        const accountNames = await accountService.getAccountNames();
-        const displayName = accountNames[currentAccount.id] || currentAccount.name;
-
         chrome.runtime.sendMessage(
           createCosmosResponse(
             CosmosResponseExecuteType.GET_COSMOS_KEY,
             'success',
             key,
             {
-              name: displayName,
               algo: 'secp256k1',
               pubKey: bytesToBase64(Array.from(compressedPubKey)),
               address: bytesToBase64(Array.from(addressBytes)),

--- a/packages/adena-extension/src/pages/popup/wallet/approve-get-cosmos-key/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-get-cosmos-key/index.tsx
@@ -46,7 +46,7 @@ function createCosmosResponse(
 const ApproveGetCosmosKeyContainer: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { walletService } = useAdenaContext();
+  const { walletService, accountService } = useAdenaContext();
   const { currentAccount } = useCurrentAccount();
   const sentRef = useRef(false);
 
@@ -100,13 +100,18 @@ const ApproveGetCosmosKeyContainer: React.FC = () => {
 
         const compressedPubKey = compressPubkeyIfNeeded(currentAccount.publicKey);
 
+        // Mirror the popup display: prefer the user-edited nickname stored in
+        // the account-name map and fall back to the auto-generated default.
+        const accountNames = await accountService.getAccountNames();
+        const displayName = accountNames[currentAccount.id] || currentAccount.name;
+
         chrome.runtime.sendMessage(
           createCosmosResponse(
             CosmosResponseExecuteType.GET_COSMOS_KEY,
             'success',
             key,
             {
-              name: currentAccount.name,
+              name: displayName,
               algo: 'secp256k1',
               pubKey: bytesToBase64(Array.from(compressedPubKey)),
               address: bytesToBase64(Array.from(addressBytes)),

--- a/packages/adena-extension/src/pages/popup/wallet/deposit/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/deposit/index.tsx
@@ -126,7 +126,7 @@ export const Deposit = (): JSX.Element => {
       <CopyInputBox>
         {currentAccount && (
           <Text type='body2Reg' display='inline-flex'>
-            {formatNickname(accountNames[currentAccount.id], 12)}
+            {formatNickname(accountNames[currentAccount.id] || currentAccount.name, 12)}
             <Text type='body2Reg' color={theme.neutral.a}>
               {` (${displayAddr})`}
             </Text>

--- a/packages/adena-extension/src/pages/web/wallet-export-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-export-screen/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { View, WebMain } from '@components/atoms';
 import useWalletExportScreen from '@hooks/web/wallet-export/use-wallet-export-screen';
+import { useAccountName } from '@hooks/use-account-name';
 import WalletExportCheckPassword from './check-password';
 import WalletExportResult from './result';
 import SensitiveInfoStep from '@components/pages/web/sensitive-info-step';
@@ -21,10 +22,16 @@ const WalletExportScreen: React.FC = () => {
     checkPassword,
     moveExport,
   } = useWalletExportScreen();
+  const { accountNames } = useAccountName();
 
   const spacing = useMemo(() => {
     return null;
   }, [])
+
+  const currentAccountDisplayName = useMemo(() => {
+    if (!currentAccount) return '';
+    return accountNames[currentAccount.id] || currentAccount.name;
+  }, [accountNames, currentAccount]);
 
   const description = useMemo(() => {
     if (exportType === 'PRIVATE_KEY') {
@@ -47,6 +54,7 @@ const WalletExportScreen: React.FC = () => {
         {walletExportState !== 'INIT' && (
           <WebMainAccountHeader
             account={currentAccount}
+            displayName={currentAccountDisplayName}
             onClickGoBack={backStep}
           />
         )}


### PR DESCRIPTION
## Summary

- Auto-detect chain from a saved/typed address prefix so the Add/Edit Address screen no longer mislabels atomone (`atone1...`) entries as Gno.land.
- Derive `addressMaxLength` from the longest registered bech32 prefix so pasting a longer-prefix address (e.g. `atone1...` while the form still shows gno) is no longer truncated by the textarea before chain auto-sync runs.
- Restructure the Edit Address layout: move `Remove Address` out of absolute positioning, pin Cancel/Save to the bottom, and make the rest of the form scroll so longer 2-line atomone addresses no longer overlap the action row.

## Background

`AddressBookItem` stores the bare address with no `chainGroup` field, so the chain has to be inferred from the bech32 prefix at display time. The list view (`address-book/index.tsx`) already did this with a local `inferChainGroup` helper; the Add/Edit form did not, defaulting to `gno` and disabling the dropdown in Edit mode. That stale value also constrained `addressMaxLength` (40 vs. 44) and was passed into `validateAlreadyAddressByAccounts(..., chain.bech32Prefix)`, silently misclassifying duplicate-account checks for atomone.

This change centralizes the heuristic in `common/utils/address-chain.ts`, seeds `chainGroup` from `params.curr?.address` on mount, and re-syncs on every address change. The dropdown remains user-clickable in Add mode (typing/pasting still wins) and disabled in Edit mode (existing behavior).

## Changes

- **New**: `packages/adena-extension/src/common/utils/address-chain.ts` — shared `inferChainGroup` helper.
- **Modified**: `pages/popup/certify/add-address/index.tsx`
  - Seed `chainGroup` from saved address; `useEffect` re-syncs on address change.
  - `addressMaxLength` derived from `chainRegistry.listChains()` (longest prefix), preventing paste truncation across chains.
  - `AddressInput`: `min-height: 70px; height: auto; word-break: break-all;` so 44-char atomone addresses wrap cleanly on two lines.
  - `RemoveAddressBtn`: out of absolute positioning, into normal flow with margins.
  - New `ScrollableContent` wrapper: middle of the form scrolls, Cancel/Save stays pinned at the bottom.
- **Modified**: `pages/popup/certify/address-book/index.tsx` — drop the duplicated local `inferChainGroup`, import from the shared util.

## Test plan

- [ ] Address Book → Add Address → paste an `atone1...` address → Chain dropdown switches to AtomOne, full 44 chars accepted (no truncation).
- [ ] Address Book → Add Address → paste a `g1...` address → Chain stays Gno.land, full 40 chars accepted.
- [ ] Save an atomone entry, re-open via Edit → Chain shows AtomOne, address renders on two lines, `Remove Address` no longer overlaps with the address text.
- [ ] In Edit Address, Cancel/Save remain pinned at the bottom; scroll the middle area to confirm the form content scrolls independently.
- [ ] Address Book list view: existing chain-icon inference for both gno and atomone entries still works (regression check).
- [ ] Save flow with both gno and atomone entries: no false `ALREADY_ADDRESS` from `validateAlreadyAddressByAccounts` (which now receives the right prefix).
