### PR TITLE
fix(ADN-782): prevent "invalid salt length" when KDF_SALT is missing

### DIFF
--- a/packages/adena-extension/src/common/storage/storage-manager.spec.ts
+++ b/packages/adena-extension/src/common/storage/storage-manager.spec.ts
@@ -1,0 +1,38 @@
+import { Storage } from './storage';
+import { StorageManager } from './storage-manager';
+
+describe('StorageManager.get', () => {
+  let mockStorageGet: jest.Mock;
+  let manager: StorageManager;
+
+  beforeEach(() => {
+    mockStorageGet = jest.fn();
+    const mockStorage = {
+      get: mockStorageGet,
+      set: jest.fn(),
+      remove: jest.fn(),
+      clear: jest.fn(),
+    } as unknown as Storage;
+    manager = new StorageManager(mockStorage);
+  });
+
+  it('returns the value coerced to string when present', async () => {
+    mockStorageGet.mockResolvedValue('hello');
+    expect(await manager.get('KEY')).toBe('hello');
+  });
+
+  it('returns an empty string when the value is undefined', async () => {
+    mockStorageGet.mockResolvedValue(undefined);
+    expect(await manager.get('KEY')).toBe('');
+  });
+
+  it('returns an empty string when the value is null', async () => {
+    mockStorageGet.mockResolvedValue(null);
+    expect(await manager.get('KEY')).toBe('');
+  });
+
+  it('coerces numeric values to strings', async () => {
+    mockStorageGet.mockResolvedValue(123);
+    expect(await manager.get('KEY')).toBe('123');
+  });
+});

--- a/packages/adena-extension/src/common/storage/storage-manager.ts
+++ b/packages/adena-extension/src/common/storage/storage-manager.ts
@@ -12,6 +12,9 @@ export class StorageManager<T extends string = string> {
 
   get = async (valueType: T): Promise<string> => {
     const value = await this.storage.get(valueType);
+    if (value === undefined || value === null) {
+      return '';
+    }
     return `${value}`;
   };
 

--- a/packages/adena-extension/src/repositories/wallet/wallet.spec.ts
+++ b/packages/adena-extension/src/repositories/wallet/wallet.spec.ts
@@ -1,0 +1,72 @@
+import { StorageManager } from '@common/storage/storage-manager';
+import { WalletRepository } from './wallet';
+
+describe('WalletRepository.getKdfSalt', () => {
+  let mockGet: jest.Mock;
+  let mockSet: jest.Mock;
+  let mockRemove: jest.Mock;
+  let repository: WalletRepository;
+
+  beforeEach(() => {
+    mockGet = jest.fn();
+    mockSet = jest.fn();
+    mockRemove = jest.fn();
+    const mockLocalStorage = {
+      get: mockGet,
+      set: mockSet,
+      remove: mockRemove,
+    } as unknown as StorageManager;
+    const mockSessionStorage = {} as unknown as StorageManager;
+    repository = new WalletRepository(mockLocalStorage, mockSessionStorage);
+  });
+
+  it('returns null when KDF_SALT is missing (empty string)', async () => {
+    mockGet.mockResolvedValue('');
+    expect(await repository.getKdfSalt()).toBeNull();
+  });
+
+  it('returns null when KDF_SALT is the literal "undefined" string', async () => {
+    // Regression: StorageManager used to coerce undefined to "undefined".
+    // base64-decoding "undefined" produces a 6-byte buffer which would
+    // trip libsodium's 16-byte salt requirement.
+    mockGet.mockResolvedValue('undefined');
+    expect(await repository.getKdfSalt()).toBeNull();
+  });
+
+  it('returns null when the decoded salt is not exactly 16 bytes', async () => {
+    const eightBytesB64 = Buffer.from(new Uint8Array(8)).toString('base64');
+    mockGet.mockResolvedValue(eightBytesB64);
+    expect(await repository.getKdfSalt()).toBeNull();
+  });
+
+  it('returns the Uint8Array when the salt is exactly 16 bytes', async () => {
+    const salt = new Uint8Array(16);
+    salt.fill(7);
+    mockGet.mockResolvedValue(Buffer.from(salt).toString('base64'));
+
+    const result = await repository.getKdfSalt();
+
+    expect(result).not.toBeNull();
+    expect(result?.length).toBe(16);
+    expect(Array.from(result as Uint8Array)).toEqual(Array.from(salt));
+  });
+});
+
+describe('WalletRepository.deleteKdfSalt', () => {
+  it('removes the KDF_SALT key from local storage', async () => {
+    const mockRemove = jest.fn();
+    const mockLocalStorage = {
+      get: jest.fn(),
+      set: jest.fn(),
+      remove: mockRemove,
+    } as unknown as StorageManager;
+    const repository = new WalletRepository(
+      mockLocalStorage,
+      {} as unknown as StorageManager,
+    );
+
+    await repository.deleteKdfSalt();
+
+    expect(mockRemove).toHaveBeenCalledWith('KDF_SALT');
+  });
+});

--- a/packages/adena-extension/src/repositories/wallet/wallet.ts
+++ b/packages/adena-extension/src/repositories/wallet/wallet.ts
@@ -183,11 +183,23 @@ export class WalletRepository {
     if (!saltB64) {
       return null;
     }
-    return Uint8Array.from(Buffer.from(saltB64, 'base64'));
+    const salt = Uint8Array.from(Buffer.from(saltB64, 'base64'));
+    // Argon2id requires exactly 16-byte salts. Treat any other length
+    // (including corrupted base64 like the literal "undefined" string)
+    // as missing so saveWallet generates a fresh salt.
+    if (salt.length !== 16) {
+      return null;
+    }
+    return salt;
   };
 
   public updateKdfSalt = async (salt: Uint8Array): Promise<void> => {
     await this.localStorage.set('KDF_SALT', Buffer.from(salt).toString('base64'));
+  };
+
+  public deleteKdfSalt = async (): Promise<boolean> => {
+    await this.localStorage.remove('KDF_SALT');
+    return true;
   };
 
   public migrate = async (password: string): Promise<void> => {

--- a/packages/adena-extension/src/services/wallet/wallet.ts
+++ b/packages/adena-extension/src/services/wallet/wallet.ts
@@ -336,6 +336,7 @@ export class WalletService {
   public clear = async (): Promise<boolean> => {
     await this.walletRepository.deleteSerializedWallet();
     await this.walletRepository.deleteWalletPassword();
+    await this.walletRepository.deleteKdfSalt();
     try {
       chrome?.action?.setPopup({ popup: '' });
     } catch (e) {


### PR DESCRIPTION
## Summary
- Resolves a crash where `libsodium`'s Argon2id rejected the salt with "invalid salt length" during new-wallet creation
- The crash surfaced for users upgrading from v1.18.1 with existing wallet data who then went through Forgot Password or Wallet Reset before unlocking with their old password

## Root Cause
- `StorageManager.get` coerced `undefined` storage values to the literal string `"undefined"` via `` `${value}` ``
- `WalletRepository.getKdfSalt` accepted that string, base64-decoded it into a 6-byte buffer, and handed it to `Argon2id.execute`, which requires exactly 16 bytes
- The KDF_SALT key was never written because the v018 migration rolled back when invoked without a password (existing SERIALIZED could not be re-encrypted)

## Changes
- `StorageManager.get` returns an empty string for `undefined`/`null` values instead of the corresponding literals
- `WalletRepository.getKdfSalt` returns `null` when the decoded salt is not exactly 16 bytes, so `saveWallet` falls back to generating a fresh salt
- `WalletRepository` exposes `deleteKdfSalt`, and `WalletService.clear` removes the KDF_SALT key so wallet reset leaves no orphaned salt
- Unit tests cover the `"undefined"` regression, invalid lengths, and the new delete method

## Test plan
- [ ] `npx jest src/common/storage src/repositories/wallet src/services/wallet` passes
- [ ] Install v1.18.1, create accounts, upgrade to this build, choose Forgot Password → Next, enter a seed phrase, set a new password → wallet creation succeeds
- [ ] Same upgrade path but via Wallet Reset → create new account → succeeds
- [ ] Fresh install on this build still creates a wallet without regression