### PR TITLE
fix: prevent dApp connect hang on GnoSwap network (ADN-767)

### DIFF
--- a/packages/adena-extension/src/pages/popup/wallet/approve-establish/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-establish/index.tsx
@@ -142,19 +142,30 @@ const ApproveEstablishContainer: React.FC = () => {
         setResponse(
           InjectionMessageInstance.failure(WalletResponseFailureType.NETWORK_TIMEOUT, {}, key),
         );
+        setDone(true);
         return;
       }
 
-      const networkId = currentNetwork.id ?? '';
-      await establishService.establishBy(accountId, networkId, {
-        hostname: siteName,
-        accountId,
-        appName,
-        favicon,
-      });
-      setResponse(
-        InjectionMessageInstance.success(WalletResponseSuccessType.CONNECTION_SUCCESS, {}, key),
-      );
+      try {
+        const chainId = currentNetwork.chainId ?? '';
+        await establishService.establishBy(accountId, chainId, {
+          hostname: siteName,
+          accountId,
+          appName,
+          favicon,
+        });
+        setResponse(
+          InjectionMessageInstance.success(WalletResponseSuccessType.CONNECTION_SUCCESS, {}, key),
+        );
+      } catch (error) {
+        setResponse(
+          InjectionMessageInstance.failure(
+            WalletResponseFailureType.UNEXPECTED_ERROR,
+            { error: (error as Error)?.message ?? String(error) },
+            key,
+          ),
+        );
+      }
       setDone(true);
       return;
     }

--- a/packages/adena-module/src/chain-registry/entries/gno.ts
+++ b/packages/adena-module/src/chain-registry/entries/gno.ts
@@ -72,7 +72,7 @@ export const GNO_DEV: GnoNetworkProfile = {
 
 export const GNO_GNOSWAP: GnoNetworkProfile = {
   ...GNO_PROFILE_BASE,
-  id: 'dev.gnoswap',
+  id: 'gnoswap',
   chainId: 'dev.gnoswap',
   displayName: 'GnoSwap Dev',
   isMainnet: false,


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does:

## Summary

- Fix the infinite loading + dApp `Promise` hang on `addEstablish` while the wallet is on GnoSwap. The legacy single-chain branch passed `currentNetwork.id` (`"gnoswap"`) as the chainId to `establishBy`, but `chainRegistry` only knows the network by `chainId: "dev.gnoswap"`, so `resolveSiblingChainIds` threw `Unknown chainId: gnoswap` and the throw escaped a missing `try/catch`.
- `approve-establish/index.tsx`: pass `currentNetwork.chainId`, wrap the legacy branch in `try/catch` (mirrors the multi-chain branch), and add the missing `setDone(true)` on the `NETWORK_TIMEOUT` early-return so the dApp always gets a response.
- `gno.ts`: change `GNO_GNOSWAP.id` from `"dev.gnoswap"` to `"gnoswap"` so the chainRegistry profile and `chains.json` agree on the same `id`. No storage migration needed — persisted `CURRENT_CHAIN_ID` for GnoSwap users is already `"gnoswap"`.

## Out of scope

`GNO_TEST12` vs `chains.json`'s `test13` is a chain-version difference (different RPC/indexer), not just an `id` mismatch — left for a separate ticket.

## Test plan

- [ ] On GnoSwap, dApp `addEstablish` (no `chainIds`) → Connect succeeds, dApp Promise resolves.
- [ ] Other built-in networks (`gnoland1`, `staging`) — regression check.
- [ ] Multi-chain `addEstablish` (explicit `chainIds`) — regression check.
- [ ] Force `establishBy` to throw → popup surfaces `UNEXPECTED_ERROR` instead of hanging.
- [ ] \`cd packages/adena-module && npx jest --ci\`
- [ ] \`cd packages/adena-extension && npx jest --ci wallet-establish\`