### PR TITLE
feat: indexer schema migration with GRC20 metadata via grc20reg qeval query

### DIFF
--- a/packages/adena-extension/src/common/provider/gno/gno-provider.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.ts
@@ -25,6 +25,7 @@ import {
 } from '@gnolang/tm2-js-client';
 import { ResponseDeliverTx } from '@gnolang/tm2-js-client/bin/proto/tm2/abci';
 import axios from 'axios';
+import { formatGnoArg, GnoArg } from './qeval';
 import { AccountInfo, GnoDocumentInfo, VMQueryType } from './types';
 import {
   fetchABCIResponse,
@@ -164,6 +165,63 @@ export class GnoProvider extends GnoJSONRPCProvider {
         return null;
       })
       .catch(() => null);
+  }
+
+  /**
+   * Build a Gno IIFE expression that runs multi-statement logic inside a single
+   * `vm/qeval` call and returns a typed value. Mirrors the pattern:
+   *
+   *   (func() <returnType> { <statements>; <call>; return <returnExpression> })()
+   *
+   * `statements` are emitted first, so any variable defined there is in scope
+   * for the `call` shorthand and the `returnExpression`. Each entry must be a
+   * complete Gno statement without a trailing semicolon.
+   *
+   * `call` is a shorthand for the most common shape: invoke a package function,
+   * capture `(value, err)`, panic on error, and return an expression derived
+   * from `value`. Arguments are escaped with `gnoLiteral`; pass `gnoRaw(expr)`
+   * when an argument should be inlined verbatim (e.g. a variable from
+   * `statements`).
+   */
+  public static buildIIFEExpression(params: {
+    returnType: string;
+    returnExpression: string;
+    statements?: string[];
+    call?: {
+      name: string;
+      args?: GnoArg[];
+      resultVar?: string;
+      errorVar?: string;
+    };
+  }): string {
+    const { returnType, returnExpression, statements = [], call } = params;
+
+    const callStmts: string[] = [];
+    if (call) {
+      const resultVar = call.resultVar ?? 'result';
+      const errorVar = call.errorVar ?? 'err';
+      const args = (call.args ?? []).map(formatGnoArg).join(', ');
+      callStmts.push(`${resultVar}, ${errorVar} := ${call.name}(${args})`);
+      callStmts.push(`if ${errorVar} != nil { panic(${errorVar}) }`);
+    }
+
+    const body = [...statements, ...callStmts, `return ${returnExpression}`].join('; ');
+    return `(func() ${returnType} { ${body} })()`;
+  }
+
+  /**
+   * Execute a Gno IIFE expression via `vm/qeval` and return the raw response
+   * string produced by the node (e.g. `("foo" string)` or `(42 int64)`).
+   * Decoding the payload into a typed value is left to the caller — combine
+   * with `parseQEvalResult` / `decodeQEvalString` / `decodeQEvalInt` etc.
+   */
+  public evaluateIIFE(
+    packagePath: string,
+    params: Parameters<typeof GnoProvider.buildIIFEExpression>[0],
+    height?: number,
+  ): Promise<string> {
+    const expression = GnoProvider.buildIIFEExpression(params);
+    return this.evaluateExpression(packagePath, expression, height);
   }
 
   public async sendTransactionSync(tx: string): Promise<BroadcastTxSyncResult> {

--- a/packages/adena-extension/src/common/provider/gno/index.ts
+++ b/packages/adena-extension/src/common/provider/gno/index.ts
@@ -1,2 +1,3 @@
 export * from './gno-provider';
+export * from './qeval';
 export * from './types';

--- a/packages/adena-extension/src/common/provider/gno/qeval.ts
+++ b/packages/adena-extension/src/common/provider/gno/qeval.ts
@@ -1,0 +1,251 @@
+/**
+ * Helpers for composing Gno `vm/qeval` expressions and decoding the raw text
+ * the node returns. A qeval response looks like a sequence of `(value type)`
+ * tuples — one per return value — joined by newlines:
+ *
+ *   ("hello" string)
+ *   (42 int64)
+ *
+ * String values are double-quoted with Go-style escapes; numeric, boolean and
+ * nil values are bare tokens. Slice and struct literals come back as Go
+ * literals (e.g. `slice[("a" string),("b" string)]`) which is awkward to parse,
+ * so for collections we recommend evaluating an IIFE that marshals to JSON.
+ */
+
+const GNO_RAW = Symbol('gno-raw');
+
+export type GnoArg = string | number | bigint | boolean | null | GnoRawArg;
+
+interface GnoRawArg {
+  [GNO_RAW]: true;
+  value: string;
+}
+
+/**
+ * Wrap a string so {@link formatGnoArg} inlines it verbatim instead of quoting
+ * it. Use for variable references or sub-expressions: `gnoRaw('addr')` becomes
+ * `addr` in the generated source.
+ */
+export const gnoRaw = (value: string): GnoRawArg => ({ [GNO_RAW]: true, value });
+
+/**
+ * Quote a value as a Go literal suitable for embedding in a qeval expression.
+ * Strings are escaped per Go's interpreted-string-literal rules.
+ */
+export const gnoLiteral = (value: Exclude<GnoArg, GnoRawArg>): string => {
+  if (value === null) return 'nil';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`gnoLiteral: non-finite number ${value} is not representable in Gno`);
+    }
+    return `${value}`;
+  }
+  if (typeof value === 'bigint') return value.toString(10);
+  return escapeGnoString(value);
+};
+
+export const formatGnoArg = (arg: GnoArg): string => {
+  if (typeof arg === 'object' && arg !== null && GNO_RAW in arg) {
+    return arg.value;
+  }
+  return gnoLiteral(arg as Exclude<GnoArg, GnoRawArg>);
+};
+
+const escapeGnoString = (value: string): string => {
+  let out = '"';
+  for (const ch of value) {
+    switch (ch) {
+      case '\\':
+        out += '\\\\';
+        break;
+      case '"':
+        out += '\\"';
+        break;
+      case '\n':
+        out += '\\n';
+        break;
+      case '\r':
+        out += '\\r';
+        break;
+      case '\t':
+        out += '\\t';
+        break;
+      default: {
+        const code = ch.charCodeAt(0);
+        // Escape other control characters; leave printable Unicode as-is.
+        if (code < 0x20 || code === 0x7f) {
+          out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+          out += ch;
+        }
+      }
+    }
+  }
+  return out + '"';
+};
+
+export interface QEvalTuple {
+  raw: string;
+  value: string;
+  type: string;
+}
+
+/**
+ * Split a qeval response into its `(value type)` tuples. Each tuple keeps the
+ * raw value token (still quoted/escaped if it is a string) and the trailing
+ * type name, so callers can dispatch on type and decode the value safely.
+ */
+export const parseQEvalResult = (response: string): QEvalTuple[] => {
+  const tuples: QEvalTuple[] = [];
+  let i = 0;
+  while (i < response.length) {
+    // Skip whitespace and tuple separators.
+    while (i < response.length && /\s/.test(response[i])) i++;
+    if (i >= response.length) break;
+    if (response[i] !== '(') {
+      throw new Error(`parseQEvalResult: expected "(" at offset ${i} in ${JSON.stringify(response)}`);
+    }
+    const start = i;
+    i++; // consume '('
+
+    // Value token: either a quoted string or a bare token up to whitespace.
+    let value: string;
+    if (response[i] === '"') {
+      const quoteStart = i;
+      i++;
+      while (i < response.length) {
+        if (response[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (response[i] === '"') {
+          i++;
+          break;
+        }
+        i++;
+      }
+      value = response.slice(quoteStart, i);
+    } else {
+      const tokenStart = i;
+      while (i < response.length && !/\s/.test(response[i]) && response[i] !== ')') i++;
+      value = response.slice(tokenStart, i);
+    }
+
+    // Skip whitespace between value and type.
+    while (i < response.length && /\s/.test(response[i])) i++;
+
+    // Type token: read until the closing ')'.
+    const typeStart = i;
+    let depth = 0;
+    while (i < response.length) {
+      const ch = response[i];
+      if (ch === '(') depth++;
+      else if (ch === ')') {
+        if (depth === 0) break;
+        depth--;
+      }
+      i++;
+    }
+    const type = response.slice(typeStart, i).trim();
+
+    if (response[i] !== ')') {
+      throw new Error(`parseQEvalResult: unterminated tuple starting at offset ${start}`);
+    }
+    i++; // consume ')'
+
+    tuples.push({ raw: response.slice(start, i), value, type });
+  }
+  return tuples;
+};
+
+/**
+ * Decode a Go interpreted string literal (the `"..."` form qeval returns for
+ * string values). Throws if the input is not a quoted string.
+ */
+export const decodeGnoString = (token: string): string => {
+  if (token.length < 2 || token[0] !== '"' || token[token.length - 1] !== '"') {
+    throw new Error(`decodeGnoString: expected quoted string, got ${JSON.stringify(token)}`);
+  }
+  let out = '';
+  for (let i = 1; i < token.length - 1; i++) {
+    const ch = token[i];
+    if (ch !== '\\') {
+      out += ch;
+      continue;
+    }
+    const next = token[++i];
+    switch (next) {
+      case '\\':
+        out += '\\';
+        break;
+      case '"':
+        out += '"';
+        break;
+      case 'n':
+        out += '\n';
+        break;
+      case 'r':
+        out += '\r';
+        break;
+      case 't':
+        out += '\t';
+        break;
+      case 'x': {
+        const hex = token.slice(i + 1, i + 3);
+        out += String.fromCharCode(parseInt(hex, 16));
+        i += 2;
+        break;
+      }
+      case 'u': {
+        const hex = token.slice(i + 1, i + 5);
+        out += String.fromCharCode(parseInt(hex, 16));
+        i += 4;
+        break;
+      }
+      default:
+        out += next;
+    }
+  }
+  return out;
+};
+
+/** Decode the first tuple in a qeval response as a string. */
+export const decodeQEvalString = (response: string): string => {
+  const [first] = parseQEvalResult(response);
+  if (!first) throw new Error('decodeQEvalString: empty qeval response');
+  return decodeGnoString(first.value);
+};
+
+/**
+ * Decode the first tuple as an integer. Returns a `bigint` so int64 values
+ * outside `Number.MAX_SAFE_INTEGER` survive the round trip; callers that know
+ * the value fits in a JS number can `Number(...)` it themselves.
+ */
+export const decodeQEvalInt = (response: string): bigint => {
+  const [first] = parseQEvalResult(response);
+  if (!first) throw new Error('decodeQEvalInt: empty qeval response');
+  if (!/^-?\d+$/.test(first.value)) {
+    throw new Error(`decodeQEvalInt: ${JSON.stringify(first.value)} is not an integer literal`);
+  }
+  return BigInt(first.value);
+};
+
+/** Decode the first tuple as a boolean. */
+export const decodeQEvalBool = (response: string): boolean => {
+  const [first] = parseQEvalResult(response);
+  if (!first) throw new Error('decodeQEvalBool: empty qeval response');
+  if (first.value === 'true') return true;
+  if (first.value === 'false') return false;
+  throw new Error(`decodeQEvalBool: ${JSON.stringify(first.value)} is not a boolean`);
+};
+
+/**
+ * Decode the first tuple by JSON-parsing its string value. Use this together
+ * with an IIFE that returns `string(jsonBytes)` — much more reliable than
+ * trying to parse Gno's native slice/struct printout.
+ */
+export const decodeQEvalJSON = <T = unknown>(response: string): T => {
+  const text = decodeQEvalString(response);
+  return JSON.parse(text) as T;
+};

--- a/packages/adena-extension/src/repositories/common/mapper/token-query.mapper.ts
+++ b/packages/adena-extension/src/repositories/common/mapper/token-query.mapper.ts
@@ -1,5 +1,5 @@
 import { parseGRC721FileContents } from '@common/utils/parse-utils';
-import { GRC20TokenModel, GRC721CollectionModel } from '@types';
+import { GRC20RegisterEvent, GRC20TokenModel, GRC721CollectionModel } from '@types';
 
 export const GRC20_FUNCTIONS = [
   'TotalSupply',
@@ -9,6 +9,92 @@ export const GRC20_FUNCTIONS = [
   'Approve',
   'TransferFrom',
 ];
+
+/** Must stay in sync with `makeGetGRC20RegisterEventsQuery` indexer filter. */
+const GRC20_REGISTER_EVENT_TYPE = 'register';
+const GRC20_REGISTER_REGISTRY_PKG_PATH = 'gno.land/r/demo/defi/grc20reg';
+
+type GnoEventAttr = { key: string; value: string };
+
+type GnoGraphQueryEvent = {
+  type?: string;
+  pkg_path?: string;
+  attrs?: GnoEventAttr[];
+};
+
+export type GRC20RegisterTransactionsQueryResult = {
+  data?: {
+    getTransactions?: Array<{
+      response?: { events?: unknown[] };
+    }>;
+  };
+};
+
+function isGnoGraphQueryEvent(ev: unknown): ev is GnoGraphQueryEvent {
+  return (
+    typeof ev === 'object' &&
+    ev !== null &&
+    'type' in ev &&
+    typeof (ev as GnoGraphQueryEvent).type === 'string' &&
+    'pkg_path' in ev &&
+    typeof (ev as GnoGraphQueryEvent).pkg_path === 'string'
+  );
+}
+
+function parseGRC20RegisterAttrs(attrs: GnoEventAttr[] | undefined): GRC20RegisterEvent | null {
+  if (!attrs?.length) {
+    return null;
+  }
+  const byKey: Record<string, string> = {};
+  for (const { key, value } of attrs) {
+    byKey[key.toLowerCase()] = value;
+  }
+  const packagePath = byKey.pkgpath;
+  if (!packagePath) {
+    return null;
+  }
+  return {
+    packagePath,
+    slug: byKey.slug ?? '',
+  };
+}
+
+/**
+ * Maps `getGRC20RegisterEvents` GraphQL response: one {@link GRC20RegisterEvent}
+ * per matching Gno event (`register` on grc20reg), derived from event attrs.
+ */
+export function mapGRC20RegisterEvent(
+  queryResult: GRC20RegisterTransactionsQueryResult | null | undefined,
+): GRC20RegisterEvent[] {
+  const transactions = queryResult?.data?.getTransactions;
+  if (!transactions?.length) {
+    return [];
+  }
+
+  const events: GRC20RegisterEvent[] = [];
+  for (const tx of transactions) {
+    const rawEvents = tx?.response?.events;
+    if (!rawEvents?.length) {
+      continue;
+    }
+    for (const ev of rawEvents) {
+      if (!isGnoGraphQueryEvent(ev)) {
+        continue;
+      }
+      if (
+        ev.type !== GRC20_REGISTER_EVENT_TYPE ||
+        ev.pkg_path !== GRC20_REGISTER_REGISTRY_PKG_PATH
+      ) {
+        continue;
+      }
+      const mapped = parseGRC20RegisterAttrs(ev.attrs);
+      if (mapped) {
+        events.push(mapped);
+      }
+    }
+  }
+  return events;
+}
 
 export function mapGRC721CollectionModel(
   networkId: string,
@@ -69,7 +155,9 @@ export function mapGRC20TokenModel(networkId: string, message: any): GRC20TokenM
   return null;
 }
 
-function parseGRC20InfoByFile(file: string): {
+function parseGRC20InfoByFile(
+  file: string,
+): {
   name: string;
   symbol: string;
   decimals: number;
@@ -135,7 +223,9 @@ function parseGRC20InfoByFile(file: string): {
   return { ...grc20Info, owner };
 }
 
-function parseBankerGRC20InfoByFile(file: string): {
+function parseBankerGRC20InfoByFile(
+  file: string,
+): {
   name: string;
   symbol: string;
   decimals: number;

--- a/packages/adena-extension/src/repositories/common/token.queries.ts
+++ b/packages/adena-extension/src/repositories/common/token.queries.ts
@@ -1,155 +1,23 @@
-export const makeAllRealmsQuery = (): string => `
-{
-  transactions(filter: {
-    success: true
-    message: {
-      type_url: add_package
-    }
-  }) {
-    messages {
-        value {
-          ... on MsgAddPackage {
-            creator
-            package {
-              path
-              name
-              files {
-                name
-                body
-              }
-            }
+export const makeGetGRC20RegisterEventsQuery = (): string => `
+query getGRC20RegisterEvents {
+  getTransactions(
+    where: {
+      success: {eq: true}, 
+      response: {
+        events: {
+          GnoEvent: {
+            type: { eq: "register" }
+            pkg_path: { eq: "gno.land/r/demo/defi/grc20reg" }
           }
         }
-    }
-  }
-}
-`;
-
-export const makeGRC721TransferEventsQuery = (packagePath: string, address: string): string => `
-{
-  transactions(
-    filter: {
-      success: true
-      events: {
-        type: "Transfer"
-        pkg_path: "${packagePath}"
-        attrs: [{
-          key: "from"
-          value: "${address}"
-        }, {
-          key:"to"
-          value: "${address}"
-        }]
       }
-      message: [
-        {
-          type_url: exec
-        }
-      ]
     }
   ) {
-    hash
-    index
-    success
-    block_height
     response {
       events {
-        ...on GnoEvent {
+        ... on GnoEvent {
           type
           pkg_path
-          func
-          attrs {
-            key
-            value
-          }
-        }
-      }
-    }
-  }
-}
-`;
-export const makeGRC721TransferEventsQueryWithCursor = (
-  packagePath: string,
-  address: string,
-): string => `
-{
-  transactions(
-    filter: {
-      success: true
-      events: {
-        type: "Transfer"
-        pkg_path: "${packagePath}"
-        attrs: [{
-          key: "from"
-          value: "${address}"
-        }, {
-          key:"to"
-          value: "${address}"
-        }]
-      }
-      message: [
-        {
-          type_url: exec
-        }
-      ]
-    }
-    ascending: false
-    after: null
-  ) {
-    pageInfo {
-      last
-      hasNext
-    }
-    edges {
-      cursor
-      transaction {
-        hash
-        index
-        success
-        block_height
-        response {
-          events {
-            ...on GnoEvent {
-              type
-              pkg_path
-              func
-              attrs {
-                key
-                value
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-`;
-
-export const makeAllTransferEventsQueryBy = (address: string): string => `
-{
-  transactions(
-    filter: {
-      success: true
-      events: {
-        type: "Transfer"
-        attrs: [{
-          key: "to"
-          value: "${address}"
-        }]
-      }
-    }
-  ) {
-    hash
-    index
-    success
-    block_height
-    response {
-      events {
-        ...on GnoEvent {
-          type
-          pkg_path
-          func
           attrs {
             key
             value
@@ -160,44 +28,276 @@ export const makeAllTransferEventsQueryBy = (address: string): string => `
   }
 }`;
 
-export const makeAllTransferEventsQueryWithCursorBy = (address: string): string => `
-{
-  transactions(
-    filter: {
-      success: true
-      events: {
-        type: "Transfer"
-        attrs: [{
-          key: "to"
-          value: "${address}"
-        }]
-      }
-    }
-    ascending: false
-    after: null
-  ) {
-    pageInfo {
-      last
-      hasNext
-    }
-    edges {
-      cursor
-      transaction {
-        hash
-        index
-        success
-        block_height
-        response {
-          events {
-            ...on GnoEvent {
-              type
-              pkg_path
-              func
-              attrs {
-                key
-                value
+export const makeGetGRC721AddPackagePathsQuery = (): string => `
+query getGRC721AddPackagePaths {
+  getTransactions(
+    where: {
+      success: {eq: true}, 
+      messages: {
+        value: {
+          MsgAddPackage: {
+            package: {
+              path: {
+                like: "gno.land/r/"
+              }
+              files: {
+                _and: [
+                  {
+                    body: {
+                      like: "gno.land/p/demo/tokens/grc721"
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func BalanceOf\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func OwnerOf\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func TransferFrom\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func Approve\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func SetApprovalForAll\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func GetApproved\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func IsApprovedForAll\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func SafeTransferFrom\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func Name\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func Symbol\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func TokenURI\\("
+                    }
+                  }
+                  {
+                    body: {
+                      like: "func SetTokenURI\\("
+                    }
+                  }
+                ]
               }
             }
+          }
+        }
+      }
+    }
+  ) {
+    messages {
+      value {
+        ...on MsgAddPackage {
+          package {
+            path
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export const makeGRC721TransferEventsQuery = (packagePath: string, address: string): string => `
+query getGRC721TransferEvents {
+  getTransactions(
+    where: {
+      response: {
+        events: {
+          _or: [
+            {
+              GnoEvent: {
+                pkg_path: { eq: "gno.land/p/demo/tokens/grc721" }
+                type: { eq: "Mint" } 
+                _and: [
+                  {
+                    attrs: {
+                      key: { eq: "tokenId" }
+                      value: { eq: "${packagePath}" }
+                    }
+                  }
+                  {
+                    attrs: {
+                      key: { eq: "to" }
+                      value: { eq: "${address}" }
+                    }
+                  }
+                ]
+              }
+            }
+            {
+              GnoEvent: {
+                pkg_path: { eq: "gno.land/p/demo/tokens/grc721" }
+                type: { eq: "Transfer" } 
+                _and: [
+                  {
+                    attrs: {
+                      key: { eq: "tokenId" }
+                      value: { eq: "${packagePath}" }
+                    }
+                  }
+                  {
+                    attrs: {
+                      key: { eq: "to" }
+                      value: { eq: "${address}" }
+                    }
+                  }
+                ]
+              }
+            }
+            {
+              GnoEvent: {
+                pkg_path: { eq: "gno.land/p/demo/tokens/grc721" }
+                type: { eq: "Transfer" } 
+                _and: [
+                  {
+                    attrs: {
+                      key: { eq: "tokenId" }
+                      value: { eq: "${packagePath}" }
+                    }
+                  }
+                  {
+                    attrs: {
+                      key: { eq: "from" }
+                      value: { eq: "${address}" }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+    order: {
+      heightAndIndex: DESC
+    }
+  ) {
+    hash
+    index
+    success
+    block_height
+    response {
+      events {
+        ...on GnoEvent {
+          type
+          pkg_path
+          attrs {
+            key
+            value
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export const makeAllTransferEventsQueryBy = (address: string): string => `
+query getTokenTransferEvents {
+  getTransactions(
+    where: {
+      response: {
+        events: {
+          _or: [
+            {
+              GnoEvent: {
+                pkg_path: { eq: "gno.land/p/demo/tokens/grc20" }
+                type: { eq: "Transfer" } 
+                attrs: {
+                  key: { eq: "to" }
+                  value: { eq: "${address}" }
+                }
+              }
+            }
+            {
+              GnoEvent: {
+                pkg_path: { eq: "gno.land/p/demo/tokens/grc20" }
+                type: { eq: "Transfer" } 
+                attrs: {
+                  key: { eq: "from" }
+                  value: { eq: "${address}" }
+                }
+              }
+            }
+            {
+              GnoEvent: {
+                pkg_path: { eq: "gno.land/p/demo/tokens/grc721" }
+                type: { eq: "Mint" } 
+                attrs: {
+                  key: { eq: "to" }
+                  value: { eq: "${address}" }
+                }
+              }
+            }
+            {
+              GnoEvent: {
+                pkg_path: { eq: "gno.land/p/demo/tokens/grc721" }
+                type: { eq: "Transfer" } 
+                attrs: {
+                  key: { eq: "to" }
+                  value: { eq: "${address}" }
+                }
+              }
+            }
+            {
+              GnoEvent: {
+                pkg_path: { eq: "gno.land/p/demo/tokens/grc721" }
+                type: { eq: "Transfer" } 
+                attrs: {
+                  key: { eq: "from" }
+                  value: { eq: "${address}" }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+    order: {
+      heightAndIndex: DESC
+    }
+  ) {
+    hash
+    index
+    success
+    block_height
+    response {
+      events {
+        ...on GnoEvent {
+          type
+          pkg_path
+          attrs {
+            key
+            value
           }
         }
       }

--- a/packages/adena-extension/src/repositories/common/token.ts
+++ b/packages/adena-extension/src/repositories/common/token.ts
@@ -13,6 +13,7 @@ import {
 
 import { GNOT_TOKEN } from '@common/constants/token.constant';
 import { GnoProvider } from '@common/provider/gno/gno-provider';
+import { decodeGnoString, gnoLiteral, parseQEvalResult } from '@common/provider/gno/qeval';
 import {
   parseGRC20ByABCIRender,
   parseGRC20ByFileContents,
@@ -30,13 +31,13 @@ import {
   TokenModel,
 } from '@types';
 import BigNumber from 'bignumber.js';
-import { mapGRC20TokenModel, mapGRC721CollectionModel } from './mapper/token-query.mapper';
+import { mapGRC20RegisterEvent, mapGRC721CollectionModel } from './mapper/token-query.mapper';
 import { AppInfoResponse } from './response';
 import {
-  makeAllRealmsQuery,
   makeAllTransferEventsQueryBy,
+  makeGetGRC20RegisterEventsQuery,
+  makeGetGRC721AddPackagePathsQuery,
   makeGRC721TransferEventsQuery,
-  makeGRC721TransferEventsQueryWithCursor,
 } from './token.queries';
 import { ITokenRepository } from './types';
 
@@ -48,6 +49,8 @@ enum LocalValueType {
 }
 
 const DEFAULT_TOKEN_NETWORK_ID = '';
+
+const GRC20_REGISTRY_PKG_PATH = 'gno.land/r/demo/defi/grc20reg';
 
 const DEFAULT_TOKEN_METAINFOS: NativeTokenModel[] = [
   {
@@ -136,9 +139,11 @@ export class TokenRepository implements ITokenRepository {
   };
 
   public getAccountTokenMetainfos = async (accountId: string): Promise<TokenModel[]> => {
-    const accountTokenMetainfos = await this.localStorage.getToObject<{
-      [key in string]: TokenModel[];
-    }>(LocalValueType.AccountTokenMetainfos);
+    const accountTokenMetainfos = await this.localStorage.getToObject<
+      {
+        [key in string]: TokenModel[];
+      }
+    >(LocalValueType.AccountTokenMetainfos);
 
     return (
       accountTokenMetainfos[accountId] ??
@@ -150,9 +155,11 @@ export class TokenRepository implements ITokenRepository {
     accountId: string,
     tokenMetainfos: TokenModel[],
   ): Promise<boolean> => {
-    const accountTokenMetainfos = await this.localStorage.getToObject<{
-      [key in string]: TokenModel[];
-    }>(LocalValueType.AccountTokenMetainfos);
+    const accountTokenMetainfos = await this.localStorage.getToObject<
+      {
+        [key in string]: TokenModel[];
+      }
+    >(LocalValueType.AccountTokenMetainfos);
 
     const isUnique = function (token0: TokenModel, token1: TokenModel): boolean {
       return token0.tokenId === token1.tokenId && token0.networkId === token1.networkId;
@@ -175,9 +182,11 @@ export class TokenRepository implements ITokenRepository {
   };
 
   public deleteTokenMetainfos = async (accountId: string): Promise<boolean> => {
-    const accountTokenMetainfos = await this.localStorage.getToObject<{
-      [key in string]: TokenModel[];
-    }>(LocalValueType.AccountTokenMetainfos);
+    const accountTokenMetainfos = await this.localStorage.getToObject<
+      {
+        [key in string]: TokenModel[];
+      }
+    >(LocalValueType.AccountTokenMetainfos);
 
     const changedAccountTokenMetainfos = {
       ...accountTokenMetainfos,
@@ -246,23 +255,89 @@ export class TokenRepository implements ITokenRepository {
       }));
     }
 
-    if (!this.queryUrl) {
+    if (!this.queryUrl || !this.gnoProvider) {
       return [];
     }
 
-    const allRealmsQuery = makeAllRealmsQuery();
-    return TokenRepository.postGraphQuery(this.networkInstance, this.queryUrl, allRealmsQuery).then(
-      (result) =>
-        result?.data?.transactions
-          ? result?.data?.transactions
-              .flatMap((tx: any) => tx.messages)
-              .map((message: any) =>
-                mapGRC20TokenModel(this.networkMetainfo?.networkId || '', message),
-              )
-              .filter((tokenInfo: GRC20TokenModel | null) => !!tokenInfo)
-          : [],
+    const getGRC20RegisterEventsQuery = makeGetGRC20RegisterEventsQuery();
+    const events = await TokenRepository.postGraphQuery(
+      this.networkInstance,
+      this.queryUrl,
+      getGRC20RegisterEventsQuery,
+    ).then(mapGRC20RegisterEvent);
+
+    const networkId = this.networkId;
+    const tokens = await Promise.all(
+      events.map((event) => this.fetchGRC20TokenInfoFromRegistry(event, networkId)),
     );
+
+    console.log(tokens);
+
+    return tokens.filter((token): token is GRC20TokenModel => token !== null);
   };
+
+  private async fetchGRC20TokenInfoFromRegistry(
+    event: { packagePath: string; slug: string },
+    networkId: string,
+  ): Promise<GRC20TokenModel | null> {
+    if (!this.gnoProvider) {
+      return null;
+    }
+
+    const registryKey = event.slug ? `${event.packagePath}.${event.slug}` : event.packagePath;
+
+    let response: string;
+    try {
+      response = await this.gnoProvider.evaluateIIFE(GRC20_REGISTRY_PKG_PATH, {
+        returnType: '(string, string, int)',
+        statements: [
+          `token := Get(${gnoLiteral(registryKey)})`,
+          'if token == nil { return "", "", 0 }',
+        ],
+        returnExpression: 'token.GetName(), token.GetSymbol(), token.GetDecimals()',
+      });
+    } catch (e) {
+      console.warn('fetchGRC20TokenInfoFromRegistry: evaluateIIFE failed', registryKey, e);
+      return null;
+    }
+
+    if (!response) {
+      console.warn('fetchGRC20TokenInfoFromRegistry: empty response', registryKey);
+      return null;
+    }
+
+    const tuples = parseQEvalResult(response);
+    if (tuples.length < 3) {
+      console.warn(
+        'fetchGRC20TokenInfoFromRegistry: unexpected tuple count',
+        registryKey,
+        response,
+      );
+      return null;
+    }
+
+    const name = decodeGnoString(tuples[0].value);
+    const symbol = decodeGnoString(tuples[1].value);
+    const decimals = Number(tuples[2].value);
+
+    if (!name || !symbol || !Number.isFinite(decimals)) {
+      // Nil token (Get returned nil) — sentinel "","" ,0
+      return null;
+    }
+
+    return {
+      main: false,
+      tokenId: event.packagePath,
+      pkgPath: event.packagePath,
+      networkId,
+      display: false,
+      type: 'grc20',
+      name,
+      symbol,
+      decimals,
+      image: '',
+    };
+  }
 
   public async fetchGRC721Collections(): Promise<GRC721CollectionModel[]> {
     if (this.apiUrl) {
@@ -290,7 +365,7 @@ export class TokenRepository implements ITokenRepository {
       return [];
     }
 
-    const allRealmsQuery = makeAllRealmsQuery();
+    const allRealmsQuery = makeGetGRC721AddPackagePathsQuery();
     return TokenRepository.postGraphQuery(this.networkInstance, this.queryUrl, allRealmsQuery).then(
       (result) =>
         result?.data?.transactions
@@ -443,10 +518,7 @@ export class TokenRepository implements ITokenRepository {
     }[] = [];
 
     if (this.apiUrl) {
-      const grc721TransferEventsQuery = makeGRC721TransferEventsQueryWithCursor(
-        packagePath,
-        address,
-      );
+      const grc721TransferEventsQuery = makeGRC721TransferEventsQuery(packagePath, address);
       const resultEvents: {
         type: string;
         pkg_path: string;
@@ -537,9 +609,11 @@ export class TokenRepository implements ITokenRepository {
     accountId: string,
     networkId: string,
   ): Promise<GRC721CollectionModel[]> {
-    const accountGRC721CollectionsMap = await this.localStorage.getToObject<{
-      [key in string]: { [key in string]: GRC721CollectionModel[] };
-    }>(LocalValueType.AccountGRC721Collections);
+    const accountGRC721CollectionsMap = await this.localStorage.getToObject<
+      {
+        [key in string]: { [key in string]: GRC721CollectionModel[] };
+      }
+    >(LocalValueType.AccountGRC721Collections);
 
     if (!accountGRC721CollectionsMap?.[accountId]?.[networkId]) {
       return [];
@@ -554,9 +628,11 @@ export class TokenRepository implements ITokenRepository {
     collections: GRC721CollectionModel[],
   ): Promise<boolean> {
     const accountGRC721CollectionsMap =
-      (await this.localStorage.getToObject<{
-        [key in string]: { [key in string]: GRC721CollectionModel[] };
-      }>(LocalValueType.AccountGRC721Collections)) || {};
+      (await this.localStorage.getToObject<
+        {
+          [key in string]: { [key in string]: GRC721CollectionModel[] };
+        }
+      >(LocalValueType.AccountGRC721Collections)) || {};
 
     const currentAccountCollections = accountGRC721CollectionsMap?.[accountId] || {};
 
@@ -575,9 +651,11 @@ export class TokenRepository implements ITokenRepository {
     accountId: string,
     networkId: string,
   ): Promise<string[]> {
-    const accountGRC721PinnedPackagesMap = await this.localStorage.getToObject<{
-      [key in string]: { [key in string]: string[] };
-    }>(LocalValueType.AccountGRC721PinnedPackages);
+    const accountGRC721PinnedPackagesMap = await this.localStorage.getToObject<
+      {
+        [key in string]: { [key in string]: string[] };
+      }
+    >(LocalValueType.AccountGRC721PinnedPackages);
 
     if (!accountGRC721PinnedPackagesMap?.[accountId]?.[networkId]) {
       return [];
@@ -592,9 +670,11 @@ export class TokenRepository implements ITokenRepository {
     packagePaths: string[],
   ): Promise<boolean> {
     const accountGRC721PinnedPackagesMap =
-      (await this.localStorage.getToObject<{
-        [key in string]: { [key in string]: string[] };
-      }>(LocalValueType.AccountGRC721PinnedPackages)) || {};
+      (await this.localStorage.getToObject<
+        {
+          [key in string]: { [key in string]: string[] };
+        }
+      >(LocalValueType.AccountGRC721PinnedPackages)) || {};
 
     const currentAccountPinnedPackages = accountGRC721PinnedPackagesMap?.[accountId] || {};
 

--- a/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.queries.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.queries.ts
@@ -1,524 +1,181 @@
-export const makeAccountTransactionsQuery = (
-  address: string,
-  cursor: string | null,
-  size = 20,
-): string => `
-  {
-    transactions(
-      filter: {
-        message: [
+/**
+ * Selection set shared by every transaction query — keeps the existing
+ * `TransactionResponse` shape consumed by the mappers
+ * (transaction-history-query.mapper.ts) intact.
+ */
+const TRANSACTION_FIELDS = `
+  hash
+  index
+  success
+  block_height
+  gas_wanted
+  gas_used
+  gas_fee {
+    amount
+    denom
+  }
+  messages {
+    typeUrl
+    value {
+      ... on BankMsgSend {
+        from_address
+        to_address
+        amount
+      }
+      ... on MsgCall {
+        caller
+        send
+        max_deposit
+        pkg_path
+        func
+        args
+      }
+      ... on MsgAddPackage {
+        creator
+        send
+        max_deposit
+        package {
+          path
+        }
+      }
+      ... on MsgRun {
+        caller
+        send
+        max_deposit
+        package {
+          path
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * All transaction history for an address: native sends/receives, GRC20/GRC721
+ * receives (by Transfer/TransferFrom args), and any VM message the address
+ * caused (caller/creator).
+ */
+export const makeAllTransactionHistoryQuery = (address: string): string => `
+query getAllTransactionHistory {
+  getTransactions(
+    where: {
+      success: { eq: true }
+      messages: {
+        _or: [
           {
-            type_url: send
-            bank_param: {
-              send: {
-                from_address: "${address}"
+            value: {
+              BankMsgSend: {
+                from_address: { eq: "${address}" }
               }
             }
           }
           {
-            type_url: send
-            bank_param: {
-              send: {
-                to_address: "${address}"
+            value: {
+              BankMsgSend: {
+                to_address: { eq: "${address}" }
               }
             }
           }
           {
-            type_url: exec
-            vm_param: {
-              exec: {
-                caller: "${address}"
-              }
-              add_package: {
-                creator: "${address}"
-              }
-              run: {
-                caller: "${address}"
+            value: {
+              MsgCall: {
+                caller: { eq: "${address}" }
               }
             }
           }
           {
-            type_url: exec
-            vm_param: {
-              exec: {
-                func: "Transfer"
-                args: ["${address}"]
+            value: {
+              MsgCall: {
+                func: { eq: "Transfer" }
+                args: { eq: "${address}" }
               }
             }
           }
           {
-            type_url: exec
-            vm_param: {
-              exec: {
-                func: "TransferFrom"
-                args: ["", "${address}"]
+            value: {
+              MsgCall: {
+                func: { eq: "TransferFrom" }
+                args: { eq: "${address}" }
+              }
+            }
+          }
+          {
+            value: {
+              MsgAddPackage: {
+                creator: { eq: "${address}" }
+              }
+            }
+          }
+          {
+            value: {
+              MsgRun: {
+                caller: { eq: "${address}" }
               }
             }
           }
         ]
       }
-      size: ${size}
-      ascending: false
-      after: ${cursor ? `"${cursor}"` : 'null'}
-    ) {
-      pageInfo {
-        last
-        hasNext
-      }
-      edges {
-        cursor
-        transaction {
-          hash
-          index
-          success
-          block_height
-          gas_wanted
-          gas_used
-          gas_fee {
-            amount
-            denom
-          }
-          messages {
-            typeUrl
-            value {
-              ... on BankMsgSend {
-                from_address
-                to_address
-                amount
-              }
-              ... on MsgCall {
-                caller
-                send
-                func
-                max_deposit
-                pkg_path
-                args
-              }
-              ... on MsgAddPackage {
-                creator
-                send
-                max_deposit
-                package {
-                  path
-                }
-              }
-              ... on MsgRun {
-                caller
-                send
-                max_deposit
-                package {
-                  path
-                }
-              }
-            }
-          }
-        }
-      }
     }
+    order: { heightAndIndex: DESC }
+  ) {
+    ${TRANSACTION_FIELDS}
   }
+}
 `;
 
-export const makeNativeTransactionsQuery = (
-  address: string,
-  cursor: string | null,
-  size = 20,
-): string => `
-  {
-    transactions(
-      filter: {
-        message: [
-          {
-            type_url: send
-            bank_param: {
-              send: {
-                from_address: "${address}"
-              }
-            }
-          }
-          {
-            type_url: send
-            bank_param: {
-              send: {
-                to_address: "${address}"
-              }
-            }
-          }
-        ]
-      }
-      size: ${size}
-      ascending: false
-      after: ${cursor ? `"${cursor}"` : 'null'}
-    ) {
-      pageInfo {
-        last
-        hasNext
-      }
-      edges {
-        cursor
-        transaction {
-          hash
-          index
-          success
-          block_height
-          gas_wanted
-          gas_used
-          gas_fee {
-            amount
-            denom
-          }
-          messages {
-            typeUrl
-            value {
-              ... on BankMsgSend {
-                from_address
-                to_address
-                amount
-              }
-            }
+/** Native (BankMsgSend) sends and receives for an address. */
+export const makeNativeTransactionHistoryQuery = (address: string): string => `
+query getNativeTransactionHistory {
+  getTransactions(
+    where: {
+      success: { eq: true }
+      messages: {
+        value: {
+          BankMsgSend: {
+            _or: [
+              { from_address: { eq: "${address}" } }
+              { to_address: { eq: "${address}" } }
+            ]
           }
         }
       }
     }
-  }
-`;
-
-export const makeGRC20TransferTransactionsQuery = (
-  address: string,
-  packagePath: string,
-  cursor: string | null,
-  size = 20,
-): string => `
-  {
-    transactions(
-      filter: {
-        message: [
-          {
-            type_url: exec
-            vm_param: {
-              exec: {
-                pkg_path: "${packagePath}"
-                func: "Transfer"
-                caller: "${address}"
-              }
-            }
-          }
-          {
-            type_url: exec
-            vm_param: {
-              exec: {
-                pkg_path: "${packagePath}"
-                func: "Transfer"
-                args: ["${address}"]
-              }
-            }
-          }
-        ]
-      }
-      size: ${size}
-      ascending: false
-      after: ${cursor ? `"${cursor}"` : 'null'}
-    ) {
-      pageInfo {
-        last
-        hasNext
-      }
-      edges {
-        cursor
-        transaction {
-          hash
-          index
-          success
-          block_height
-          gas_wanted
-          gas_used
-          gas_fee {
-            amount
-            denom
-          }
-          messages {
-            typeUrl
-            value {
-              ...on MsgCall {
-                caller
-                send
-                max_deposit
-                pkg_path
-                func
-                args
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
-/**
- * XXX: The fix is required after the indexer's pagination update.
- */
-export const makeGRC20ReceivedTransactionsByAddressQuery = (address: string): string => `
-{
-  transactions(filter: {
-    message: {
-      type_url: exec
-      vm_param: {
-        exec: {
-          func: "Transfer"
-          args: ["${address}"]
-        }
-      }
-    }
-  }) {
-    hash
-    index
-    success
-    block_height
-    gas_wanted
-    gas_used
-    gas_fee {
-      amount
-      denom
-    }
-    messages {
-      value {
-        ...on MsgCall {
-          caller
-          send
-          pkg_path
-          func
-          args
-        }
-      }
-    }
+    order: { heightAndIndex: DESC }
+  ) {
+    ${TRANSACTION_FIELDS}
   }
 }
 `;
 
 /**
- * XXX: The fix is required after the indexer's pagination update.
+ * GRC20 transfers (sent or received) for an address, scoped to a single
+ * token package. `caller eq address` catches sends; `args eq address`
+ * catches the recipient slot of `Transfer(to, amount)`.
  */
-export const makeVMTransactionsByAddressQuery = (address: string): string => `
-{
-  transactions(filter: {
-    message: {
-      route: vm
-      vm_param: {
-        exec: {
-          caller: "${address}"
-        }
-        add_package: {
-          creator: "${address}"
-        }
-        run: {
-          caller: "${address}"
-        }
-      }
-    }
-  }) {
-    hash
-    index
-    success
-    block_height
-    gas_wanted
-    gas_used
-    gas_fee {
-      amount
-      denom
-    }
-    messages {
-      value {
-        ... on BankMsgSend {
-          from_address
-          to_address
-          amount
-        }
-        ... on MsgCall {
-          caller
-          send
-          max_deposit
-          func
-          pkg_path
-          args
-        }
-        ... on MsgAddPackage {
-          creator
-          package {
-            path
-          }
-        }
-        ... on MsgRun {
-          caller
-          send
-          package {
-            path
-          }
-        }
-      }
-    }
-  }
-}
-`;
-
-export const makeNativeTokenSendTransactionsByAddressQuery = (address: string): string => `
-{
-  transactions(filter: {
-    message: {
-      type_url: send
-      bank_param: {
-        send: {
-          from_address: "${address}"
-        }
-      }
-    }
-  }) {
-    hash
-    index
-    success
-    block_height
-    gas_wanted
-    gas_used
-    gas_fee {
-      amount
-      denom
-    }
-    messages {
-      value {
-        ...on BankMsgSend{
-          from_address
-          to_address
-          amount
-        }
-      }
-    }
-  }
-}
-`;
-
-/**
- * XXX: The fix is required after the indexer's pagination update.
- */
-export const makeNativeTokenReceivedTransactionsByAddressQuery = (address: string): string => `
-{
-  transactions(filter: {
-    message: {
-      type_url: send
-      bank_param: {
-        send: {
-          to_address: "${address}"
-        }
-      }
-    }
-  }) {
-    hash
-    index
-    success
-    block_height
-    gas_wanted
-    gas_used
-    gas_fee {
-      amount
-      denom
-    }
-    messages {
-      value {
-        ...on BankMsgSend{
-          from_address
-          to_address
-          amount
-        }
-      }
-    }
-  }
-}
-`;
-
-/**
- * XXX: The fix is required after the indexer's pagination update.
- */
-export const makeGRC20ReceivedTransactionsByAddressQueryByPackagePath = (
+export const makeGRC20TransactionHistoryQuery = (
   address: string,
   packagePath: string,
 ): string => `
-{
-  transactions(filter: {
-    message: {
-      type_url: exec
-      vm_param: {
-        exec: {
-          func: "Transfer"
-          pkg_path: "${packagePath}"
-          args: ["${address}"]
+query getGRC20TransactionHistory {
+  getTransactions(
+    where: {
+      success: { eq: true }
+      messages: {
+        value: {
+          MsgCall: {
+            pkg_path: { eq: "${packagePath}" }
+            func: { eq: "Transfer" }
+            _or: [
+              { caller: { eq: "${address}" } }
+              { args: { eq: "${address}" } }
+            ]
+          }
         }
       }
     }
-  }) {
-    hash
-    index
-    success
-    block_height
-    gas_wanted
-    gas_used
-    gas_fee {
-      amount
-      denom
-    }
-    messages {
-      value {
-        ...on MsgCall {
-          caller
-          send
-          pkg_path
-          func
-          args
-        }
-      }
-    }
-  }
-}
-`;
-
-/**
- * XXX: The fix is required after the indexer's pagination update.
- */
-export const makeGRC20SendTransactionsByAddressQueryByPackagePath = (
-  address: string,
-  packagePath: string,
-): string => `
-{
-  transactions(filter: {
-    message: {
-      type_url: exec
-      vm_param: {
-        exec: {
-          pkg_path: "${packagePath}"
-          caller: "${address}"
-        }
-      }
-    }
-  }) {
-    hash
-    index
-    success
-    block_height
-    gas_wanted
-    gas_used
-    gas_fee {
-      amount
-      denom
-    }
-    messages {
-      value {
-        ... on MsgCall {
-          caller
-          send
-          max_deposit
-          func
-          pkg_path
-          args
-        }
-      }
-    }
+    order: { heightAndIndex: DESC }
+  ) {
+    ${TRANSACTION_FIELDS}
   }
 }
 `;

--- a/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.ts
@@ -4,19 +4,33 @@ import {
   mapReceivedTransactionByBankMsgSend,
   mapReceivedTransactionByMsgCall,
   mapSendTransactionByBankMsgSend,
+  mapTransactionEdgeByAddress,
   mapVMTransaction,
 } from './mapper/transaction-history-query.mapper';
 import {
+  BankSendValue,
+  MsgCallValue,
+  TransactionResponse,
+} from './response/transaction-history-query-response';
+import {
+  makeAllTransactionHistoryQuery,
   makeBlockTimeLegacyQuery,
   makeBlockTimeQuery,
-  makeGRC20ReceivedTransactionsByAddressQuery,
-  makeGRC20ReceivedTransactionsByAddressQueryByPackagePath,
-  makeGRC20SendTransactionsByAddressQueryByPackagePath,
-  makeNativeTokenReceivedTransactionsByAddressQuery,
-  makeNativeTokenSendTransactionsByAddressQuery,
-  makeVMTransactionsByAddressQuery,
+  makeGRC20TransactionHistoryQuery,
+  makeNativeTransactionHistoryQuery,
 } from './transaction-history-indexer.queries';
 import { ITransactionHistoryIndexerRepository } from './types';
+
+type TransactionsQueryResult = {
+  data?: {
+    getTransactions?: TransactionResponse[] | null;
+  } | null;
+} | null;
+
+const EMPTY_PAGE: TransactionWithPageInfo = {
+  page: { hasNext: false, cursor: null },
+  transactions: [],
+};
 
 export class TransactionHistoryIndexerRepository implements ITransactionHistoryIndexerRepository {
   private axiosInstance: AxiosInstance;
@@ -39,172 +53,74 @@ export class TransactionHistoryIndexerRepository implements ITransactionHistoryI
     return this.networkMetainfo.indexerUrl + '/graphql/query';
   }
 
-  /**
-   * XXX: The fix is required after the indexer's pagination update.
-   */
   public async fetchAllTransactionHistoryBy(address: string): Promise<TransactionWithPageInfo> {
     if (!this.queryUrl) {
-      return {
-        page: {
-          hasNext: false,
-          cursor: null,
-        },
-        transactions: [],
-      };
+      return EMPTY_PAGE;
     }
 
-    const grc20ReceivedTransactionsQuery = makeGRC20ReceivedTransactionsByAddressQuery(address);
-    const nativeTokenSendQuery = makeNativeTokenSendTransactionsByAddressQuery(address);
-    const nativeTokenReceivedQuery = makeNativeTokenReceivedTransactionsByAddressQuery(address);
-    const vmTransactionsQuery = makeVMTransactionsByAddressQuery(address);
-    return Promise.all([
-      TransactionHistoryIndexerRepository.postGraphQuery(
-        this.axiosInstance,
-        this.queryUrl,
-        grc20ReceivedTransactionsQuery,
-      ).then((result) =>
-        result?.data?.transactions
-          ? result?.data?.transactions.map(mapReceivedTransactionByMsgCall)
-          : [],
-      ),
-      TransactionHistoryIndexerRepository.postGraphQuery(
-        this.axiosInstance,
-        this.queryUrl,
-        nativeTokenSendQuery,
-      ).then((result) =>
-        result?.data?.transactions
-          ? result?.data?.transactions.map(mapSendTransactionByBankMsgSend)
-          : [],
-      ),
-      TransactionHistoryIndexerRepository.postGraphQuery(
-        this.axiosInstance,
-        this.queryUrl,
-        nativeTokenReceivedQuery,
-      ).then((result) =>
-        result?.data?.transactions
-          ? result?.data?.transactions.map(mapReceivedTransactionByBankMsgSend)
-          : [],
-      ),
-      TransactionHistoryIndexerRepository.postGraphQuery(
-        this.axiosInstance,
-        this.queryUrl,
-        vmTransactionsQuery,
-      ).then((result) =>
-        result?.data?.transactions ? result?.data?.transactions.map(mapVMTransaction) : [],
-      ),
-    ])
-      .then((results) => results.flatMap((result) => result))
-      .then((txs) => ({
-        page: {
-          hasNext: false,
-          cursor: null,
-        },
-        transactions: txs,
-      }));
+    const result = await TransactionHistoryIndexerRepository.postGraphQuery<
+      TransactionsQueryResult
+    >(this.axiosInstance, this.queryUrl, makeAllTransactionHistoryQuery(address));
+
+    const transactions = (result?.data?.getTransactions ?? []).map((tx) =>
+      mapTransactionEdgeByAddress(tx, address),
+    );
+
+    return {
+      page: { hasNext: false, cursor: null },
+      transactions,
+    };
   }
 
-  /**
-   * XXX: The fix is required after the indexer's pagination update.
-   */
   public async fetchNativeTransactionHistoryBy(address: string): Promise<TransactionWithPageInfo> {
     if (!this.queryUrl) {
-      return {
-        page: {
-          hasNext: false,
-          cursor: null,
-        },
-        transactions: [],
-      };
+      return EMPTY_PAGE;
     }
 
-    const nativeTokenSendQuery = makeNativeTokenSendTransactionsByAddressQuery(address);
-    const nativeTokenReceivedQuery = makeNativeTokenReceivedTransactionsByAddressQuery(address);
-    return Promise.all([
-      TransactionHistoryIndexerRepository.postGraphQuery(
-        this.axiosInstance,
-        this.queryUrl,
-        nativeTokenSendQuery,
-      ).then((result) =>
-        result?.data?.transactions
-          ? result?.data?.transactions.map(mapSendTransactionByBankMsgSend)
-          : [],
-      ),
-      TransactionHistoryIndexerRepository.postGraphQuery(
-        this.axiosInstance,
-        this.queryUrl,
-        nativeTokenReceivedQuery,
-      ).then((result) =>
-        result?.data?.transactions
-          ? result?.data?.transactions.map(mapReceivedTransactionByBankMsgSend)
-          : [],
-      ),
-    ])
-      .then((results) => results.flatMap((result) => result))
-      .then((txs) => ({
-        page: {
-          hasNext: false,
-          cursor: null,
-        },
-        transactions: txs,
-      }));
+    const result = await TransactionHistoryIndexerRepository.postGraphQuery<
+      TransactionsQueryResult
+    >(this.axiosInstance, this.queryUrl, makeNativeTransactionHistoryQuery(address));
+
+    const transactions = (result?.data?.getTransactions ?? []).map((tx) => {
+      const bankTx = tx as TransactionResponse<BankSendValue>;
+      const firstMessage = bankTx.messages?.[0];
+      const isReceive = firstMessage?.value?.to_address === address;
+      return isReceive
+        ? mapReceivedTransactionByBankMsgSend(bankTx)
+        : mapSendTransactionByBankMsgSend(bankTx);
+    });
+
+    return {
+      page: { hasNext: false, cursor: null },
+      transactions,
+    };
   }
 
-  /**
-   * XXX: The fix is required after the indexer's pagination update.
-   */
   public async fetchGRC20TransactionHistoryBy(
     address: string,
     packagePath: string,
   ): Promise<TransactionWithPageInfo> {
     if (!this.queryUrl) {
-      return {
-        page: {
-          hasNext: false,
-          cursor: null,
-        },
-        transactions: [],
-      };
+      return EMPTY_PAGE;
     }
 
-    const grc20ReceivedTransactionsQuery = makeGRC20ReceivedTransactionsByAddressQueryByPackagePath(
-      address,
-      packagePath,
-    );
-    const grc20SendTransactionsQuery = makeGRC20SendTransactionsByAddressQueryByPackagePath(
-      address,
-      packagePath,
-    );
-    return Promise.all([
-      TransactionHistoryIndexerRepository.postGraphQuery(
-        this.axiosInstance,
-        this.queryUrl,
-        grc20ReceivedTransactionsQuery,
-      ).then((result) =>
-        result?.data?.transactions
-          ? result?.data?.transactions.map(mapReceivedTransactionByMsgCall)
-          : [],
-      ),
-      TransactionHistoryIndexerRepository.postGraphQuery(
-        this.axiosInstance,
-        this.queryUrl,
-        grc20SendTransactionsQuery,
-      ).then((result) =>
-        result?.data?.transactions ? result?.data?.transactions.map(mapVMTransaction) : [],
-      ),
-    ])
-      .then((results) => results.flatMap((result) => result))
-      .then((txs) => ({
-        page: {
-          hasNext: false,
-          cursor: null,
-        },
-        transactions: txs,
-      }));
+    const result = await TransactionHistoryIndexerRepository.postGraphQuery<
+      TransactionsQueryResult
+    >(this.axiosInstance, this.queryUrl, makeGRC20TransactionHistoryQuery(address, packagePath));
+
+    const transactions = (result?.data?.getTransactions ?? []).map((tx) => {
+      const callTx = tx as TransactionResponse<MsgCallValue>;
+      const firstMessage = callTx.messages?.[0];
+      const isCallerSelf = firstMessage?.value?.caller === address;
+      return isCallerSelf ? mapVMTransaction(callTx) : mapReceivedTransactionByMsgCall(callTx);
+    });
+
+    return {
+      page: { hasNext: false, cursor: null },
+      transactions,
+    };
   }
 
-  /**
-   * XXX: The fix is required after the indexer's pagination update.
-   */
   public async fetchBlockTimeByHeight(height: number): Promise<string | null> {
     if (!this.queryUrl) {
       return null;

--- a/packages/adena-extension/src/types/token.ts
+++ b/packages/adena-extension/src/types/token.ts
@@ -116,6 +116,11 @@ export interface MainToken {
   chainIconUrl?: string;
 }
 
+export interface GRC20RegisterEvent {
+  packagePath: string;
+  slug: string;
+}
+
 export interface GRC721CollectionModel {
   tokenId: string;
   networkId: string;

--- a/packages/adena-module/src/utils/messages.ts
+++ b/packages/adena-module/src/utils/messages.ts
@@ -255,7 +255,7 @@ export function documentToTx(document: Document): Tx {
   return {
     messages,
     fee: TxFee.create({
-      gas_wanted: document.fee.gas,
+      gas_wanted: BigInt(document.fee.gas),
       gas_fee: document.fee.amount
         .map((feeAmount) => `${feeAmount.amount}${feeAmount.denom}`)
         .join(','),
@@ -288,7 +288,7 @@ export function documentToDefaultTx(document: Document, publicKey?: Uint8Array):
   return {
     messages,
     fee: TxFee.create({
-      gas_wanted: document.fee.gas,
+      gas_wanted: BigInt(document.fee.gas),
       gas_fee: document.fee.amount
         .map((feeAmount) => `${feeAmount.amount}${feeAmount.denom}`)
         .join(','),
@@ -412,7 +412,7 @@ export const rawTxToTx = (rawTx: RawTx): Tx | null => {
       messages,
 
       fee: TxFee.create({
-        gas_wanted: document.fee.gas_wanted,
+        gas_wanted: BigInt(document.fee.gas_wanted),
         gas_fee: document.fee.gas_fee,
       }),
       signatures: (document.signatures || []).map(rawSignatureToTxSignature),

--- a/packages/adena-module/src/utils/messages.ts
+++ b/packages/adena-module/src/utils/messages.ts
@@ -255,7 +255,7 @@ export function documentToTx(document: Document): Tx {
   return {
     messages,
     fee: TxFee.create({
-      gas_wanted: BigInt(document.fee.gas),
+      gas_wanted: document.fee.gas,
       gas_fee: document.fee.amount
         .map((feeAmount) => `${feeAmount.amount}${feeAmount.denom}`)
         .join(','),
@@ -288,7 +288,7 @@ export function documentToDefaultTx(document: Document, publicKey?: Uint8Array):
   return {
     messages,
     fee: TxFee.create({
-      gas_wanted: BigInt(document.fee.gas),
+      gas_wanted: document.fee.gas,
       gas_fee: document.fee.amount
         .map((feeAmount) => `${feeAmount.amount}${feeAmount.denom}`)
         .join(','),
@@ -412,7 +412,7 @@ export const rawTxToTx = (rawTx: RawTx): Tx | null => {
       messages,
 
       fee: TxFee.create({
-        gas_wanted: BigInt(document.fee.gas_wanted),
+        gas_wanted: document.fee.gas_wanted,
         gas_fee: document.fee.gas_fee,
       }),
       signatures: (document.signatures || []).map(rawSignatureToTxSignature),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
- feature
- bug
- style
- cleanup
- documentation
- test
-->
- feature

## What this PR does:

## Summary

- Add a typed `vm/qeval` helper layer to `GnoProvider` that builds Go IIFE
  expressions and decodes their tuple responses, so multi-statement realm
  calls (`(value, err)` handling, struct method chains) can run in a single
  ABCI round-trip.
- Hydrate `fetchAllGRC20Tokens` from the on-chain `grc20reg` registry: the
  indexer feeds register events, then a per-token IIFE pulls
  `name / symbol / decimals` directly from the realm. Replaces the previous
  no-op that logged events and returned `[]`.
- Migrate the indexer transaction-history queries to the new
  `getTransactions(where: ..., order: ...)` schema. Three multi-query fetches
  collapse into single requests using message-level `_or` filters; the
  outward-facing repository interface and pagination contract are kept (page
  is hard-coded to `{ hasNext: false, cursor: null }`), so the API
  implementation, service, and React hook are untouched.
- Bump `gas_wanted` to `BigInt` in `adena-module` message builders to match
  the upstream `TxFee` field type.

## Details

### `qeval` helpers (`common/provider/gno/qeval.ts`)
- `gnoLiteral` / `gnoRaw` / `formatGnoArg` escape JS values into Go literals
  (Go-style string escapes for quotes, newlines and control chars; `gnoRaw`
  inlines a verbatim sub-expression for variable references).
- `parseQEvalResult` tokenizes the `(value type)\n(value type)...` response
  shape; `decodeGnoString` / `decodeQEvalString` / `decodeQEvalInt`
  (`bigint`-returning, so `int64` survives the round trip) / `decodeQEvalBool`
  / `decodeQEvalJSON<T>` cover the common scalar payloads.
- `GnoProvider.buildIIFEExpression` and `GnoProvider.evaluateIIFE` compose
  the `(func() <returnType> { <statements>; <call>; return <returnExpr> })()`
  shape and dispatch it through the existing `evaluateExpression` ABCI path.

### GRC20 registry hydration
- `mapGRC20RegisterEvent` extracts `{ packagePath, slug }` from grc20reg
  `register` events surfaced by `makeGetGRC20RegisterEventsQuery`.
- For each event, `fetchGRC20TokenInfoFromRegistry` evaluates the following
  IIFE against `gno.land/r/demo/defi/grc20reg`:

  ```go
  (func() (string, string, int) {
    token := Get("<packagePath>[.<slug>]");
    if token == nil { return "", "", 0 };
    return token.GetName(), token.GetSymbol(), token.GetDecimals()
  })()
  ```

  The key follows grc20reg's `fqname` convention: bare `packagePath` when the
  slug is empty, `packagePath.slug` otherwise. Tokens whose registry entry
  returns the `("", "", 0)` sentinel are filtered out.

### Indexer history migration
- Query file rewritten against `getTransactions(where: ..., order: {
  heightAndIndex: DESC })`. Three call sites that used to fan out into 4 / 2
  / 2 parallel queries each now issue one merged query with `_or`-combined
  message filters.
- Stale `XXX: pagination` helpers and unused query factories are removed.
- The repository continues to return `TransactionWithPageInfo` so the React
  Query infinite-query hook and the HTTP `TransactionHistoryApiRepository`
  do not have to change. `page` is fixed to `{ hasNext: false, cursor: null }`
  (matching what the old indexer code already produced after its
  `Promise.all`).