### PR TITLE
fix: default network edit/delete robustness (ADN-776)

### DIFF
--- a/packages/adena-extension/src/hooks/use-network.ts
+++ b/packages/adena-extension/src/hooks/use-network.ts
@@ -51,6 +51,7 @@ interface NetworkResponse {
   changeNetwork: (networkId: string) => Promise<boolean>;
   changeNetworkMode: (mode: NetworkMode) => Promise<void>;
   updateNetwork: (network: NetworkMetainfo | AtomoneNetworkMetainfo) => Promise<boolean>;
+  resetNetworkToDefault: (chainGroup: ChainGroup, networkId: string) => Promise<boolean>;
   deleteNetwork: (chainGroup: ChainGroup, networkId: string) => Promise<boolean>;
   setModified: (modified: boolean) => void;
 }
@@ -341,6 +342,28 @@ export const useNetwork = (): NetworkResponse => {
     ],
   );
 
+  const resetNetworkToDefault = useCallback(
+    async (chainGroup: ChainGroup, networkId: string): Promise<boolean> => {
+      if (chainGroup === 'atomone') {
+        const fetched = await chainService.fetchDefaultAtomoneNetworks().catch(() => []);
+        const factory = fetched.find((network) => network.id === networkId);
+        if (!factory) {
+          console.warn('resetNetworkToDefault: no factory entry for atomone id', networkId);
+          return false;
+        }
+        return updateNetwork(factory);
+      }
+      const fetched = await chainService.fetchDefaultNetworks().catch(() => []);
+      const factory = fetched.find((network) => network.id === networkId);
+      if (!factory) {
+        console.warn('resetNetworkToDefault: no factory entry for gno id', networkId);
+        return false;
+      }
+      return updateNetwork(factory);
+    },
+    [chainService, updateNetwork],
+  );
+
   const deleteNetwork = useCallback(
     async (chainGroup: ChainGroup, networkId: string) => {
       if (chainGroup === 'atomone') {
@@ -414,6 +437,7 @@ export const useNetwork = (): NetworkResponse => {
     changeNetwork,
     changeNetworkMode,
     updateNetwork,
+    resetNetworkToDefault,
     addNetwork,
     deleteNetwork,
     setModified,

--- a/packages/adena-extension/src/hooks/use-network.ts
+++ b/packages/adena-extension/src/hooks/use-network.ts
@@ -397,11 +397,17 @@ export const useNetwork = (): NetworkResponse => {
         setAtomoneNetworkMetainfos(changedNetworks);
 
         if (networkId === currentAtomoneNetwork?.id) {
+          const isMainnet = mode === 'mainnet';
           const fallback =
-            changedNetworks.find((current) => !current.deleted && current.isMainnet) ?? null;
+            changedNetworks.find(
+              (current) => !current.deleted && current.isMainnet === isMainnet,
+            ) ??
+            changedNetworks.find((current) => !current.deleted) ??
+            null;
           setCurrentAtomoneNetwork(fallback);
           if (fallback) {
             setSelectedProfileByChainGroup((prev) => ({ ...prev, atomone: fallback.id }));
+            await chainService.updateCurrentAtomoneNetworkId(fallback.id).catch(() => null);
           }
         }
         return true;
@@ -422,11 +428,35 @@ export const useNetwork = (): NetworkResponse => {
       setNetworkMetainfos(changedNetworks);
 
       if (networkId === currentGnoNetwork?.id) {
-        changeNetworkOfProvider(DEFAULT_NETWORK);
+        const isMainnet = mode === 'mainnet';
+        const fallback =
+          changedNetworks.find(
+            (current) => !current.deleted && (current.main === true) === isMainnet,
+          ) ??
+          changedNetworks.find((current) => !current.deleted) ??
+          null;
+        if (fallback) {
+          await chainService.updateCurrentNetworkId(fallback.id);
+          await changeNetworkOfProvider(fallback);
+          setSelectedProfileByChainGroup((prev) => ({ ...prev, gno: fallback.id }));
+        } else {
+          setCurrentNetwork(null);
+        }
       }
       return true;
     },
-    [currentGnoNetwork, currentAtomoneNetwork, networkMetainfos, atomoneNetworks, chainService],
+    [
+      currentGnoNetwork,
+      currentAtomoneNetwork,
+      networkMetainfos,
+      atomoneNetworks,
+      chainService,
+      mode,
+      changeNetworkOfProvider,
+      setCurrentNetwork,
+      setCurrentAtomoneNetwork,
+      setSelectedProfileByChainGroup,
+    ],
   );
 
   const dispatchChangedEvent = useCallback(

--- a/packages/adena-extension/src/hooks/use-network.ts
+++ b/packages/adena-extension/src/hooks/use-network.ts
@@ -8,12 +8,13 @@ import { useEvent } from './use-event';
 
 import CHAIN_DATA from '@resources/chains/chains.json';
 import { NetworkState } from '@states';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { AtomoneNetworkMetainfo, NetworkMetainfo } from '@types';
 import {
   atomoneNetworkToProfile,
   atomoneNetworkToTokenProfiles,
 } from './helpers/atomone-to-profile';
+import { toGnoNetworkProfile } from '@common/mapper/network-profile-mapper';
 
 export type ChainGroup = 'gno' | 'atomone';
 export type NetworkMode = NetworkState.NetworkMode;
@@ -81,6 +82,8 @@ export const useNetwork = (): NetworkResponse => {
     NetworkState.selectedProfileByChainGroup,
   );
   const [modified, setModified] = useRecoilState(NetworkState.modified);
+
+  const queryClient = useQueryClient();
 
   const { data: failedNetwork = null, refetch: refetchNetworkState } = useQuery<boolean | null>(
     ['network/failedNetwork', currentGnoNetwork],
@@ -318,6 +321,9 @@ export const useNetwork = (): NetworkResponse => {
         }
         if (network.id === currentAtomoneNetwork?.id) {
           setCurrentAtomoneNetwork(network);
+          // Drop the stale cosmos balance cache so the new rpcUrl/restUrl is
+          // hit immediately instead of waiting for the next refetch interval.
+          queryClient.invalidateQueries({ queryKey: ['balances', 'cosmos'] });
         }
         return true;
       }
@@ -328,8 +334,15 @@ export const useNetwork = (): NetworkResponse => {
       await chainService.updateNetworks(changedNetworks);
       setNetworkMetainfos(changedNetworks);
 
+      if (!network.deleted) {
+        chainRegistry.register(toGnoNetworkProfile(network));
+      }
+
       if (network.id === currentGnoNetwork?.id) {
-        changeNetworkOfProvider(network);
+        await changeNetworkOfProvider(network);
+        // Drop the stale gno balance cache so the new rpcUrl/chainId is hit
+        // immediately instead of waiting for the next refetch interval.
+        queryClient.invalidateQueries({ queryKey: ['balances', 'gno'] });
       }
       return true;
     },
@@ -339,6 +352,9 @@ export const useNetwork = (): NetworkResponse => {
       networkMetainfos,
       atomoneNetworks,
       chainService,
+      chainRegistry,
+      queryClient,
+      changeNetworkOfProvider,
     ],
   );
 

--- a/packages/adena-extension/src/pages/popup/wallet/edit-custom-network/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/edit-custom-network/index.tsx
@@ -40,7 +40,8 @@ const EditCustomNetworkContainer: React.FC = () => {
   const currentNetworkId = params.networkId;
   const chainGroup: ChainGroup = params.chainGroup;
   const fieldType = chainGroup === 'atomone' ? 'lcd' : 'indexer';
-  const { networks, atomoneNetworks, updateNetwork, deleteNetwork } = useNetwork();
+  const { networks, atomoneNetworks, updateNetwork, resetNetworkToDefault, deleteNetwork } =
+    useNetwork();
   const {
     name,
     rpcUrl,
@@ -168,10 +169,8 @@ const EditCustomNetworkContainer: React.FC = () => {
 
   const clearNetwork = useCallback(async () => {
     if (isDefault && originNetwork) {
-      changeName(originNetwork.networkName);
-      changeRPCUrl(originNetwork.rpcUrl);
-      changeExtraUrl(originExtraUrl);
-      changeChainId(originNetwork.chainId);
+      await resetNetworkToDefault(chainGroup, currentNetworkId);
+      goBack();
       return;
     }
     await deleteNetwork(chainGroup, currentNetworkId);
@@ -180,8 +179,8 @@ const EditCustomNetworkContainer: React.FC = () => {
     chainGroup,
     isDefault,
     originNetwork,
-    originExtraUrl,
     currentNetworkId,
+    resetNetworkToDefault,
     deleteNetwork,
     goBack,
   ]);

--- a/packages/adena-extension/src/repositories/common/chain.spec.ts
+++ b/packages/adena-extension/src/repositories/common/chain.spec.ts
@@ -107,7 +107,7 @@ describe('ChainRepository — AtomOne methods', () => {
       ]);
     });
 
-    it('preserves deleted flag on stored entries', async () => {
+    it('preserves the deleted flag on stored default entries', async () => {
       const deletedDefault = {
         ...ATOMONE_DEFAULTS[1],
         deleted: true,
@@ -122,9 +122,22 @@ describe('ChainRepository — AtomOne methods', () => {
 
       const testnet = result.find((network) => network.id === 'atomone-testnet-1');
       expect(testnet).toBeDefined();
-      // default entry comes from fetched defaults (always fresh) — stored deleted=true
-      // is not carried over, matching the existing Gno getNetworks behavior.
-      expect(testnet?.deleted).toBe(false);
+      expect(testnet?.deleted).toBe(true);
+    });
+
+    it('preserves user-edited rpc/rest urls on stored default entries', async () => {
+      const editedMainnet = {
+        ...ATOMONE_DEFAULTS[0],
+        rpcUrl: 'https://my-node.example/rpc',
+        restUrl: 'https://my-node.example/rest',
+      };
+      storedValue = [editedMainnet, ATOMONE_DEFAULTS[1]];
+
+      const result = await repository.getAtomoneNetworks();
+
+      const mainnet = result.find((network) => network.id === 'atomone-1');
+      expect(mainnet?.rpcUrl).toBe('https://my-node.example/rpc');
+      expect(mainnet?.restUrl).toBe('https://my-node.example/rest');
     });
 
     it('does not duplicate defaults when custom shares an id with a default', async () => {
@@ -137,6 +150,15 @@ describe('ChainRepository — AtomOne methods', () => {
       const result = await repository.getAtomoneNetworks();
 
       expect(result.filter((network) => network.id === 'atomone-1')).toHaveLength(1);
+    });
+
+    it('adds fetched defaults that have no stored counterpart', async () => {
+      // Storage was populated before a new default shipped in atomone-chains.json.
+      storedValue = [{ ...ATOMONE_DEFAULTS[0], deleted: false }];
+
+      const result = await repository.getAtomoneNetworks();
+
+      expect(result.map((network) => network.id)).toEqual(['atomone-1', 'atomone-testnet-1']);
     });
   });
 

--- a/packages/adena-extension/src/repositories/common/chain.ts
+++ b/packages/adena-extension/src/repositories/common/chain.ts
@@ -49,14 +49,16 @@ export class ChainRepository {
       return fetchedNetworks;
     }
 
-    const defaultNetworks = fetchedNetworks.filter(
-      (network) =>
-        network.default || networks?.find((current) => current.id === network.id) === undefined,
+    // Prefer the locally stored entry when it shares an id with a fetched default
+    // so user edits and the deleted flag survive a restart. Fall back to fetched
+    // when no local copy exists (newly introduced defaults).
+    const localById = new Map(networks.map((network) => [network.id, network]));
+    const fetchedIds = new Set(fetchedNetworks.map((network) => network.id));
+    const defaultNetworks = fetchedNetworks.map(
+      (fetched) => localById.get(fetched.id) ?? fetched,
     );
     const customNetworks = networks.filter(
-      (network) =>
-        network.default === false &&
-        defaultNetworks.find((network1) => network.id === network1.id) === undefined,
+      (network) => network.default === false && !fetchedIds.has(network.id),
     );
     return [...defaultNetworks, ...customNetworks];
   };
@@ -95,14 +97,13 @@ export class ChainRepository {
       return fetchedNetworks;
     }
 
-    const defaultNetworks = fetchedNetworks.filter(
-      (network) =>
-        network.default || networks?.find((current) => current.id === network.id) === undefined,
+    const localById = new Map(networks.map((network) => [network.id, network]));
+    const fetchedIds = new Set(fetchedNetworks.map((network) => network.id));
+    const defaultNetworks = fetchedNetworks.map(
+      (fetched) => localById.get(fetched.id) ?? fetched,
     );
     const customNetworks = networks.filter(
-      (network) =>
-        network.default === false &&
-        defaultNetworks.find((network1) => network.id === network1.id) === undefined,
+      (network) => network.default === false && !fetchedIds.has(network.id),
     );
     return [...defaultNetworks, ...customNetworks];
   };

--- a/packages/adena-extension/src/services/resource/chain.ts
+++ b/packages/adena-extension/src/services/resource/chain.ts
@@ -23,6 +23,14 @@ export class ChainService {
     return fetchedNetworks;
   };
 
+  public fetchDefaultNetworks = async (): Promise<NetworkMetainfo[]> => {
+    return this.chainRepository.fetchNetworkMetainfos();
+  };
+
+  public fetchDefaultAtomoneNetworks = async (): Promise<AtomoneNetworkMetainfo[]> => {
+    return this.chainRepository.fetchAtomoneMetainfos();
+  };
+
   public addGnoNetwork = async (
     name: string,
     rpcUrl: string,


### PR DESCRIPTION
## Summary

- Preserve user edits to default networks (rpc/rest URLs, deleted flag) across reload, and wire the **Reset to Default** button on the Edit Network screen to actually restore the shipped `chains.json` values.
- Refresh `chainRegistry` and invalidate the React Query balance caches when the active gno/atomone network is edited so the new RPC / Chain ID / REST URL takes effect immediately instead of after the next refetch interval. dApp `approveEstablish` health checks also pick up the new endpoint.
- When deleting the active network, fall back to the first non-deleted entry matching the current testnet mode (was hardcoded beta-mainnet for gno, hardcoded `isMainnet` for atomone). The new current network id is also persisted so the fallback survives a reload.

## Test plan

- [ ] Edit active gno default network's RPC URL -> Save -> balance refetches from the new RPC without waiting for the refetch interval
- [ ] Edit active gno default network's Chain ID -> dApp Approve Establish health check uses the new chainId/RPC
- [ ] Edit active atomone network's RPC/REST URL -> cosmos balance refetches from the new endpoints immediately
- [ ] Edit a default network -> reload the extension -> user edits and `deleted` flag survive
- [ ] Edit a default network -> click **Reset to Default** -> storage is restored to the `chains.json` factory values
- [ ] testnet mode ON: activate a custom gno testnet, delete it -> wallet falls back to the first non-deleted gno testnet (not beta-mainnet)
- [ ] mainnet mode: same path -> wallet falls back to the first gno mainnet
- [ ] Repeat the two cases above for atomone (testnet mode delete -> atomone testnet, not atomone mainnet)
- [ ] After delete fallback, reload the extension -> the fallback selection persists (current network id was saved)
- [ ] Regression: switching to an unedited network still works for both chain groups
- [ ] Regression: adding a brand-new custom network (gno + atomone) still works and shows up in the list