### PR TITLE
fix: re-fit main balance font on account switch (ADN-772)

### DIFF
--- a/packages/adena-extension/src/components/pages/main/main-token-balance/main-token-balance.styles.ts
+++ b/packages/adena-extension/src/components/pages/main/main-token-balance/main-token-balance.styles.ts
@@ -41,4 +41,16 @@ export const MainTokenBalanceWrapper = styled(View).withConfig({
     left: 0;
     white-space: nowrap;
   }
+
+  /* Force natural font sizes on the clone so scrollWidth stays a stable
+     reference width regardless of the current $compact state. */
+  .measure-clone .value.integer,
+  .measure-clone .denom {
+    font-size: 32px !important;
+    line-height: 39px !important;
+  }
+  .measure-clone .value.decimal {
+    font-size: 24px !important;
+    line-height: 39px !important;
+  }
 `;


### PR DESCRIPTION
## Summary

- **Bug** — On the wallet home screen, the main balance auto-scales its font to fit. After switching from a long-balance account (e.g. `8,846,559.886565 GNOT`) to a short-balance account and back, the large font from the short account was retained, causing the long balance to overflow and clip the right edge (`GNO` showing instead of `GNOT`).
- **Cause** — `MainTokenBalance` measures a hidden `.measure-clone` to decide whether to apply compact font sizes. The wrapper's `$compact` CSS rules also targeted descendants inside the clone, so the clone reflected the *current* compact state instead of a stable natural width. Combined with `useTokenBalance`'s `keepPreviousData: true` non-atomic value transitions on account switch, this produced a state where `setCompact(true)` was not re-applied for the long balance.
- **Fix** — Add CSS rules scoped to `.measure-clone .value.integer / .value.decimal / .denom` that pin the clone to its natural sizes (32px / 24px / 32px, line-height 39px) regardless of `$compact`. Higher selector specificity (0,3,0 vs the compact rules' 0,2,0) ensures the override always wins. The measurement logic in `main-token-balance.tsx` is untouched.

## Test plan

- [ ] Repro the original bug on `main`: open Account A (long balance) → Account B (short balance) → back to Account A; confirm the right edge clips.
- [ ] On this branch, repeat the same A → B → A flow; the balance must shrink back to the compact size on every return to A.
- [ ] Toggle A ↔ B several times in quick succession; the font scales correctly each time.
- [ ] Verify on multiple networks (e.g. GnoSwap Dev) and with both Gno and Cosmos accounts.
- [ ] \`npm test\` in \`packages/adena-extension\` passes (existing \`main-token-balance.spec.tsx\` still green).
- [ ] \`yarn build\` in \`packages/adena-extension\` succeeds.