### PR TITLE
feat(ADN-780): default fresh installs to Testnet Mode with test-13

### DIFF
--- a/packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx
+++ b/packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx
@@ -8,9 +8,16 @@ import {
   atomoneNetworkToProfile,
   atomoneNetworkToTokenProfiles,
 } from '@hooks/helpers/atomone-to-profile';
+import {
+  normalizeStoredId,
+  pickDefaultByMode,
+  resolveNetworkMode,
+} from '@common/utils/network-default';
 import { NetworkState, TokenState, WalletState } from '@states';
 import { AtomoneNetworkMetainfo, NetworkMetainfo, StateType, TokenModel } from '@types';
 import { GnoProvider } from '../gno/gno-provider';
+
+type NetworkMode = NetworkState.NetworkMode;
 
 export interface WalletContextProps {
   wallet: Wallet | null;
@@ -54,18 +61,12 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
   useEffect(() => {
     initWallet();
     initNetworkMetainfos();
-    initAtomoneNetworkChain();
   }, []);
 
   // Pull every persisted AtomOne network (defaults + user-added customs) into
-  // the recoil atom plus chainRegistry/tokenRegistry, then restore the
-  // previously selected one. Without this, the atom keeps its hardcoded
-  // default and the registries never learn about custom profiles, so
-  // changeNetwork(custom) silently no-ops the cosmos balance fetch and
-  // useTokenMetainfo cannot seed cosmos rows. Selection lookup runs against
-  // the hydrated list (defaults + customs) — falling back to the static json
-  // would erase a user-selected custom on every reload.
-  async function initAtomoneNetworkChain(): Promise<void> {
+  // the recoil atom plus chainRegistry/tokenRegistry. Returns the hydrated
+  // list so the caller can pick the active one once the mode is resolved.
+  async function loadAtomoneNetworks(): Promise<AtomoneNetworkMetainfo[]> {
     let networks: AtomoneNetworkMetainfo[];
     try {
       networks = await chainService.getAtomoneNetworks();
@@ -85,11 +86,13 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
         tokenRegistry.register(token);
       }
     }
+    return networks;
+  }
 
-    const storedMode = await chainService.getNetworkMode().catch(() => null);
-    const mode = storedMode === 'testnet' ? 'testnet' : 'mainnet';
-    setNetworkMode(mode);
-
+  async function initCurrentAtomoneNetwork(
+    networks: AtomoneNetworkMetainfo[],
+    mode: NetworkMode,
+  ): Promise<void> {
     const storedId = await chainService.getCurrentAtomoneNetworkId().catch(() => null);
     const wantsMainnet = mode === 'mainnet';
     const candidates = networks.filter((network) => !network.deleted);
@@ -175,6 +178,11 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
     return true;
   }
 
+  // Orchestrates the full network bootstrap. Loads gno + AtomOne networks,
+  // resolves the active mode using storage precedence (see resolveNetworkMode),
+  // then picks the matching current network on each chain group. The order
+  // matters: mode must be known before the current-network fallback can pick
+  // a sensible default for fresh installs.
   async function initNetworkMetainfos(): Promise<boolean> {
     const networkMetainfos = await chainService.getNetworks();
     if (networkMetainfos.length === 0) {
@@ -182,20 +190,33 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
     }
 
     setNetworkMetainfos(networkMetainfos);
-
     chainService.updateNetworks(networkMetainfos);
-    await initCurrentNetworkMetainfos(networkMetainfos);
+
+    const atomoneNetworks = await loadAtomoneNetworks();
+
+    const storedMode = await chainService.getNetworkMode().catch(() => null);
+    const storedCurrentId = normalizeStoredId(
+      await chainService.getCurrentNetworkId().catch(() => ''),
+    );
+    const mode = resolveNetworkMode(storedMode, storedCurrentId, networkMetainfos);
+    setNetworkMode(mode);
+
+    await initCurrentNetworkMetainfos(networkMetainfos, storedCurrentId, mode);
+    await initCurrentAtomoneNetwork(atomoneNetworks, mode);
 
     return true;
   }
 
   async function initCurrentNetworkMetainfos(
     networkMetainfos: NetworkMetainfo[],
+    storedCurrentId: string | null,
+    mode: NetworkMode,
   ): Promise<boolean> {
-    const currentNetworkId = await chainService.getCurrentNetworkId();
+    const storedNetwork = storedCurrentId
+      ? networkMetainfos.find((network) => network.id === storedCurrentId)
+      : undefined;
     const currentNetwork =
-      networkMetainfos.find((networkMetainfo) => networkMetainfo.id === currentNetworkId) ??
-      networkMetainfos[0];
+      storedNetwork ?? pickDefaultByMode(networkMetainfos, mode) ?? networkMetainfos[0];
 
     await chainService.updateCurrentNetworkId(currentNetwork.id);
     await changeNetwork(currentNetwork);

--- a/packages/adena-extension/src/common/utils/network-default.spec.ts
+++ b/packages/adena-extension/src/common/utils/network-default.spec.ts
@@ -1,0 +1,99 @@
+import { NetworkMetainfo } from '@types';
+import {
+  normalizeStoredId,
+  pickDefaultByMode,
+  resolveNetworkMode,
+} from './network-default';
+
+function makeNetwork(overrides: Partial<NetworkMetainfo> & Pick<NetworkMetainfo, 'id'>): NetworkMetainfo {
+  return {
+    default: true,
+    main: false,
+    chainId: overrides.id,
+    chainName: overrides.id,
+    networkId: overrides.id,
+    networkName: overrides.id,
+    addressPrefix: 'g',
+    rpcUrl: '',
+    indexerUrl: '',
+    gnoUrl: '',
+    apiUrl: '',
+    linkUrl: '',
+    deleted: false,
+    ...overrides,
+  } as NetworkMetainfo;
+}
+
+const GNOLAND1 = makeNetwork({ id: 'gnoland1', main: true });
+const TEST_13 = makeNetwork({ id: 'test-13', main: false });
+const STAGING = makeNetwork({ id: 'staging', main: false });
+const DEV = makeNetwork({ id: 'dev', main: false });
+const NETWORKS: NetworkMetainfo[] = [GNOLAND1, TEST_13, STAGING, DEV];
+
+describe('normalizeStoredId', () => {
+  it('returns null for empty / undefined / null / sentinel strings', () => {
+    expect(normalizeStoredId('')).toBeNull();
+    expect(normalizeStoredId(null)).toBeNull();
+    expect(normalizeStoredId(undefined)).toBeNull();
+    expect(normalizeStoredId('undefined')).toBeNull();
+    expect(normalizeStoredId('null')).toBeNull();
+  });
+
+  it('returns the raw id for legitimate values', () => {
+    expect(normalizeStoredId('gnoland1')).toBe('gnoland1');
+    expect(normalizeStoredId('test-13')).toBe('test-13');
+  });
+});
+
+describe('resolveNetworkMode', () => {
+  it('uses explicit stored mode regardless of stored network', () => {
+    expect(resolveNetworkMode('mainnet', 'test-13', NETWORKS)).toBe('mainnet');
+    expect(resolveNetworkMode('testnet', 'gnoland1', NETWORKS)).toBe('testnet');
+  });
+
+  it('derives mode from the stored networks main flag when stored mode is missing', () => {
+    expect(resolveNetworkMode(null, 'gnoland1', NETWORKS)).toBe('mainnet');
+    expect(resolveNetworkMode(null, 'test-13', NETWORKS)).toBe('testnet');
+    expect(resolveNetworkMode(null, 'staging', NETWORKS)).toBe('testnet');
+  });
+
+  it('defaults to testnet for a fresh install (no stored values)', () => {
+    expect(resolveNetworkMode(null, null, NETWORKS)).toBe('testnet');
+  });
+
+  it('falls back to testnet when the stored id does not match any known network', () => {
+    expect(resolveNetworkMode(null, 'unknown-id', NETWORKS)).toBe('testnet');
+  });
+});
+
+describe('pickDefaultByMode', () => {
+  it('prefers test-13 for testnet mode', () => {
+    expect(pickDefaultByMode(NETWORKS, 'testnet')?.id).toBe('test-13');
+  });
+
+  it('prefers gnoland1 for mainnet mode', () => {
+    expect(pickDefaultByMode(NETWORKS, 'mainnet')?.id).toBe('gnoland1');
+  });
+
+  it('falls back to a generic testnet default when test-13 is missing', () => {
+    const withoutTest13 = NETWORKS.filter((network) => network.id !== 'test-13');
+    expect(pickDefaultByMode(withoutTest13, 'testnet')?.id).toBe('staging');
+  });
+
+  it('skips deleted networks when picking', () => {
+    const withDeletedTest13 = NETWORKS.map((network) =>
+      network.id === 'test-13' ? { ...network, deleted: true } : network,
+    );
+    expect(pickDefaultByMode(withDeletedTest13, 'testnet')?.id).toBe('staging');
+  });
+
+  it('returns the first non-deleted network when no testnet default exists', () => {
+    const onlyMainnet: NetworkMetainfo[] = [GNOLAND1];
+    expect(pickDefaultByMode(onlyMainnet, 'testnet')?.id).toBe('gnoland1');
+  });
+
+  it('returns undefined when every network is deleted', () => {
+    const allDeleted = NETWORKS.map((network) => ({ ...network, deleted: true }));
+    expect(pickDefaultByMode(allDeleted, 'testnet')).toBeUndefined();
+  });
+});

--- a/packages/adena-extension/src/common/utils/network-default.ts
+++ b/packages/adena-extension/src/common/utils/network-default.ts
@@ -1,0 +1,67 @@
+import { NetworkModeValue } from '@repositories/common';
+import { NetworkState } from '@states';
+import { NetworkMetainfo } from '@types';
+
+type NetworkMode = NetworkState.NetworkMode;
+
+const PRIMARY_TESTNET_ID = 'test-13';
+const PRIMARY_MAINNET_ID = 'gnoland1';
+
+// StorageManager.get coerces undefined to the string "undefined" because it
+// wraps the value with a template literal. Treat those sentinel strings, plus
+// the empty string and falsy values, as "no stored id".
+export function normalizeStoredId(raw: string | null | undefined): string | null {
+  if (!raw || raw === 'undefined' || raw === 'null') {
+    return null;
+  }
+  return raw;
+}
+
+// Derive the active network mode using the precedence:
+// 1. Explicit stored mode wins.
+// 2. If only a current network id is stored, derive mode from that network's
+//    `main` flag so a user who has only ever used Mainnet stays on Mainnet
+//    after ADN-780 changes the default for genuinely new installs.
+// 3. With neither stored, treat as a fresh install and default to testnet.
+export function resolveNetworkMode(
+  storedMode: NetworkModeValue | null,
+  storedCurrentId: string | null,
+  networks: NetworkMetainfo[],
+): NetworkMode {
+  if (storedMode === 'mainnet' || storedMode === 'testnet') {
+    return storedMode;
+  }
+  if (storedCurrentId) {
+    const storedNetwork = networks.find((network) => network.id === storedCurrentId);
+    if (storedNetwork) {
+      return storedNetwork.main === true ? 'mainnet' : 'testnet';
+    }
+  }
+  return 'testnet';
+}
+
+// Pick the default network for a given mode. Prefers the canonical id
+// (test-13 for testnet, gnoland1 for mainnet) so the result is stable even if
+// chains.json ordering changes, then falls back to any matching default, and
+// finally to the first non-deleted network.
+export function pickDefaultByMode(
+  networks: NetworkMetainfo[],
+  mode: NetworkMode,
+): NetworkMetainfo | undefined {
+  const wantsMainnet = mode === 'mainnet';
+  const preferredId = wantsMainnet ? PRIMARY_MAINNET_ID : PRIMARY_TESTNET_ID;
+  const preferred = networks.find(
+    (network) => !network.deleted && network.id === preferredId,
+  );
+  if (preferred) {
+    return preferred;
+  }
+  const generic = networks.find(
+    (network) =>
+      !network.deleted && (network.main === true) === wantsMainnet && network.default,
+  );
+  if (generic) {
+    return generic;
+  }
+  return networks.find((network) => !network.deleted);
+}

--- a/packages/adena-extension/src/hooks/use-network.ts
+++ b/packages/adena-extension/src/hooks/use-network.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { fetchHealth } from '@common/utils/fetch-utils';
+import { pickDefaultByMode } from '@common/utils/network-default';
 import { EventMessage } from '@inject/message';
 import { useAdenaContext, useWalletContext } from './use-context';
 import { useEvent } from './use-event';
@@ -57,7 +58,10 @@ interface NetworkResponse {
   setModified: (modified: boolean) => void;
 }
 
-const DEFAULT_NETWORK: NetworkMetainfo = CHAIN_DATA[0];
+const DEFAULT_TESTNET_NETWORK: NetworkMetainfo =
+  CHAIN_DATA.find((network) => network.id === 'test-13') ?? CHAIN_DATA[0];
+const DEFAULT_MAINNET_NETWORK: NetworkMetainfo =
+  CHAIN_DATA.find((network) => network.id === 'gnoland1') ?? CHAIN_DATA[0];
 
 function isAtomoneNetwork(
   network: NetworkMetainfo | AtomoneNetworkMetainfo,
@@ -274,9 +278,7 @@ export const useNetwork = (): NetworkResponse => {
       await chainService.updateNetworkMode(nextMode).catch(() => null);
       const wantsMainnet = nextMode === 'mainnet';
 
-      const gnoTarget = networkMetainfos.find(
-        (network) => !network.deleted && (network.main === true) === wantsMainnet,
-      );
+      const gnoTarget = pickDefaultByMode(networkMetainfos, nextMode);
       if (gnoTarget && gnoTarget.id !== currentGnoNetwork?.id) {
         await chainService.updateCurrentNetworkId(gnoTarget.id);
         await changeNetworkOfProvider(gnoTarget);
@@ -467,8 +469,11 @@ export const useNetwork = (): NetworkResponse => {
     [currentGnoNetwork],
   );
 
+  const fallbackNetwork: NetworkMetainfo =
+    mode === 'testnet' ? DEFAULT_TESTNET_NETWORK : DEFAULT_MAINNET_NETWORK;
+
   return {
-    currentNetwork: currentGnoNetwork || DEFAULT_NETWORK,
+    currentNetwork: currentGnoNetwork || fallbackNetwork,
     currentAtomoneNetwork,
     networks: networkMetainfos,
     atomoneNetworks,

--- a/packages/adena-extension/src/repositories/common/chain.spec.ts
+++ b/packages/adena-extension/src/repositories/common/chain.spec.ts
@@ -193,3 +193,28 @@ describe('ChainRepository — AtomOne methods', () => {
     });
   });
 });
+
+describe('ChainRepository — getCurrentNetworkId', () => {
+  function makeRepository(getValue: string): ChainRepository {
+    const localStorage = {
+      get: jest.fn().mockResolvedValue(getValue),
+    } as unknown as StorageManager;
+    const networkInstance = {} as AxiosInstance;
+    return new ChainRepository(localStorage, networkInstance);
+  }
+
+  it('returns an empty string when storage holds the literal "undefined"', async () => {
+    const repository = makeRepository('undefined');
+    expect(await repository.getCurrentNetworkId()).toBe('');
+  });
+
+  it('returns an empty string when storage holds "null"', async () => {
+    const repository = makeRepository('null');
+    expect(await repository.getCurrentNetworkId()).toBe('');
+  });
+
+  it('returns the stored id verbatim for legitimate values', async () => {
+    const repository = makeRepository('test-13');
+    expect(await repository.getCurrentNetworkId()).toBe('test-13');
+  });
+});

--- a/packages/adena-extension/src/repositories/common/chain.ts
+++ b/packages/adena-extension/src/repositories/common/chain.ts
@@ -140,8 +140,14 @@ export class ChainRepository {
     return true;
   };
 
-  public getCurrentNetworkId = (): Promise<string> => {
-    return this.localStorage.get('CURRENT_NETWORK_ID');
+  public getCurrentNetworkId = async (): Promise<string> => {
+    // StorageManager.get stringifies undefined as the literal "undefined".
+    // Mirror getCurrentAtomoneNetworkId and treat those sentinels as missing.
+    const value = await this.localStorage.get('CURRENT_NETWORK_ID').catch(() => '');
+    if (!value || value === 'undefined' || value === 'null') {
+      return '';
+    }
+    return value;
   };
 
   public updateCurrentNetworkId = async (networkId: string): Promise<boolean> => {

--- a/packages/adena-extension/src/resources/chains/chains.json
+++ b/packages/adena-extension/src/resources/chains/chains.json
@@ -15,21 +15,6 @@
     "linkUrl": "https://gnoscan.io"
   },
   {
-    "id": "staging",
-    "default": true,
-    "main": false,
-    "chainId": "staging",
-    "chainName": "Gno.land",
-    "networkId": "staging",
-    "networkName": "Staging",
-    "addressPrefix": "g",
-    "rpcUrl": "https://rpc.staging.gno.land:443",
-    "indexerUrl": "https://staging.indexer.onbloc.xyz",
-    "gnoUrl": "https://staging.gno.land",
-    "apiUrl": "https://staging.api.onbloc.xyz",
-    "linkUrl": "https://gnoscan.io"
-  },
-  {
     "id": "test-13",
     "default": true,
     "main": false,
@@ -42,6 +27,21 @@
     "indexerUrl": "https://indexer.test-13.gnoland.network:443",
     "gnoUrl": "https://gnoweb.test-13.gnoland.network",
     "apiUrl": "",
+    "linkUrl": "https://gnoscan.io"
+  },
+  {
+    "id": "staging",
+    "default": true,
+    "main": false,
+    "chainId": "staging",
+    "chainName": "Gno.land",
+    "networkId": "staging",
+    "networkName": "Staging",
+    "addressPrefix": "g",
+    "rpcUrl": "https://rpc.staging.gno.land:443",
+    "indexerUrl": "https://staging.indexer.onbloc.xyz",
+    "gnoUrl": "https://staging.gno.land",
+    "apiUrl": "https://staging.api.onbloc.xyz",
     "linkUrl": "https://gnoscan.io"
   },
   {

--- a/packages/adena-extension/src/states/network.ts
+++ b/packages/adena-extension/src/states/network.ts
@@ -9,9 +9,6 @@ const ATOMONE_DEFAULT_NETWORKS: AtomoneNetworkMetainfo[] = (
   ATOMONE_CHAIN_DATA as unknown as AtomoneNetworkMetainfo[]
 ).map((network) => ({ ...network, deleted: false }));
 
-const DEFAULT_ATOMONE_MAINNET: AtomoneNetworkMetainfo | null =
-  ATOMONE_DEFAULT_NETWORKS.find((network) => network.default && network.isMainnet) ?? null;
-
 export const networkMetainfos = atom<NetworkMetainfo[]>({
   key: 'network/networkMetainfos',
   default: [],
@@ -32,9 +29,12 @@ export const atomoneNetworkMetainfos = atom<AtomoneNetworkMetainfo[]>({
   default: ATOMONE_DEFAULT_NETWORKS,
 });
 
+// Stay null until WalletProvider hydrates this from storage; the provider
+// resolves the mode and picks the matching AtomOne network. Defaulting to a
+// mainnet entry caused a first-render flash for users who land on testnet.
 export const currentAtomoneNetwork = atom<AtomoneNetworkMetainfo | null>({
   key: 'network/current-atomone-network',
-  default: DEFAULT_ATOMONE_MAINNET,
+  default: null,
 });
 
 export const networkMode = atom<NetworkMode>({


### PR DESCRIPTION
## Summary

Fresh installs now boot into Testnet Mode with `test-13` selected, instead of Beta Mainnet/Staging.

Existing users are unaffected: when `NETWORK_MODE` is unset, the active mode is derived from the stored network's `main` flag, so a user who has only ever used Beta Mainnet stays on Beta Mainnet after the update.

### What changed

- **chains.json** - `test-13` now precedes `staging` so the testnet default list naturally falls on `test-13`.
- **`network-default` helper (new)** - `pickDefaultByMode` (prefers canonical ids `test-13` / `gnoland1`, falls back to generic + first non-deleted), `resolveNetworkMode` (stored mode -> derive from stored network -> testnet for fresh installs), `normalizeStoredId` (handles `''`, `'undefined'`, `'null'` sentinels).
- **`WalletProvider` bootstrap** - load gno networks, load AtomOne networks, resolve mode using both stored values, then pick the current network per chain group sequentially. Removes the race between `initNetworkMetainfos` and the old `initAtomoneNetworkChain`.
- **`useNetwork`** - `changeNetworkMode` now uses `pickDefaultByMode` so toggling Testnet always lands on `test-13`. The hook's `currentNetwork` fallback is mode-aware to avoid a gnoland1 flash before the provider hydrates.
- **`currentAtomoneNetwork` atom default -> `null`** so the first render does not flash a mainnet AtomOne entry on fresh-install testnet users.
- **`getCurrentNetworkId` repository method** - normalizes `'undefined'` / `'null'` / empty values, mirroring the AtomOne variant. `StorageManager.get` stringifies missing values, which previously slipped through truthy checks.

### Mode resolution policy

| `NETWORK_MODE` | `CURRENT_NETWORK_ID` | Resolved mode |
|---|---|---|
| `'mainnet'` / `'testnet'` | any | the stored mode |
| unset | known id | derive from stored network's `main` flag |
| unset | unset | `testnet` (fresh install) |

## Test plan

Automated (passing locally):
- [x] `pickDefaultByMode`, `resolveNetworkMode`, `normalizeStoredId` unit tests (`network-default.spec.ts`)
- [x] `getCurrentNetworkId` normalization tests (`chain.spec.ts`)
- [x] Full extension test suite: `npx jest` -> 138 suites / 382 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on changed files clean

Manual:
- [ ] Fresh install: clear storage -> create wallet -> verify Testnet toggle ON, current network `Testnet 13`
- [ ] Toggle Testnet OFF -> `gnoland1` (Beta Mainnet); toggle ON -> back to `test-13`
- [ ] Existing user simulation: storage has `CURRENT_NETWORK_ID=gnoland1`, no `NETWORK_MODE` -> verify toggle OFF, current = gnoland1
- [ ] Existing user simulation: storage has `CURRENT_NETWORK_ID=staging`, no `NETWORK_MODE` -> verify toggle ON, current = staging
- [ ] Explicit selection preserved: with both `NETWORK_MODE` and `CURRENT_NETWORK_ID` set, no override on reload