### PR TITLE
chore: bump package version to v1.19.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adena-wallet",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "description": "Adena Wallet",
   "license": "Adena License",
   "private": true,

--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adena-extension",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "private": true,
   "description": "Adena is a friendly browser extension wallet for the Gno.land blockchain.",
   "scripts": {

--- a/packages/adena-extension/public/manifest.json
+++ b/packages/adena-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Adena",
   "description": "Adena is a friendly browser extension wallet for the gno.land blockchain.",
   "manifest_version": 3,
-  "version": "1.19.3",
+  "version": "1.19.4",
   "action": {
     "default_icon": {
       "16": "icons/icon16.png",

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adena-module",
   "private": true,
-  "version": "1.19.3",
+  "version": "1.19.4",
   "description": "Adena's Wallet",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
## Summary
- Bump package version from `1.19.3` to `1.19.4` across the monorepo (`package.json`, `packages/adena-extension/package.json`, `packages/adena-extension/public/manifest.json`, `packages/adena-module/package.json`).

## Included since v1.19.3
- feat(ADN-780): default fresh installs to Testnet Mode with test-13 (#849)
- fix(ADN-782): prevent "invalid salt length" when KDF_SALT is missing (#850)
- fix(ADN-783): prevent duplicate word indexes in seed phrase verification (#851)

## Test plan
- [ ] `npm install` succeeds at the repo root with the new version
- [ ] Build the extension and verify the loaded `manifest.json` reports `1.19.4`
- [ ] Confirm the about/version surface in the UI shows `1.19.4`