### PR TITLE
fix: toggle account/settings header buttons (ADN-773)

### DIFF
--- a/packages/adena-extension/src/router/popup/header/top-menu/index.tsx
+++ b/packages/adena-extension/src/router/popup/header/top-menu/index.tsx
@@ -16,6 +16,7 @@ import { useAdenaContext } from '@hooks/use-context';
 import { useAccountName } from '@hooks/use-account-name';
 import { useNetwork } from '@hooks/use-network';
 import { useAccountChainAddresses } from '@hooks/use-account-chain-addresses';
+import useAppNavigate from '@hooks/use-app-navigate';
 import { AccountAddressesPopover } from '@components/pages/router/top-menu/account-addresses-popover';
 import UnresponsiveNetworksIndicator from '@router/popup/header/unresponsive-networks-indicator';
 import mixins from '@styles/mixins';
@@ -73,14 +74,41 @@ const StyledCopyIconButton = styled.button.withConfig({
 
 export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
   const navigate = useNavigate();
+  const { goBack } = useAppNavigate();
   const { establishService } = useAdenaContext();
   const [hostname, setHostname] = useState('');
   const [protocol, setProtocol] = useState('');
   const { currentAccount } = useCurrentAccount();
-  const goToAccounts = (): void => navigate(RoutePath.Accounts);
-  const goToSettings = (): void => navigate(RoutePath.Setting);
   const [isEstablish, setIsEstablish] = useState(false);
   const location = useLocation();
+
+  const matchesArea = (path: string, base: string): boolean =>
+    path === base || path.startsWith(`${base}/`);
+  const isOnSettings = matchesArea(location.pathname, RoutePath.Setting);
+  const isOnAccounts = matchesArea(location.pathname, RoutePath.Accounts);
+
+  const goToAccounts = (): void => {
+    if (isOnAccounts) {
+      goBack();
+      return;
+    }
+    if (isOnSettings) {
+      navigate(RoutePath.Accounts, { replace: true });
+      return;
+    }
+    navigate(RoutePath.Accounts);
+  };
+  const goToSettings = (): void => {
+    if (isOnSettings) {
+      goBack();
+      return;
+    }
+    if (isOnAccounts) {
+      navigate(RoutePath.Setting, { replace: true });
+      return;
+    }
+    navigate(RoutePath.Setting);
+  };
   const [currentAccountName, setCurrentAccountName] = useState('');
   const { accountNames } = useAccountName();
   const { currentNetwork, unresponsiveNetworks } = useNetwork();


### PR DESCRIPTION
## Summary
- Header account/settings buttons used to push a new history entry on every click, even when already on the target page — multiple clicks stacked the same route and made back-navigation feel broken.
- Same-area click now closes via `goBack()` (toggle); cross-overlay click (settings ↔ accounts, including their sub-pages) navigates with `{ replace: true }` so the back stack stays at most `[Wallet, OneOverlay]`.
- Reuses `goBack` from the existing `useAppNavigate` hook (falls back to `RoutePath.Home` when history is empty).

## Test plan
- [ ] Wallet → click hamburger → on `/settings`; click hamburger again → returns to Wallet (no extra history entry).
- [ ] On `/settings`, enter a sub-page (e.g. Security) → click hamburger → returns to the page before entering settings.
- [ ] Wallet → click account button → on `/wallet/accounts`; click account button again → returns to Wallet.
- [ ] Wallet → settings → accounts (via header buttons) → back once → returns directly to Wallet (settings is not in the stack).
- [ ] On `/settings/security`, click account button → lands on `/wallet/accounts` and a single back returns to Wallet.
- [ ] Click the same header button 5x rapidly on its target page; one browser back returns to the previous page (no stack accumulation).
- [ ] Regression: from Wallet/NFT/Explore/History/ConnectedApps, both buttons still navigate forward as before.