### PR TITLE
fix(ADN-783): prevent duplicate word indexes in seed phrase verification

### DIFF
--- a/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.spec.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.spec.tsx
@@ -1,0 +1,48 @@
+import { pickTwoDistinctIndexes } from './validate-mnemonic-step';
+
+describe('pickTwoDistinctIndexes', () => {
+  afterEach(() => {
+    jest.spyOn(Math, 'random').mockRestore();
+  });
+
+  it('returns two distinct indexes', () => {
+    for (let i = 0; i < 100; i++) {
+      const [a, b] = pickTwoDistinctIndexes(12);
+      expect(a).not.toBe(b);
+      expect(a).toBeGreaterThanOrEqual(0);
+      expect(a).toBeLessThan(12);
+      expect(b).toBeGreaterThanOrEqual(0);
+      expect(b).toBeLessThan(12);
+    }
+  });
+
+  it('returns indexes in ascending order', () => {
+    for (let i = 0; i < 100; i++) {
+      const [a, b] = pickTwoDistinctIndexes(12);
+      expect(a).toBeLessThan(b);
+    }
+  });
+
+  it('shifts the second index when the raw draw would collide with the first', () => {
+    // Math.random sequence: 0.5 (first index → 6), 0.5 (second raw → 5,
+    // shifted to 6+1=7 because 5 < 6 is false... wait 5 < 6 is true).
+    // Use clearer values: first = 0.0 → 0, second raw = 0.0 → 0, shifted to 1.
+    const spy = jest.spyOn(Math, 'random');
+    spy.mockReturnValueOnce(0);
+    spy.mockReturnValueOnce(0);
+    expect(pickTwoDistinctIndexes(12)).toEqual([0, 1]);
+  });
+
+  it('keeps the second index unchanged when it is already below the first', () => {
+    const spy = jest.spyOn(Math, 'random');
+    // first = 0.5 → 6, second raw = 0.0 → 0, 0 < 6 so no shift → [0, 6]
+    spy.mockReturnValueOnce(0.5);
+    spy.mockReturnValueOnce(0);
+    expect(pickTwoDistinctIndexes(12)).toEqual([0, 6]);
+  });
+
+  it('throws when total is less than 2', () => {
+    expect(() => pickTwoDistinctIndexes(1)).toThrow();
+    expect(() => pickTwoDistinctIndexes(0)).toThrow();
+  });
+});

--- a/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.tsx
+++ b/packages/adena-extension/src/pages/web/wallet-create-screen/validate-mnemonic-step.tsx
@@ -12,6 +12,21 @@ const StyledContainer = styled(View)`
   row-gap: 24px;
 `;
 
+// Uniformly samples two distinct indexes from [0, total). Equivalent to
+// picking a random pair from C(total, 2) — the second index is drawn from
+// the remaining (total - 1) slots and shifted past the first when needed.
+export const pickTwoDistinctIndexes = (total: number): number[] => {
+  if (total < 2) {
+    throw new Error('pickTwoDistinctIndexes requires total >= 2');
+  }
+  const first = Math.floor(Math.random() * total);
+  let second = Math.floor(Math.random() * (total - 1));
+  if (second >= first) {
+    second += 1;
+  }
+  return [first, second].sort((a, b) => a - b);
+};
+
 const ValidateMnemonicStep = ({
   useWalletCreateScreenReturn,
 }: {
@@ -72,10 +87,7 @@ const ValidateMnemonicStep = ({
     setSecondSeedError(false);
   }, []);
   useEffect(() => {
-    const randomIndexes = Array.from({ length: 2 }, () => Math.floor(Math.random() * 12)).sort(
-      (a, b) => a - b,
-    );
-    setValidateSeedIndexes(randomIndexes);
+    setValidateSeedIndexes(pickTwoDistinctIndexes(12));
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- The seed phrase verification step on the create-wallet screen could ask the same word position twice (~8.3% probability)
- Two random indexes were drawn independently from \`[0, 12)\` with no dedup check; \`sort()\` only reorders values, it doesn't deduplicate

## Root Cause
\`\`\`ts
const randomIndexes = Array
  .from({ length: 2 }, () => Math.floor(Math.random() * 12))
  .sort((a, b) => a - b);
\`\`\`
Both draws sample from the same uniform distribution, so \`P(collision) = 1/12\`.

## Changes
- Extract a \`pickTwoDistinctIndexes(total)\` helper that samples the second index from \`[0, total - 1)\` and shifts past the first index on collision. This yields a uniform distribution over all \`C(total, 2)\` pairs with exactly two RNG calls (no rejection sampling)
- Add unit tests for distinctness, ascending order, both shift / no-shift branches, and the \`total < 2\` guard

## Test plan
- [ ] \`npx jest src/pages/web/wallet-create-screen/validate-mnemonic-step.spec.tsx\` passes
- [ ] Manual: run the create-wallet flow on the web onboarding multiple times; the verification screen never requests the same word position twice