### PR TITLE
ADN-768: align ApproveLogin Unlock layout and bump v1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adena-wallet",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Adena Wallet",
   "license": "Adena License",
   "private": true,

--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adena-extension",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "private": true,
   "description": "Adena is a friendly browser extension wallet for the Gno.land blockchain.",
   "scripts": {

--- a/packages/adena-extension/public/manifest.json
+++ b/packages/adena-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Adena",
   "description": "Adena is a friendly browser extension wallet for the gno.land blockchain.",
   "manifest_version": 3,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "action": {
     "default_icon": {
       "16": "icons/icon16.png",

--- a/packages/adena-extension/src/pages/popup/wallet/approve-login/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/approve-login/index.tsx
@@ -21,11 +21,10 @@ import { RoutePath } from '@types';
 import LoadingApproveTransaction from './loading-approve-transaction';
 
 const text = 'Enter\nYour Password';
-const Wrapper = styled.div`
-  ${mixins.flex({ justify: 'flex-start' })};
-  max-width: 100%;
-  min-height: 100%;
-  padding: 29px 20px 72px;
+const Wrapper = styled.main`
+  ${mixins.flex({ justify: 'stretch' })}
+  width: 100%;
+  height: 100%;
 `;
 
 export const ApproveLogin = (): JSX.Element => {

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adena-module",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Adena's Wallet",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
## Summary

- **ApproveLogin Unlock layout** — replace the bespoke `styled.div` wrapper (`padding: 29px 20px 72px`, `justify: flex-start`) with `styled.main` + `flex: stretch` so the dApp approval Unlock screen renders identically to the regular Login screen. Fixes the Unlock button position/top spacing drift after the ADN-760 popup redesign.
- **Version bump** — bumps `adena-extension`, `adena-module`, root `package.json`, and `manifest.json` to `1.19.1`.

## v1.19.1 release scope

This is the version-bump PR for the v1.19.1 release. Beyond the ApproveLogin fix above, v1.19.1 ships everything merged to `main` since v1.19.0:

- #835 — Send self-send fix for non-GRC20 tokens + Send summary card style alignment
- #836 — security review Findings #01–#06 + ADN-745 / ADN-747 / ADN-765 bundle
- #839 — ADN-767: prevent dApp connect hang on GnoSwap network
- #840 — ADN-768: ApproveLogin Unlock layout (this PR) + version bump to 1.19.1

## Test plan

- [ ] Trigger a dApp approve flow on a locked wallet → Unlock screen layout (button position, top padding) matches the regular Unlock screen.
- [ ] Confirm extension manifest version reads `1.19.1` after build.
- [ ] `yarn build` in `packages/adena-extension` succeeds.
