### PR TITLE
chore: bump package version to v1.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adena-wallet",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "Adena Wallet",
   "license": "Adena License",
   "private": true,

--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adena-extension",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "private": true,
   "description": "Adena is a friendly browser extension wallet for the Gno.land blockchain.",
   "scripts": {

--- a/packages/adena-extension/public/manifest.json
+++ b/packages/adena-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Adena",
   "description": "Adena is a friendly browser extension wallet for the gno.land blockchain.",
   "manifest_version": 3,
-  "version": "1.19.2",
+  "version": "1.19.3",
   "action": {
     "default_icon": {
       "16": "icons/icon16.png",

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adena-module",
   "private": true,
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "Adena's Wallet",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
## Summary
- Bump package version from `1.19.2` to `1.19.3` across the monorepo (`package.json`, `packages/adena-extension/package.json`, `packages/adena-extension/public/manifest.json`, `packages/adena-module/package.json`).

## Included since v1.19.2
- feat: replace test13 with test-13 network (ADN-779) (#847)
- feat: indexer schema migration with GRC20 metadata via grc20reg qeval query (#846)
- fix(ADN-777): show token name instead of network name on send confirm (#845)
- fix: default network edit/delete robustness (ADN-776) (#844)

## Test plan
- [ ] `npm install` succeeds at the repo root with the new version
- [ ] Build the extension and verify the loaded `manifest.json` reports `1.19.3`
- [ ] Confirm the about/version surface in the UI shows `1.19.3`