### PR TITLE
fix(ADN-777): show token name instead of network name on send confirm

### DIFF
--- a/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary-balance/transfer-summary-balance.spec.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary-balance/transfer-summary-balance.spec.tsx
@@ -12,7 +12,7 @@ describe('TransferSummaryBalance Component', () => {
       tokenImage: '',
       value: '',
       denom: '',
-      chainName: 'Gno.land',
+      tokenName: 'Gno.land',
     };
 
     render(

--- a/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary-balance/transfer-summary-balance.stories.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary-balance/transfer-summary-balance.stories.tsx
@@ -11,6 +11,6 @@ export const Default: StoryObj<TransferSummaryBalanceProps> = {
     tokenImage: 'https://raw.githubusercontent.com/onbloc/gno-token-resource/main/gno-native/images/gnot.svg',
     value: '4,000.123',
     denom: 'GNOT',
-    chainName: 'Gno.land',
+    tokenName: 'Gno.land',
   },
 };

--- a/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary-balance/transfer-summary-balance.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary-balance/transfer-summary-balance.tsx
@@ -6,7 +6,7 @@ export interface TransferSummaryBalanceProps {
   tokenImage: string;
   value: string;
   denom: string;
-  chainName: string;
+  tokenName: string;
   chainBadgeImage?: string;
 }
 
@@ -14,7 +14,7 @@ const TransferSummaryBalance: React.FC<TransferSummaryBalanceProps> = ({
   tokenImage,
   value,
   denom,
-  chainName,
+  tokenName,
   chainBadgeImage,
 }) => {
   return (
@@ -25,7 +25,7 @@ const TransferSummaryBalance: React.FC<TransferSummaryBalanceProps> = ({
           <img className='chain-badge' src={chainBadgeImage} alt='chain badge' />
         )}
       </div>
-      <span className='chain-name'>{chainName}</span>
+      <span className='chain-name'>{tokenName}</span>
       <div className='balance-wrapper'>
         <TokenBalance
           value={value}

--- a/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary/transfer-summary.tsx
+++ b/packages/adena-extension/src/components/pages/transfer-summary/transfer-summary/transfer-summary.tsx
@@ -108,7 +108,7 @@ const TransferSummary: React.FC<TransferSummaryProps> = ({
           tokenImage={tokenImage}
           value={transferBalance.value}
           denom={transferBalance.denom}
-          chainName={chainName}
+          tokenName={tokenMetainfo.name}
           chainBadgeImage={chainBadgeImage}
         />
 


### PR DESCRIPTION
## Summary
- Token row on the Send Confirm screen was rendering the active network's display name (e.g. `GnoSwap Dev`) instead of the token name (e.g. `Gno.land`)
- Root cause: container passed `tokenProfile?.displayName` into a misleadingly-named `chainName` prop on `TransferSummaryBalance`; after custom networks decoupled the network display name from the token name, the row started showing the wrong label
- Renamed the prop to `tokenName` and fed it `tokenMetainfo.name` so the token row labels the token itself, while the `Network` row keeps using the chain display name

## Changes
- `transfer-summary-balance.tsx`: rename prop `chainName` → `tokenName`
- `transfer-summary.tsx`: pass `tokenName={tokenMetainfo.name}` (Network row still gets `chainName`)
- `transfer-summary-balance.spec.tsx` / `.stories.tsx`: sync prop name

## Test plan
- [ ] Unit tests: `npx jest transfer-summary` passes
- [ ] Default network (Gno.land): token row shows `Gno.land`, Network row shows `Gno.land` (no regression)
- [ ] Custom network (e.g. `GnoSwap Dev`): token row shows `Gno.land`, Network row shows `GnoSwap Dev`
- [ ] GRC20 token: token row shows the token's `tokenMetainfo.name`
- [ ] Cosmos token (AtomOne): token row shows AtomOne native token name, chain badge still rendered