### PR TITLE
feat(ADN-744): Chrome Side Panel support

### DIFF
--- a/packages/adena-extension/public/manifest.json
+++ b/packages/adena-extension/public/manifest.json
@@ -3,6 +3,7 @@
   "description": "Adena is a friendly browser extension wallet for the gno.land blockchain.",
   "manifest_version": 3,
   "version": "1.19.4",
+  "minimum_chrome_version": "115",
   "action": {
     "default_icon": {
       "16": "icons/icon16.png",
@@ -10,10 +11,13 @@
     },
     "default_title": "Adena"
   },
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["unlimitedStorage", "storage", "tabs", "alarms", "notifications"],
+  "permissions": ["unlimitedStorage", "storage", "tabs", "alarms", "notifications", "sidePanel"],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/packages/adena-extension/public/sidepanel.html
+++ b/packages/adena-extension/public/sidepanel.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Adena Side Panel</title>
+    <meta charset="utf-8" />
+    <link href="/resources/fonts/inter.css" rel="stylesheet" type="text/css" />
+    <style>
+      html,
+      body {
+        background-color: #212128;
+        overflow-y: auto;
+        scroll-behavior: auto;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="popup"></div>
+    <div id="portal-root">
+      <div id="portal-popup"></div>
+    </div>
+  </body>
+</html>

--- a/packages/adena-extension/src/App/use-app.ts
+++ b/packages/adena-extension/src/App/use-app.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect } from 'react';
 import { useIdleTimer } from 'react-idle-timer';
 import { useLocation } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import { isAutoLockTriggeredMessage } from '@common/utils/auto-lock-timer';
 import { CommandMessage } from '@inject/message/command-message';
@@ -12,6 +13,7 @@ import { useNetwork } from '@hooks/use-network';
 import useScrollHistory from '@hooks/use-scroll-history';
 import { useTokenMetainfo } from '@hooks/use-token-metainfo';
 import { useWallet } from '@hooks/use-wallet';
+import { EstablishState } from '@states';
 
 const useApp = (): void => {
   const { wallet } = useWalletContext();
@@ -23,10 +25,11 @@ const useApp = (): void => {
   const { scrollMove } = useScrollHistory();
   const { lockedWallet } = useWallet();
   const queryClient = useQueryClient();
+  const setEstablishRevision = useSetRecoilState(EstablishState.establishRevisionState);
 
   // Listen for the AUTO_LOCK_TRIGGERED broadcast from background. Without
   // this, the popup keeps rendering the unlocked screen until the next user
-  // interaction nudges react-query to refetch — invalidating the cached
+  // interaction nudges react-query to refetch. Invalidating the cached
   // `wallet/locked` query forces an immediate re-evaluation, which the
   // existing routing logic in use-init-wallet picks up.
   useEffect(() => {
@@ -41,10 +44,24 @@ const useApp = (): void => {
     };
   }, [queryClient]);
 
+  useEffect(() => {
+    if (!chrome.storage?.onChanged) return;
+    const listener = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string,
+    ): void => {
+      if (areaName === 'local' && changes.ADENA_DATA) {
+        setEstablishRevision((value) => value + 1);
+      }
+    };
+    chrome.storage.onChanged.addListener(listener);
+    return (): void => {
+      chrome.storage.onChanged.removeListener(listener);
+    };
+  }, [setEstablishRevision]);
+
   const sendActivityPing = useCallback(() => {
-    chrome.runtime
-      .sendMessage(CommandMessage.command('resetAutoLockTimer'))
-      .catch(() => undefined);
+    chrome.runtime.sendMessage(CommandMessage.command('resetAutoLockTimer')).catch(() => undefined);
   }, []);
 
   // Send an activity ping whenever a real user input is detected. The throttle
@@ -57,7 +74,7 @@ const useApp = (): void => {
   });
 
   // Mounting any UI surface (popup, separate window, web page) counts as
-  // activity, so reset the timer on first render too — otherwise a user who
+  // activity, so reset the timer on first render too. Otherwise a user who
   // opens the popup without moving the mouse would see no reset event.
   useEffect(() => {
     if (lockedWallet === false) {

--- a/packages/adena-extension/src/background.ts
+++ b/packages/adena-extension/src/background.ts
@@ -105,6 +105,20 @@ interface GetAllGnoSessionsMessage {
   type: 'GET_ALL_GNO_SESSIONS';
 }
 
+interface SetSidePanelModeMessage {
+  type: 'SET_SIDE_PANEL_MODE';
+  enabled: boolean;
+}
+
+function isSetSidePanelModeMessage(message: unknown): message is SetSidePanelModeMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    (message as SetSidePanelModeMessage).type === 'SET_SIDE_PANEL_MODE' &&
+    typeof (message as SetSidePanelModeMessage).enabled === 'boolean'
+  );
+}
+
 function isGetGnoSessionMessage(message: unknown): message is GetGnoSessionMessage {
   return (
     typeof message === 'object' &&
@@ -294,10 +308,33 @@ function existsWallet(): Promise<boolean> {
     .catch(() => false);
 }
 
-function setupPopup(existWallet: boolean): boolean {
+async function handleSetSidePanelMode({
+  enabled,
+}: SetSidePanelModeMessage): Promise<{ success: boolean }> {
+  if (!chrome.sidePanel) return { success: false };
+
+  await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: enabled });
+
+  if (enabled) {
+    chrome.action.setPopup({ popup: '' });
+  } else {
+    const exist = await existsWallet();
+    chrome.action.setPopup({ popup: exist ? 'popup.html' : '' });
+  }
+
+  return { success: true };
+}
+
+async function isSidePanelModeActive(): Promise<boolean> {
+  if (!chrome.sidePanel?.getPanelBehavior) return false;
+  const behavior = await chrome.sidePanel.getPanelBehavior();
+  return behavior.openPanelOnActionClick === true;
+}
+
+async function setupPopup(existWallet: boolean): Promise<void> {
+  if (await isSidePanelModeActive()) return;
   const popupUri = existWallet ? 'popup.html' : '';
   chrome.action.setPopup({ popup: popupUri });
-  return true;
 }
 
 chrome.runtime.onInstalled.addListener((details) => {
@@ -306,27 +343,22 @@ chrome.runtime.onInstalled.addListener((details) => {
       url: chrome.runtime.getURL('/register.html'),
     });
   } else if (details.reason === 'update') {
-    existsWallet().then((existWallet) => {
-      setupPopup(existWallet);
-    });
+    existsWallet().then(setupPopup).catch(console.warn);
   }
 });
 
 chrome.tabs.onCreated.addListener(() => {
-  existsWallet().then((existWallet) => {
-    setupPopup(existWallet);
-  });
+  existsWallet().then(setupPopup).catch(console.warn);
 });
 
 chrome.action.onClicked.addListener(async () => {
-  existsWallet().then((existWallet) => {
-    setupPopup(existWallet);
-    if (!existWallet) {
-      chrome.tabs.create({
-        url: chrome.runtime.getURL('/register.html'),
-      });
-    }
-  });
+  const existWallet = await existsWallet();
+  await setupPopup(existWallet);
+  if (!existWallet) {
+    chrome.tabs.create({
+      url: chrome.runtime.getURL('/register.html'),
+    });
+  }
 });
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
@@ -340,10 +372,8 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
         await clearInMemoryKey(inMemoryProvider);
         // Tell any open UI surface that auto-lock just fired so it can
         // invalidate cached lock state and route to Login immediately.
-        // The send rejects when no UI is listening — that's expected.
-        chrome.runtime
-          .sendMessage({ type: AUTO_LOCK_TRIGGERED_MESSAGE })
-          .catch(() => undefined);
+        // The send rejects when no UI is listening, which is expected.
+        chrome.runtime.sendMessage({ type: AUTO_LOCK_TRIGGERED_MESSAGE }).catch(() => undefined);
         console.info('Auto-lock fired');
         break;
       default:
@@ -427,6 +457,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (isGetAllGnoSessionsMessage(message)) {
     const sessions = handleGetAllGnoSessions();
     sendResponse(sessions);
+    return true;
+  }
+
+  if (isSetSidePanelModeMessage(message)) {
+    handleSetSidePanelMode(message).then(sendResponse).catch(console.warn);
     return true;
   }
 

--- a/packages/adena-extension/src/common/storage/chrome-local-storage.ts
+++ b/packages/adena-extension/src/common/storage/chrome-local-storage.ts
@@ -71,6 +71,14 @@ export class ChromeLocalStorage implements Storage {
     }
     this.storage = chrome.storage.local;
     this.migrator = new StorageMigrator(StorageMigrator.migrations(), this.storage);
+
+    if (chrome.storage.onChanged) {
+      chrome.storage.onChanged.addListener((changes, areaName) => {
+        if (areaName === 'local' && changes[ChromeLocalStorage.StorageKey]) {
+          this.current = null;
+        }
+      });
+    }
   }
 
   public get = async (key: string): Promise<any> => {

--- a/packages/adena-extension/src/pages/popup/certify/connected-apps/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/connected-apps/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import styled, { useTheme } from 'styled-components';
 
 import disconnected from '@assets/disconnected.svg';
@@ -10,7 +10,7 @@ import useAppNavigate from '@hooks/use-app-navigate';
 import { useAdenaContext } from '@hooks/use-context';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { EstablishSite } from '@repositories/wallet';
-import { WalletState } from '@states';
+import { EstablishState, WalletState } from '@states';
 import mixins from '@styles/mixins';
 import { getTheme } from '@styles/theme';
 
@@ -26,21 +26,18 @@ export const ConnectedApps = (): JSX.Element => {
   const { goBack } = useAppNavigate();
   const [state] = useRecoilState(WalletState.state);
   const [data, setData] = useState<EnrichedSite[]>([]);
+  const establishRevision = useRecoilValue(EstablishState.establishRevisionState);
 
   useEffect(() => {
     updateData();
-  }, []);
+  }, [establishRevision]);
 
   const onClickDisconnect = async (item: EnrichedSite): Promise<void> => {
     if (!currentAccount) {
       return;
     }
     if (item.source === 'cosmos') {
-      await establishAtomOneService.unEstablishBy(
-        currentAccount.id,
-        item.hostname,
-        item.chainId,
-      );
+      await establishAtomOneService.unEstablishBy(currentAccount.id, item.hostname, item.chainId);
     } else {
       await establishService.unEstablishBy(currentAccount.id, item.hostname);
     }

--- a/packages/adena-extension/src/pages/popup/certify/settings/index.tsx
+++ b/packages/adena-extension/src/pages/popup/certify/settings/index.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { FullButtonRightIcon } from '@components/atoms';
+import { FullButtonRightIcon, Text } from '@components/atoms';
 import { IconName } from '@components/atoms/icon';
+import Toggle from '@components/atoms/toggle';
 import { BottomFixedButton } from '@components/molecules';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import useAppNavigate from '@hooks/use-app-navigate';
@@ -54,6 +55,49 @@ export const Settings = (): JSX.Element => {
   const { walletService } = useAdenaContext();
   const { clearWallet } = useWalletContext();
   const { loadAccounts } = useLoadAccounts();
+  const [isSidePanelOn, setIsSidePanelOn] = useState(false);
+  const [supportsSidePanel] = useState(
+    () => typeof chrome !== 'undefined' && Boolean(chrome.sidePanel?.getPanelBehavior),
+  );
+  const [activeTabId, setActiveTabId] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!supportsSidePanel || !chrome.sidePanel?.getPanelBehavior) return;
+    chrome.sidePanel
+      .getPanelBehavior()
+      .then((behavior) => {
+        setIsSidePanelOn(behavior.openPanelOnActionClick ?? false);
+      })
+      .catch(() => undefined);
+  }, [supportsSidePanel]);
+
+  useEffect(() => {
+    if (!supportsSidePanel) return;
+    chrome.tabs
+      .query({ active: true, lastFocusedWindow: true })
+      .then((tabs) => {
+        if (tabs[0]?.id !== undefined) setActiveTabId(tabs[0].id);
+      })
+      .catch(() => undefined);
+  }, [supportsSidePanel]);
+
+  const onToggleSidePanel = useCallback(
+    (activated: boolean) => {
+      setIsSidePanelOn(activated);
+
+      if (activated && activeTabId !== undefined && chrome.sidePanel?.open) {
+        chrome.sidePanel.open({ tabId: activeTabId }).catch(() => undefined);
+      }
+
+      chrome.runtime
+        .sendMessage({ type: 'SET_SIDE_PANEL_MODE', enabled: activated })
+        .catch(() => undefined)
+        .finally(() => {
+          window.close();
+        });
+    },
+    [activeTabId],
+  );
 
   const onClickLockWallet = useCallback(async () => {
     await walletService.lockWallet();
@@ -79,6 +123,14 @@ export const Settings = (): JSX.Element => {
         onClick={onClickLockWallet}
       />
       <Divider />
+      {supportsSidePanel && (
+        <SidePanelRow>
+          <SidePanelLabel>
+            <Text type='body1Bold'>Use Side Panel</Text>
+          </SidePanelLabel>
+          <Toggle activated={isSidePanelOn} onToggle={onToggleSidePanel} />
+        </SidePanelRow>
+      )}
       {menuMakerInfo.map((v, i) => (
         <FullButtonRightIcon
           key={i}
@@ -115,4 +167,18 @@ const Divider = styled.div`
   height: 1px;
   background-color: ${getTheme('neutral', 'b')};
   margin: 12px 0;
+`;
+
+const SidePanelRow = styled.div`
+  ${mixins.flex({ direction: 'row', justify: 'space-between', align: 'center' })};
+  width: 100%;
+  height: 54px;
+  padding: 0px 24px 0px 20px;
+  border-radius: 18px;
+  background-color: ${getTheme('neutral', '_7')};
+  margin-bottom: 12px;
+`;
+
+const SidePanelLabel = styled.div`
+  ${mixins.flex({ direction: 'row', align: 'center' })};
 `;

--- a/packages/adena-extension/src/router/popup/header/approve-menu/index.tsx
+++ b/packages/adena-extension/src/router/popup/header/approve-menu/index.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import { RoutePath } from '@types';
 import { getTheme } from '@styles/theme';
 import mixins from '@styles/mixins';
-import {
-  AccountSelectorButton,
-  NetworkIconButton,
-} from '@components/atoms';
+import { AccountSelectorButton, NetworkIconButton } from '@components/atoms';
 import IconCopy from '@assets/icon-copy';
 import { AccountAddressesPopover } from '@components/pages/router/top-menu/account-addresses-popover';
 import {
@@ -22,6 +20,7 @@ import { useAdenaContext } from '@hooks/use-context';
 import { useAccountName } from '@hooks/use-account-name';
 import { useAccountChainAddresses } from '@hooks/use-account-chain-addresses';
 import { useNetwork } from '@hooks/use-network';
+import { EstablishState } from '@states';
 
 const COSMOS_APPROVE_PATHS: string[] = [
   RoutePath.ApproveEstablishCosmos,
@@ -108,6 +107,7 @@ const ApproveMenu = (): JSX.Element => {
   const [popoverY, setPopoverY] = useState(0);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const chainAddressEntries = useAccountChainAddresses();
+  const establishRevision = useRecoilValue(EstablishState.establishRevisionState);
 
   useEffect(() => {
     if (location.search) {
@@ -120,7 +120,7 @@ const ApproveMenu = (): JSX.Element => {
     if (requestData) {
       updateEstablishState();
     }
-  }, [requestData, currentAccount, currentNetwork]);
+  }, [requestData, currentAccount, currentNetwork, establishRevision]);
 
   useEffect(() => {
     if (!currentAccount) return;

--- a/packages/adena-extension/src/router/popup/header/top-menu/index.tsx
+++ b/packages/adena-extension/src/router/popup/header/top-menu/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import {
@@ -19,6 +20,7 @@ import { useAccountChainAddresses } from '@hooks/use-account-chain-addresses';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { AccountAddressesPopover } from '@components/pages/router/top-menu/account-addresses-popover';
 import UnresponsiveNetworksIndicator from '@router/popup/header/unresponsive-networks-indicator';
+import { EstablishState } from '@states';
 import mixins from '@styles/mixins';
 import { RoutePath } from '@types';
 
@@ -112,6 +114,7 @@ export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
   const [currentAccountName, setCurrentAccountName] = useState('');
   const { accountNames } = useAccountName();
   const { currentNetwork, unresponsiveNetworks } = useNetwork();
+  const establishRevision = useRecoilValue(EstablishState.establishRevisionState);
 
   const copyButtonRef = useRef<HTMLButtonElement>(null);
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -167,7 +170,7 @@ export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
 
   useEffect(() => {
     initAccountInfo();
-  }, [currentAccount, hostname, accountNames]);
+  }, [currentAccount, hostname, accountNames, establishRevision]);
 
   useEffect(() => {
     getCurrentUrl().then(async (currentUrl) => {
@@ -182,7 +185,7 @@ export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
 
   useEffect(() => {
     updateEstablished();
-  }, [location.pathname, hostname, currentAccount, currentNetwork]);
+  }, [location.pathname, hostname, currentAccount, currentNetwork, establishRevision]);
 
   const initAccountInfo = async (): Promise<void> => {
     if (!currentAccount) {

--- a/packages/adena-extension/src/sidepanel.tsx
+++ b/packages/adena-extension/src/sidepanel.tsx
@@ -1,0 +1,10 @@
+import * as ReactDOM from 'react-dom/client';
+
+import App from './App/popup';
+
+const mountNode = document.getElementById('popup');
+if (mountNode) {
+  const root = ReactDOM.createRoot(mountNode);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  root.render((<App />) as any);
+}

--- a/packages/adena-extension/src/states/establish.ts
+++ b/packages/adena-extension/src/states/establish.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const establishRevisionState = atom<number>({
+  key: 'establishRevision',
+  default: 0,
+});

--- a/packages/adena-extension/src/states/index.ts
+++ b/packages/adena-extension/src/states/index.ts
@@ -1,6 +1,7 @@
 export * as AccountState from './account';
 export * as BalanceState from './balance';
 export * as CommonState from './common';
+export * as EstablishState from './establish';
 export * as ExploreState from './explore';
 export * as NetworkState from './network';
 export * as TokenState from './token';

--- a/packages/adena-extension/webpack.config.js
+++ b/packages/adena-extension/webpack.config.js
@@ -12,6 +12,7 @@ const config = {
   entry: {
     web: path.join(__dirname, './src/web.tsx'),
     popup: path.join(__dirname, './src/popup.tsx'),
+    sidepanel: path.join(__dirname, './src/sidepanel.tsx'),
     content: path.join(__dirname, './src/content.ts'),
     background: path.join(__dirname, './src/background.ts'),
     inject: path.join(__dirname, './src/inject.ts'),
@@ -120,6 +121,11 @@ const config = {
       template: './public/popup.html',
       chunks: ['popup'],
       filename: 'popup.html',
+    }),
+    new HtmlWebPackPlugin({
+      template: './public/sidepanel.html',
+      chunks: ['sidepanel'],
+      filename: 'sidepanel.html',
     }),
     new NodePolyfillPlugin(),
     new ProvidePlugin({


### PR DESCRIPTION
## Summary

Add opt-in Chrome Side Panel support so users can keep the wallet open in
the browser side panel instead of the transient action popup.

- **Side panel surface**: new `sidepanel` webpack entry + HTML template,
  `side_panel` declaration and `sidePanel` permission in the manifest, and
  `minimum_chrome_version: 115` for the Side Panel API. The panel reuses the
  existing popup `App`.
- **Background**: a `SET_SIDE_PANEL_MODE` message toggles
  `openPanelOnActionClick` and clears the action popup when side panel mode
  is on. `setupPopup` is now async and skips popup setup while side panel
  mode is active, so clicking the toolbar icon opens the panel.
- **Settings UI**: a "Use Side Panel" toggle appears when the Side Panel API
  is available. It reflects the current panel behavior, opens the panel for
  the active tab when enabled, and notifies the background of the change.
- **State sync**: a long-lived side panel must not show stale data. A new
  `establishRevision` atom is bumped on `chrome.storage.local` `ADENA_DATA`
  changes; the connected-apps, approve and top menus depend on it to refresh
  established-site state. `ChromeLocalStorage` also invalidates its in-memory
  cache on the same change so reads stay consistent across surfaces.

## Test plan

- [ ] On Chrome 115+, enable the "Use Side Panel" toggle in Settings: the
      panel opens and clicking the toolbar icon thereafter opens the panel.
- [ ] Disable the toggle: the toolbar icon falls back to the popup.
- [ ] Connect/disconnect a site in one surface and confirm the connected-apps
      list and header menus update in an already-open side panel.
- [ ] On Chrome < 115 (or no Side Panel API), the toggle is hidden and popup
      behavior is unchanged.