### PR TITLE
chore: update test-13 RPC endpoint

### DIFF
--- a/packages/adena-extension/src/migrates/migrations/v019/storage-migration-v019.spec.ts
+++ b/packages/adena-extension/src/migrates/migrations/v019/storage-migration-v019.spec.ts
@@ -48,7 +48,7 @@ describe('StorageMigration019', () => {
     const result = await new StorageMigration019().up(makeInput({ NETWORKS: [] }));
     const test13 = result.data.NETWORKS.find((n) => n.chainId === 'test-13');
     expect(test13).toBeDefined();
-    expect(test13?.rpcUrl).toBe('https://rpc.test-13-aeddi-1.gnoland.network:443');
+    expect(test13?.rpcUrl).toBe('https://test13.rpc.onbloc.xyz:443');
     expect(test13?.indexerUrl).toBe('https://indexer.test-13.gnoland.network:443');
   });
 

--- a/packages/adena-extension/src/resources/chains/chains.json
+++ b/packages/adena-extension/src/resources/chains/chains.json
@@ -23,7 +23,7 @@
     "networkId": "test-13",
     "networkName": "Testnet 13",
     "addressPrefix": "g",
-    "rpcUrl": "https://rpc.test-13-aeddi-1.gnoland.network:443",
+    "rpcUrl": "https://test13.rpc.onbloc.xyz:443",
     "indexerUrl": "https://indexer.test-13.gnoland.network:443",
     "gnoUrl": "https://gnoweb.test-13.gnoland.network",
     "apiUrl": "",

--- a/packages/adena-module/src/chain-registry/entries/gno.ts
+++ b/packages/adena-module/src/chain-registry/entries/gno.ts
@@ -52,7 +52,7 @@ export const GNO_TEST13: GnoNetworkProfile = {
   displayName: 'Gno.land Testnet 13',
   isMainnet: false,
   nativeTokenId: 'test-13:ugnot',
-  rpcEndpoints: ['https://rpc.test-13-aeddi-1.gnoland.network:443'],
+  rpcEndpoints: ['https://test13.rpc.onbloc.xyz:443'],
   indexerUrl: 'https://indexer.test-13.gnoland.network:443',
   gnoUrl: 'https://gnoweb.test-13.gnoland.network',
   linkUrl: 'https://gnoscan.io',


### PR DESCRIPTION
## Summary
- Update the Testnet 13 RPC endpoint to https://test13.rpc.onbloc.xyz:443.
- Keep the migration test expectation aligned with chains.json.

## Verification
- LSP diagnostics passed for the changed TypeScript and JSON files.
- Confirmed the old RPC URL no longer appears in the touched files.
- Targeted Jest run was skipped after dependency installation was aborted per request.