### PR TITLE
feat: replace test13 with test-13 network (ADN-779)

### DIFF
--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.spec.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.spec.ts
@@ -23,7 +23,7 @@ describe('GNO_CONNECT_ALLOWED_ORIGINS', () => {
         'https://gno.land',
         'https://betanet.testnets.gno.land',
         'https://staging.gno.land',
-        'https://test13.testnets.gno.land',
+        'https://gnoweb.test-13.gnoland.network',
       ]),
     );
     expect(result.some((url) => url.startsWith('http://'))).toBe(false);

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
@@ -235,7 +235,7 @@ describe('isAllowedGnoConnectOrigin', () => {
     expect(isAllowedGnoConnectOrigin('https://gno.land')).toBe(true);
     expect(isAllowedGnoConnectOrigin('https://betanet.testnets.gno.land')).toBe(true);
     expect(isAllowedGnoConnectOrigin('https://staging.gno.land')).toBe(true);
-    expect(isAllowedGnoConnectOrigin('https://test13.testnets.gno.land')).toBe(true);
+    expect(isAllowedGnoConnectOrigin('https://gnoweb.test-13.gnoland.network')).toBe(true);
   });
 
   it('returns false for unregistered origins', () => {

--- a/packages/adena-extension/src/migrates/migrations/v019/storage-migration-v019.spec.ts
+++ b/packages/adena-extension/src/migrates/migrations/v019/storage-migration-v019.spec.ts
@@ -1,0 +1,165 @@
+import { StorageMigration019 } from './storage-migration-v019';
+
+const BASE_DATA = {
+  NETWORKS: [],
+  CURRENT_CHAIN_ID: 'test13',
+  CURRENT_NETWORK_ID: 'test13',
+  SERIALIZED: '',
+  ENCRYPTED_STORED_PASSWORD: '',
+  CURRENT_ACCOUNT_ID: '',
+  ACCOUNT_NAMES: {},
+  ESTABLISH_SITES: {},
+  ADDRESS_BOOK: '',
+  ACCOUNT_TOKEN_METAINFOS: {},
+  QUESTIONNAIRE_EXPIRED_DATE: null,
+  WALLET_CREATION_GUIDE_CONFIRM_DATE: null,
+  ADD_ACCOUNT_GUIDE_CONFIRM_DATE: null,
+  ACCOUNT_GRC721_COLLECTIONS: {},
+  ACCOUNT_GRC721_PINNED_PACKAGES: {},
+  KDF_SALT: 'abc123',
+};
+
+function makeInput(overrides: Partial<typeof BASE_DATA> = {}) {
+  return { version: 18 as const, data: { ...BASE_DATA, ...overrides } };
+}
+
+describe('StorageMigration019', () => {
+  it('version is 19', () => {
+    expect(new StorageMigration019().version).toBe(19);
+  });
+
+  it('migrates CURRENT_CHAIN_ID from test13 to test-13', async () => {
+    const result = await new StorageMigration019().up(makeInput());
+    expect(result.version).toBe(19);
+    expect(result.data.CURRENT_CHAIN_ID).toBe('test-13');
+  });
+
+  it('migrates CURRENT_NETWORK_ID from test13 to test-13', async () => {
+    const result = await new StorageMigration019().up(makeInput());
+    expect(result.data.CURRENT_NETWORK_ID).toBe('test-13');
+  });
+
+  it('does not change CURRENT_CHAIN_ID if it is not test13', async () => {
+    const result = await new StorageMigration019().up(makeInput({ CURRENT_CHAIN_ID: 'gnoland1' }));
+    expect(result.data.CURRENT_CHAIN_ID).toBe('gnoland1');
+  });
+
+  it('refreshes NETWORKS with test-13 from chains.json', async () => {
+    const result = await new StorageMigration019().up(makeInput({ NETWORKS: [] }));
+    const test13 = result.data.NETWORKS.find((n) => n.chainId === 'test-13');
+    expect(test13).toBeDefined();
+    expect(test13?.rpcUrl).toBe('https://rpc.test-13-aeddi-1.gnoland.network:443');
+    expect(test13?.indexerUrl).toBe('https://indexer.test-13.gnoland.network:443');
+  });
+
+  it('migrates ESTABLISH_SITES chainId from test13 to test-13', async () => {
+    const input = makeInput({
+      ESTABLISH_SITES: {
+        'acc-1': [
+          {
+            hostname: 'dapp.example',
+            chainId: 'test13',
+            account: 'g1abc',
+            name: 'App',
+            favicon: null,
+            establishedTime: '0',
+          },
+        ],
+      },
+    });
+    const result = await new StorageMigration019().up(input);
+    expect(result.data.ESTABLISH_SITES['acc-1'][0].chainId).toBe('test-13');
+  });
+
+  it('leaves non-test13 ESTABLISH_SITES chainId unchanged', async () => {
+    const input = makeInput({
+      ESTABLISH_SITES: {
+        'acc-1': [
+          {
+            hostname: 'dapp.example',
+            chainId: 'gnoland1',
+            account: 'g1abc',
+            name: 'App',
+            favicon: null,
+            establishedTime: '0',
+          },
+        ],
+      },
+    });
+    const result = await new StorageMigration019().up(input);
+    expect(result.data.ESTABLISH_SITES['acc-1'][0].chainId).toBe('gnoland1');
+  });
+
+  it('migrates ACCOUNT_TOKEN_METAINFOS networkId from test13 to test-13', async () => {
+    const input = makeInput({
+      ACCOUNT_TOKEN_METAINFOS: {
+        'acc-1': [
+          {
+            main: true,
+            tokenId: 'test13:ugnot',
+            networkId: 'test13',
+            display: true,
+            type: 'gno-native' as const,
+            name: 'Gno',
+            symbol: 'GNOT',
+            decimals: 6,
+            image: '',
+          },
+        ],
+      },
+    });
+    const result = await new StorageMigration019().up(input);
+    expect(result.data.ACCOUNT_TOKEN_METAINFOS['acc-1'][0].networkId).toBe('test-13');
+  });
+
+  it('migrates ACCOUNT_GRC721_COLLECTIONS object key from test13 to test-13', async () => {
+    const input = makeInput({
+      ACCOUNT_GRC721_COLLECTIONS: {
+        'acc-1': {
+          test13: [
+            {
+              tokenId: '1',
+              networkId: 'test13',
+              display: true,
+              type: 'grc721' as const,
+              packagePath: 'gno.land/r/test',
+              name: 'NFT',
+              symbol: 'NFT',
+              image: null,
+              isTokenUri: false,
+              isMetadata: false,
+            },
+          ],
+        },
+      },
+    });
+    const result = await new StorageMigration019().up(input);
+    const accountCollections = result.data.ACCOUNT_GRC721_COLLECTIONS['acc-1'];
+    expect(accountCollections['test13']).toBeUndefined();
+    expect(accountCollections['test-13']).toHaveLength(1);
+    expect(accountCollections['test-13'][0].networkId).toBe('test-13');
+  });
+
+  it('migrates ACCOUNT_GRC721_PINNED_PACKAGES object key from test13 to test-13', async () => {
+    const input = makeInput({
+      ACCOUNT_GRC721_PINNED_PACKAGES: {
+        'acc-1': {
+          test13: ['gno.land/r/test/nft'],
+          gnoland1: ['gno.land/r/other/nft'],
+        },
+      },
+    });
+    const result = await new StorageMigration019().up(input);
+    const pinned = result.data.ACCOUNT_GRC721_PINNED_PACKAGES['acc-1'];
+    expect(pinned['test13']).toBeUndefined();
+    expect(pinned['test-13']).toEqual(['gno.land/r/test/nft']);
+    expect(pinned['gnoland1']).toEqual(['gno.land/r/other/nft']);
+  });
+
+  it('throws on invalid v018 data', async () => {
+    const bad: any = { version: 18, data: { ...BASE_DATA, SERIALIZED: null } };
+    await expect(new StorageMigration019().up(bad)).rejects.toThrow(
+      'Storage Data does not match version V018',
+    );
+  });
+});

--- a/packages/adena-extension/src/migrates/migrations/v019/storage-migration-v019.ts
+++ b/packages/adena-extension/src/migrates/migrations/v019/storage-migration-v019.ts
@@ -1,0 +1,167 @@
+import { StorageModel } from '@common/storage';
+import { Migration } from '@migrates/migrator';
+import CHAIN_DATA from '@resources/chains/chains.json';
+import { StorageModelDataV018 } from '../v018/storage-model-v018';
+import {
+  AccountGRC721CollectionsV019,
+  AccountGRC721PinnedPackagesV019,
+  AccountTokenMetainfoModelV019,
+  EstablishSitesModelV019,
+  NetworksModelV019,
+  StorageModelDataV019,
+} from './storage-model-v019';
+
+const OLD_CHAIN_ID = 'test13';
+const NEW_CHAIN_ID = 'test-13';
+
+export class StorageMigration019 implements Migration<StorageModelDataV019> {
+  public readonly version = 19;
+
+  async up(
+    current: StorageModel<StorageModelDataV018>,
+  ): Promise<StorageModel<StorageModelDataV019>> {
+    if (!this.validateModelV018(current.data)) {
+      throw new Error('Storage Data does not match version V018');
+    }
+    const previous: StorageModelDataV018 = current.data;
+    return {
+      version: this.version,
+      data: {
+        ...previous,
+        CURRENT_CHAIN_ID: this.migrateChainId(previous.CURRENT_CHAIN_ID),
+        CURRENT_NETWORK_ID: this.migrateChainId(previous.CURRENT_NETWORK_ID),
+        NETWORKS: this.migrateNetworks(previous.NETWORKS),
+        ESTABLISH_SITES: this.migrateEstablishSites(previous.ESTABLISH_SITES),
+        ACCOUNT_TOKEN_METAINFOS: this.migrateTokenMetainfos(previous.ACCOUNT_TOKEN_METAINFOS),
+        ACCOUNT_GRC721_COLLECTIONS: this.migrateGrc721Collections(
+          previous.ACCOUNT_GRC721_COLLECTIONS,
+        ),
+        ACCOUNT_GRC721_PINNED_PACKAGES: this.migrateGrc721PinnedPackages(
+          previous.ACCOUNT_GRC721_PINNED_PACKAGES,
+        ),
+      },
+    };
+  }
+
+  private validateModelV018(currentData: StorageModelDataV018): boolean {
+    const storageDataKeys = [
+      'NETWORKS',
+      'CURRENT_CHAIN_ID',
+      'CURRENT_NETWORK_ID',
+      'SERIALIZED',
+      'ENCRYPTED_STORED_PASSWORD',
+      'CURRENT_ACCOUNT_ID',
+      'ESTABLISH_SITES',
+      'ADDRESS_BOOK',
+      'ACCOUNT_TOKEN_METAINFOS',
+      'ACCOUNT_GRC721_COLLECTIONS',
+      'ACCOUNT_GRC721_PINNED_PACKAGES',
+      'KDF_SALT',
+    ];
+    const currentDataKeys = Object.keys(currentData);
+    const hasKeys = storageDataKeys.every((key) => currentDataKeys.includes(key));
+    if (!hasKeys) {
+      return false;
+    }
+    if (!Array.isArray(currentData.NETWORKS)) {
+      return false;
+    }
+    if (typeof currentData.CURRENT_CHAIN_ID !== 'string') {
+      return false;
+    }
+    if (typeof currentData.CURRENT_NETWORK_ID !== 'string') {
+      return false;
+    }
+    if (typeof currentData.SERIALIZED !== 'string') {
+      return false;
+    }
+    if (typeof currentData.ENCRYPTED_STORED_PASSWORD !== 'string') {
+      return false;
+    }
+    if (typeof currentData.CURRENT_ACCOUNT_ID !== 'string') {
+      return false;
+    }
+    if (currentData.ACCOUNT_NAMES && typeof currentData.ACCOUNT_NAMES !== 'object') {
+      return false;
+    }
+    if (currentData.ESTABLISH_SITES && typeof currentData.ESTABLISH_SITES !== 'object') {
+      return false;
+    }
+    return true;
+  }
+
+  private migrateChainId(id: string): string {
+    return id === OLD_CHAIN_ID ? NEW_CHAIN_ID : id;
+  }
+
+  private migrateNetworks(networks: StorageModelDataV018['NETWORKS']): NetworksModelV019 {
+    const defaultNetworks = CHAIN_DATA.filter((n) => n.default);
+    const customNetworks = networks
+      .filter((n) => !n.default)
+      .map((n) => {
+        const provided = CHAIN_DATA.find((d) => d.chainId === n.id);
+        if (provided) {
+          return { ...provided, chainName: n.chainName, networkName: n.networkName, rpcUrl: n.rpcUrl };
+        }
+        return { ...n, indexerUrl: n.indexerUrl || '' };
+      });
+    return [...defaultNetworks, ...customNetworks];
+  }
+
+  private migrateEstablishSites(
+    sites: StorageModelDataV018['ESTABLISH_SITES'],
+  ): EstablishSitesModelV019 {
+    const result: EstablishSitesModelV019 = {};
+    for (const accountId of Object.keys(sites)) {
+      result[accountId] = sites[accountId].map((site) => ({
+        ...site,
+        chainId: site.chainId === OLD_CHAIN_ID ? NEW_CHAIN_ID : site.chainId,
+      }));
+    }
+    return result;
+  }
+
+  private migrateTokenMetainfos(
+    metainfos: StorageModelDataV018['ACCOUNT_TOKEN_METAINFOS'],
+  ): AccountTokenMetainfoModelV019 {
+    const result: AccountTokenMetainfoModelV019 = {};
+    for (const accountId of Object.keys(metainfos)) {
+      result[accountId] = metainfos[accountId].map((token) => ({
+        ...token,
+        networkId: token.networkId === OLD_CHAIN_ID ? NEW_CHAIN_ID : token.networkId,
+      }));
+    }
+    return result;
+  }
+
+  private migrateGrc721Collections(
+    collections: StorageModelDataV018['ACCOUNT_GRC721_COLLECTIONS'],
+  ): AccountGRC721CollectionsV019 {
+    const result: AccountGRC721CollectionsV019 = {};
+    for (const accountId of Object.keys(collections)) {
+      result[accountId] = {};
+      for (const networkId of Object.keys(collections[accountId])) {
+        const newNetworkId = networkId === OLD_CHAIN_ID ? NEW_CHAIN_ID : networkId;
+        result[accountId][newNetworkId] = collections[accountId][networkId].map((item) => ({
+          ...item,
+          networkId: item.networkId === OLD_CHAIN_ID ? NEW_CHAIN_ID : item.networkId,
+        }));
+      }
+    }
+    return result;
+  }
+
+  private migrateGrc721PinnedPackages(
+    pinned: StorageModelDataV018['ACCOUNT_GRC721_PINNED_PACKAGES'],
+  ): AccountGRC721PinnedPackagesV019 {
+    const result: AccountGRC721PinnedPackagesV019 = {};
+    for (const accountId of Object.keys(pinned)) {
+      result[accountId] = {};
+      for (const networkId of Object.keys(pinned[accountId])) {
+        const newNetworkId = networkId === OLD_CHAIN_ID ? NEW_CHAIN_ID : networkId;
+        result[accountId][newNetworkId] = pinned[accountId][networkId];
+      }
+    }
+    return result;
+  }
+}

--- a/packages/adena-extension/src/migrates/migrations/v019/storage-model-v019.ts
+++ b/packages/adena-extension/src/migrates/migrations/v019/storage-model-v019.ts
@@ -1,0 +1,148 @@
+export type StorageModelV019 = {
+  version: 19;
+  data: StorageModelDataV019;
+};
+
+export type StorageModelDataV019 = {
+  NETWORKS: NetworksModelV019;
+  CURRENT_CHAIN_ID: CurrentChainIdModelV019;
+  CURRENT_NETWORK_ID: CurrentNetworkIdModelV019;
+  SERIALIZED: SerializedModelV019;
+  ENCRYPTED_STORED_PASSWORD: EncryptedStoredPasswordModelV019;
+  CURRENT_ACCOUNT_ID: CurrentAccountIdModelV019;
+  ACCOUNT_NAMES: AccountNamesModelV019;
+  ESTABLISH_SITES: EstablishSitesModelV019;
+  ADDRESS_BOOK: AddressBookModelV019;
+  ACCOUNT_TOKEN_METAINFOS: AccountTokenMetainfoModelV019;
+  QUESTIONNAIRE_EXPIRED_DATE: QuestionnaireExpiredDateModelV019;
+  WALLET_CREATION_GUIDE_CONFIRM_DATE: WalletCreationGuideConfirmDateModelV019;
+  ADD_ACCOUNT_GUIDE_CONFIRM_DATE: AddAccountGuideConfirmDateModelV019;
+  ACCOUNT_GRC721_COLLECTIONS: AccountGRC721CollectionsV019;
+  ACCOUNT_GRC721_PINNED_PACKAGES: AccountGRC721PinnedPackagesV019;
+  KDF_SALT: KdfSaltModelV019;
+};
+
+export type KdfSaltModelV019 = string;
+
+export type NetworksModelV019 = {
+  id: string;
+  default: boolean;
+  main: boolean;
+  chainId: string;
+  chainName: string;
+  networkId: string;
+  networkName: string;
+  addressPrefix: string;
+  rpcUrl: string;
+  indexerUrl: string;
+  gnoUrl: string;
+  apiUrl: string;
+  linkUrl: string;
+  deleted?: boolean;
+}[];
+
+export type CurrentChainIdModelV019 = string;
+
+export type CurrentNetworkIdModelV019 = string;
+
+export type SerializedModelV019 = string;
+
+export type QuestionnaireExpiredDateModelV019 = number | null;
+
+export type WalletCreationGuideConfirmDateModelV019 = number | null;
+
+export type AddAccountGuideConfirmDateModelV019 = number | null;
+
+export type WalletModelV019 = {
+  accounts: AccountDataModelV019[];
+  keyrings: KeyringDataModelV019[];
+  currentAccountId?: string;
+};
+
+export type AccountDataModelV019 = {
+  id?: string;
+  index: number;
+  type: 'HD_WALLET' | 'PRIVATE_KEY' | 'LEDGER' | 'WEB3_AUTH' | 'AIRGAP';
+  name: string;
+  keyringId: string;
+  hdPath?: number;
+  publicKey: number[];
+  addressBytes?: number[];
+};
+
+export type KeyringDataModelV019 = {
+  id?: string;
+  type: 'HD_WALLET' | 'PRIVATE_KEY' | 'LEDGER' | 'WEB3_AUTH' | 'AIRGAP';
+  publicKey?: number[];
+  privateKey?: number[];
+  seed?: number[];
+  mnemonic?: string;
+  addressBytes?: number[];
+};
+
+export type EncryptedStoredPasswordModelV019 = string;
+
+export type CurrentAccountIdModelV019 = string;
+
+type AccountId = string;
+type NetworkId = string;
+
+export type AccountNamesModelV019 = { [key in AccountId]: string };
+
+export type EstablishSitesModelV019 = {
+  [key in AccountId]: {
+    hostname: string;
+    chainId: string;
+    account: string;
+    name: string;
+    favicon: string | null;
+    establishedTime: string;
+  }[];
+};
+
+export type AddressBookModelV019 = string;
+
+export type AccountTokenMetainfoModelV019 = {
+  [key in string]: {
+    main: boolean;
+    tokenId: string;
+    networkId: string;
+    display: boolean;
+    type: 'gno-native' | 'grc20' | 'ibc-native' | 'ibc-tokens';
+    name: string;
+    symbol: string;
+    decimals: number;
+    description?: string;
+    websiteUrl?: string;
+    image: string;
+    denom?: string;
+    pkgPath?: string;
+    originChain?: string;
+    originDenom?: string;
+    originType?: string;
+    path?: string;
+    channel?: string;
+    port?: string;
+  }[];
+};
+
+export type AccountGRC721CollectionsV019 = {
+  [key in AccountId]: {
+    [key in NetworkId]: {
+      tokenId: string;
+      networkId: string;
+      display: boolean;
+      type: 'grc721';
+      packagePath: string;
+      name: string;
+      symbol: string;
+      image: string | null;
+      isTokenUri: boolean;
+      isMetadata: boolean;
+    }[];
+  };
+};
+
+export type AccountGRC721PinnedPackagesV019 = {
+  [key in AccountId]: { [key in NetworkId]: string[] };
+};

--- a/packages/adena-extension/src/migrates/storage-migrator.spec.ts
+++ b/packages/adena-extension/src/migrates/storage-migrator.spec.ts
@@ -70,7 +70,7 @@ describe('StorageMigrator', () => {
     const migrated = await migrator.migrate(current, '123');
 
     expect(migrated).not.toBeNull();
-    expect(migrated?.version).toBe(18);
+    expect(migrated?.version).toBe(19);
     expect(migrated?.data).not.toBeNull();
     expect(migrated?.data.NETWORKS).toHaveLength(4);
     expect(migrated?.data.CURRENT_CHAIN_ID).toBe('');
@@ -87,7 +87,7 @@ describe('StorageMigrator', () => {
     const migrated = await migrator.migrate(current, '123');
 
     expect(migrated).not.toBeNull();
-    expect(migrated?.version).toBe(18);
+    expect(migrated?.version).toBe(19);
     expect(migrated?.data).not.toBeNull();
     expect(migrated?.data.SERIALIZED).not.toBe('');
     expect(migrated?.data.ADDRESS_BOOK).toBe('');

--- a/packages/adena-extension/src/migrates/storage-migrator.ts
+++ b/packages/adena-extension/src/migrates/storage-migrator.ts
@@ -34,6 +34,8 @@ import { StorageMigration017 } from './migrations/v017/storage-migration-v017';
 import { StorageModelDataV017, StorageModelV017 } from './migrations/v017/storage-model-v017';
 import { StorageMigration018 } from './migrations/v018/storage-migration-v018';
 import { StorageModelDataV018, StorageModelV018 } from './migrations/v018/storage-model-v018';
+import { StorageMigration019 } from './migrations/v019/storage-migration-v019';
+import { StorageModelDataV019, StorageModelV019 } from './migrations/v019/storage-model-v019';
 import { Migration, Migrator } from './migrator';
 
 const LegacyStorageKeys = [
@@ -49,7 +51,7 @@ const LegacyStorageKeys = [
 ];
 
 // The latest storage model type
-export type StorageModelLatest = StorageModelV018;
+export type StorageModelLatest = StorageModelV019;
 
 // Default data structure for version 1 storage model
 const defaultData: StorageModelDataV001 = {
@@ -65,7 +67,7 @@ const defaultData: StorageModelDataV001 = {
   ACCOUNT_TOKEN_METAINFOS: {},
 };
 
-const defaultLegacyData: StorageModelDataV018 = {
+const defaultLegacyData: StorageModelDataV019 = {
   NETWORKS: [],
   CURRENT_CHAIN_ID: '',
   CURRENT_NETWORK_ID: '',
@@ -121,6 +123,7 @@ export class StorageMigrator implements Migrator {
   async deserialize(
     data: string | undefined,
   ): Promise<
+    | StorageModelV019
     | StorageModelV018
     | StorageModelV017
     | StorageModelV016
@@ -153,6 +156,7 @@ export class StorageMigrator implements Migrator {
 
   // Retrieves the current storage data, performing deserialization
   async getCurrent(): Promise<
+    | StorageModelV019
     | StorageModelV018
     | StorageModelV017
     | StorageModelV016
@@ -179,13 +183,13 @@ export class StorageMigrator implements Migrator {
     }
 
     return {
-      version: 18,
+      version: 19,
       data: defaultLegacyData,
     };
   }
 
   // Migrates storage data to the latest version
-  async migrate(current: StorageModel, password: string): Promise<StorageModelV018 | null> {
+  async migrate(current: StorageModel, password: string): Promise<StorageModelV019 | null> {
     let latest = current;
     try {
       const currentVersion = current.version || 1;
@@ -227,6 +231,7 @@ export class StorageMigrator implements Migrator {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     json: any,
   ): Promise<
+    | StorageModelV019
     | StorageModelV018
     | StorageModelV017
     | StorageModelV016
@@ -246,6 +251,9 @@ export class StorageMigrator implements Migrator {
     | StorageModelV002
     | StorageModelV001
   > {
+    if (json?.version === 19) {
+      return json as StorageModelV019;
+    }
     if (json?.version === 18) {
       return json as StorageModelV018;
     }
@@ -346,6 +354,7 @@ export class StorageMigrator implements Migrator {
       new StorageMigration016(),
       new StorageMigration017(),
       new StorageMigration018(),
+      new StorageMigration019(),
     ];
   }
 }

--- a/packages/adena-extension/src/resources/chains/chains.json
+++ b/packages/adena-extension/src/resources/chains/chains.json
@@ -30,18 +30,18 @@
     "linkUrl": "https://gnoscan.io"
   },
   {
-    "id": "test13",
+    "id": "test-13",
     "default": true,
     "main": false,
-    "chainId": "test13",
-    "chainName": "test13",
-    "networkId": "test13",
+    "chainId": "test-13",
+    "chainName": "test-13",
+    "networkId": "test-13",
     "networkName": "Testnet 13",
     "addressPrefix": "g",
-    "rpcUrl": "https://rpc.test13.testnets.gno.land:443",
-    "indexerUrl": "https://test13.indexer.onbloc.xyz",
-    "gnoUrl": "https://test13.testnets.gno.land",
-    "apiUrl": "https://test13.api.onbloc.xyz",
+    "rpcUrl": "https://rpc.test-13-aeddi-1.gnoland.network:443",
+    "indexerUrl": "https://indexer.test-13.gnoland.network:443",
+    "gnoUrl": "https://gnoweb.test-13.gnoland.network",
+    "apiUrl": "",
     "linkUrl": "https://gnoscan.io"
   },
   {

--- a/packages/adena-extension/src/services/wallet/wallet-establish.spec.ts
+++ b/packages/adena-extension/src/services/wallet/wallet-establish.spec.ts
@@ -8,7 +8,7 @@ const HOSTNAME = 'dapp.example';
 const GNO_PROFILES = [
   { chainGroup: 'gno', chainId: 'gnoland1' },
   { chainGroup: 'gno', chainId: 'staging' },
-  { chainGroup: 'gno', chainId: 'test12' },
+  { chainGroup: 'gno', chainId: 'test-13' },
 ];
 
 function makeChainRegistry(): ChainRegistry {

--- a/packages/adena-module/src/chain-registry/entries/gno.ts
+++ b/packages/adena-module/src/chain-registry/entries/gno.ts
@@ -45,16 +45,16 @@ export const GNO_STAGING: GnoNetworkProfile = {
   linkUrl: 'https://gnoscan.io',
 };
 
-export const GNO_TEST12: GnoNetworkProfile = {
+export const GNO_TEST13: GnoNetworkProfile = {
   ...GNO_PROFILE_BASE,
-  id: 'test12',
-  chainId: 'test12',
-  displayName: 'Gno.land Testnet 12',
+  id: 'test-13',
+  chainId: 'test-13',
+  displayName: 'Gno.land Testnet 13',
   isMainnet: false,
-  nativeTokenId: 'test12:ugnot',
-  rpcEndpoints: ['https://rpc.test12.testnets.gno.land:443'],
-  indexerUrl: 'https://test12.indexer.onbloc.xyz',
-  gnoUrl: 'https://test12.testnets.gno.land',
+  nativeTokenId: 'test-13:ugnot',
+  rpcEndpoints: ['https://rpc.test-13-aeddi-1.gnoland.network:443'],
+  indexerUrl: 'https://indexer.test-13.gnoland.network:443',
+  gnoUrl: 'https://gnoweb.test-13.gnoland.network',
   linkUrl: 'https://gnoscan.io',
 };
 
@@ -86,7 +86,7 @@ export const GNO_GNOSWAP: GnoNetworkProfile = {
 export const GNO_NETWORK_PROFILES: GnoNetworkProfile[] = [
   GNOLAND1,
   GNO_STAGING,
-  GNO_TEST12,
+  GNO_TEST13,
   GNO_DEV,
   GNO_GNOSWAP,
 ];

--- a/packages/adena-module/src/chain-registry/registry.spec.ts
+++ b/packages/adena-module/src/chain-registry/registry.spec.ts
@@ -96,8 +96,8 @@ describe('ChainRegistry', () => {
     expect(profile?.isMainnet).toBe(true);
   });
 
-  it('test12 has isMainnet false', () => {
-    const profile = registry.get('test12');
+  it('test-13 has isMainnet false', () => {
+    const profile = registry.get('test-13');
     expect(profile?.isMainnet).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Replace the `test13` network entry with the new `test-13` network across the codebase
- New network uses `gnoland.network` domain for all endpoints
- Add storage migration v019 to rename all stored `test13` references to `test-13`

## Changes

### Network configuration
- `chains.json`: update `test13` entry — new chain ID (`test-13`), RPC/Indexer/GnoWeb URLs
- `adena-module/chain-registry/entries/gno.ts`: replace `GNO_TEST12` with `GNO_TEST13`

### New endpoints
| | Before | After |
|---|---|---|
| Chain ID | `test13` | `test-13` |
| RPC | `https://rpc.test13.testnets.gno.land:443` | `https://rpc.test-13-aeddi-1.gnoland.network:443` |
| Indexer | `https://test13.indexer.onbloc.xyz` | `https://indexer.test-13.gnoland.network:443` |
| GnoWeb | `https://test13.testnets.gno.land` | `https://gnoweb.test-13.gnoland.network` |

### Storage migration v019
Migrates all stored `test13` chain ID references to `test-13`:
- `CURRENT_CHAIN_ID` / `CURRENT_NETWORK_ID`
- `NETWORKS` (default networks reloaded from chains.json)
- `ESTABLISH_SITES[].chainId`
- `ACCOUNT_TOKEN_METAINFOS[].networkId`
- `ACCOUNT_GRC721_COLLECTIONS` / `ACCOUNT_GRC721_PINNED_PACKAGES` object keys

## Test plan

- [x] `storage-migration-v019.spec.ts` — 11 cases covering all migrated fields
- [x] `registry.spec.ts` — test-13 isMainnet check
- [x] `wallet-establish.spec.ts` — test-13 chain group check
- [ ] Manual: select Testnet 13, confirm RPC connection with new endpoint
- [ ] Manual: verify token list and tx history load (indexer-based, no apiUrl)
- [ ] Manual: confirm existing test13 storage migrates cleanly to test-13 on extension restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)