### PR TITLE
fix: support gnoconnect tx links on the Local network with a runtime-gated loopback trust

### DIFF
--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.spec.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.spec.ts
@@ -1,47 +1,57 @@
+import {
+  getLoopbackOriginChainId,
+  GNO_CONNECT_ALLOWED_ORIGINS,
+  isLoopbackOrigin,
+} from './gno-connect-allowlist.constant';
+
 describe('GNO_CONNECT_ALLOWED_ORIGINS', () => {
-  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
-
-  afterEach(() => {
-    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
-  });
-
-  const loadAllowlist = (): readonly string[] => {
-    let result: readonly string[] = [];
-    jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      result = require('./gno-connect-allowlist.constant').GNO_CONNECT_ALLOWED_ORIGINS;
-    });
-    return result;
-  };
-
-  it('trusts exactly the gnoUrl origins declared in chains.json', () => {
-    const result = loadAllowlist();
-
-    expect(result).toEqual(
+  it('statically trusts every https gnoUrl origin declared in chains.json', () => {
+    expect(GNO_CONNECT_ALLOWED_ORIGINS).toEqual(
       expect.arrayContaining([
         'https://gno.land',
         'https://betanet.testnets.gno.land',
         'https://staging.gno.land',
         'https://test13.testnets.gno.land',
-        'http://127.0.0.1:8888',
       ]),
     );
   });
 
-  it('trusts the local (loopback) origin regardless of build mode', () => {
-    // The Local network must support gnoconnect txlinks even in production builds.
-    process.env.NODE_ENV = 'production';
-    const prodResult = loadAllowlist();
-    process.env.NODE_ENV = 'development';
-    const devResult = loadAllowlist();
-
-    expect(prodResult).toContain('http://127.0.0.1:8888');
-    expect(new Set(prodResult)).toEqual(new Set(devResult));
+  it('never statically trusts a loopback origin', () => {
+    // Loopback origins are gated at runtime against the wallet's active network,
+    // so they must not appear in the unconditional allowlist.
+    expect(GNO_CONNECT_ALLOWED_ORIGINS.some((origin) => isLoopbackOrigin(origin))).toBe(false);
+    expect(GNO_CONNECT_ALLOWED_ORIGINS).not.toContain('http://127.0.0.1:8888');
   });
 
   it('contains no duplicates', () => {
-    const result = loadAllowlist();
+    expect(new Set(GNO_CONNECT_ALLOWED_ORIGINS).size).toBe(GNO_CONNECT_ALLOWED_ORIGINS.length);
+  });
+});
 
-    expect(new Set(result).size).toBe(result.length);
+describe('isLoopbackOrigin', () => {
+  it('recognizes plain-http loopback origins', () => {
+    expect(isLoopbackOrigin('http://127.0.0.1:8888')).toBe(true);
+    expect(isLoopbackOrigin('http://localhost:8888')).toBe(true);
+    expect(isLoopbackOrigin('http://127.0.0.1')).toBe(true);
+  });
+
+  it('rejects non-loopback and https origins', () => {
+    expect(isLoopbackOrigin('https://gno.land')).toBe(false);
+    expect(isLoopbackOrigin('https://127.0.0.1:8888')).toBe(false);
+    expect(isLoopbackOrigin('http://evil.example')).toBe(false);
+    // A loopback host embedded in a larger hostname must not match.
+    expect(isLoopbackOrigin('http://127.0.0.1.evil.example')).toBe(false);
+  });
+});
+
+describe('getLoopbackOriginChainId', () => {
+  it('maps a known loopback origin to the chainId that declares it', () => {
+    expect(getLoopbackOriginChainId('http://127.0.0.1:8888')).toBe('dev');
+  });
+
+  it('returns null for https origins and unknown loopback origins', () => {
+    expect(getLoopbackOriginChainId('https://gno.land')).toBeNull();
+    expect(getLoopbackOriginChainId('http://127.0.0.1:9999')).toBeNull();
+    expect(getLoopbackOriginChainId('http://localhost:8888')).toBeNull();
   });
 });

--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.spec.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.spec.ts
@@ -14,8 +14,7 @@ describe('GNO_CONNECT_ALLOWED_ORIGINS', () => {
     return result;
   };
 
-  it('production build trusts only https chains.json origins, never loopback', () => {
-    process.env.NODE_ENV = 'production';
+  it('trusts exactly the gnoUrl origins declared in chains.json', () => {
     const result = loadAllowlist();
 
     expect(result).toEqual(
@@ -24,29 +23,23 @@ describe('GNO_CONNECT_ALLOWED_ORIGINS', () => {
         'https://betanet.testnets.gno.land',
         'https://staging.gno.land',
         'https://test13.testnets.gno.land',
+        'http://127.0.0.1:8888',
       ]),
     );
-    // In production no loopback origin is trusted: any local process holding the
-    // port could otherwise inject RPC endpoints into the wallet flow.
-    expect(result.filter((url) => url.startsWith('http://'))).toEqual([]);
   });
 
-  it('development build also trusts loopback origins from chains.json', () => {
+  it('trusts the local (loopback) origin regardless of build mode', () => {
+    // The Local network must support gnoconnect txlinks even in production builds.
+    process.env.NODE_ENV = 'production';
+    const prodResult = loadAllowlist();
     process.env.NODE_ENV = 'development';
-    const result = loadAllowlist();
+    const devResult = loadAllowlist();
 
-    expect(result).toEqual(expect.arrayContaining(['https://gno.land', 'http://127.0.0.1:8888']));
-  });
-
-  it('test environment behaves like development (non-production)', () => {
-    process.env.NODE_ENV = 'test';
-    const result = loadAllowlist();
-
-    expect(result).toContain('http://127.0.0.1:8888');
+    expect(prodResult).toContain('http://127.0.0.1:8888');
+    expect(new Set(prodResult)).toEqual(new Set(devResult));
   });
 
   it('contains no duplicates', () => {
-    process.env.NODE_ENV = 'production';
     const result = loadAllowlist();
 
     expect(new Set(result).size).toBe(result.length);

--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
@@ -1,17 +1,13 @@
 import CHAIN_DATA from '@resources/chains/chains.json';
 
+// Loopback local hosts served by local gno nodes speak plain HTTP; every other host
+// is assumed to be reachable over HTTPS.
+export const LOOPBACK_LOCAL_HOST_PATTERN = /^(127\.0\.0\.1|localhost|0\.0\.0\.0|\[::1\])(?::\d+)?$/i;
+
 // dApp origin allowlist for gnoconnect meta-tag RPC injection.
-// Derived from chains.json gnoUrl. Loopback origins (127.0.0.1, localhost)
-// are trusted only in development builds — in production any process
-// holding the local port (other dev servers, malicious postinstall, etc.)
-// could otherwise inject RPC endpoints into the wallet flow.
-const isDevelopmentBuild = process.env.NODE_ENV !== 'production';
-
-const isLoopbackOrigin = (url: string): boolean =>
-  url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost');
-
-export const GNO_CONNECT_ALLOWED_ORIGINS: readonly string[] = CHAIN_DATA.map(
-  (chain) => chain.gnoUrl,
-)
-  .filter((url): url is string => Boolean(url))
-  .filter((url) => url.startsWith('https://') || (isDevelopmentBuild && isLoopbackOrigin(url)));
+// The single source of truth is chains.json
+// Nothing is synthesized or filtered by build mode — to trust another origin
+// (e.g. a local node under a different host or port), add it to chains.json.
+export const GNO_CONNECT_ALLOWED_ORIGINS: readonly string[] = Array.from(
+  new Set(CHAIN_DATA.map((chain) => chain.gnoUrl).filter((url): url is string => Boolean(url))),
+);

--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
@@ -4,10 +4,52 @@ import CHAIN_DATA from '@resources/chains/chains.json';
 // is assumed to be reachable over HTTPS.
 export const LOOPBACK_LOCAL_HOST_PATTERN = /^(127\.0\.0\.1|localhost|0\.0\.0\.0|\[::1\])(?::\d+)?$/i;
 
-// dApp origin allowlist for gnoconnect meta-tag RPC injection.
-// The single source of truth is chains.json
-// Nothing is synthesized or filtered by build mode — to trust another origin
-// (e.g. a local node under a different host or port), add it to chains.json.
+// True when `origin` is a plain-HTTP loopback origin (e.g. http://127.0.0.1:8888).
+export const isLoopbackOrigin = (origin: string): boolean => {
+  const HTTP_PREFIX = 'http://';
+  if (!origin.startsWith(HTTP_PREFIX)) {
+    return false;
+  }
+
+  return LOOPBACK_LOCAL_HOST_PATTERN.test(origin.slice(HTTP_PREFIX.length));
+};
+
+// gnoconnect meta-tag RPC injection is gated by the dApp origin. The single
+// source of truth is chains.json.
+//
+// - Remote (https) gno origins are team-controlled and trusted unconditionally.
+// - Loopback origins (local dev nodes) are NOT statically trusted:
+//   any process that holds the local port could otherwise drive the wallet flow.
+//   They are honored only at runtime, when the wallet's *active* network is the one that
+//   declares them (see getLoopbackOriginChainId + the runtime gate in CommandHandler).
+interface ChainOrigin {
+  origin: string;
+  chainId: string;
+}
+
+const CHAIN_ORIGINS: ChainOrigin[] = CHAIN_DATA.map((chain) => ({
+  origin: chain.gnoUrl,
+  chainId: chain.chainId,
+})).filter((entry): entry is ChainOrigin => Boolean(entry.origin));
+
+// Remote https origins — trusted unconditionally.
 export const GNO_CONNECT_ALLOWED_ORIGINS: readonly string[] = Array.from(
-  new Set(CHAIN_DATA.map((chain) => chain.gnoUrl).filter((url): url is string => Boolean(url))),
+  new Set(
+    CHAIN_ORIGINS.filter(({ origin }) => !isLoopbackOrigin(origin)).map(({ origin }) => origin),
+  ),
 );
+
+// Loopback origin -> the chainId that declares it.
+// Trust is granted only when this chainId matches the wallet's active network
+const LOOPBACK_ORIGIN_CHAIN_IDS: ReadonlyMap<string, string> = new Map(
+  CHAIN_ORIGINS.filter(({ origin }) => isLoopbackOrigin(origin)).map(
+    ({ origin, chainId }) => [origin, chainId] as const,
+  ),
+);
+
+// Returns the chainId a loopback origin may act as, or null
+// if the origin is not a known loopback gno origin.
+// Callers MUST additionally verify this chainId is the wallet's active network
+// before honoring the origin's gnoconnect data.
+export const getLoopbackOriginChainId = (origin: string): string | null =>
+  LOOPBACK_ORIGIN_CHAIN_IDS.get(origin) ?? null;

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -21,6 +21,7 @@ import {
   GnoConnectInfo,
   GnoMessageInfo,
   isAllowedGnoConnectOrigin,
+  isLoopbackGnoConnectTrusted,
   parseGnoConnectInfo,
   parseGnoMessageInfo,
 } from './methods/gno-connect';
@@ -145,17 +146,20 @@ export class CommandHandler {
     }
 
     // Runtime trust gate for loopback origins: only honor a local node's
-    // gnoconnect declarations when the wallet is currently on the matching
-    // network. Prevents an arbitrary process holding the local port from driving
-    // the wallet flow when the user is on another network.
+    // gnoconnect declarations when the meta-declared chainId matches the one the
+    // origin is permitted to act as AND that chainId is the wallet's active network.
+    // This prevents an arbitrary process holding the local port from
+    // switching the wallet to a foreign network or driving the flow while the
+    // user is on another network.
     if (isLoopbackOrigin) {
       const networkResponse = await executor.getNetwork();
       const activeChainId =
         networkResponse.type === WalletResponseSuccessType.GET_NETWORK_SUCCESS
           ? networkResponse.data?.chainId
           : undefined;
-      if (activeChainId !== loopbackChainId) {
-        console.info('Loopback gnoconnect origin is not the active network; ignoring');
+
+      if (!isLoopbackGnoConnectTrusted(loopbackChainId, gnoConnectInfo.chainId, activeChainId)) {
+        console.info('Loopback gnoconnect origin is not trusted for the active network; ignoring');
         return;
       }
     }

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -16,6 +16,7 @@ import {
 } from './commands/encrypt';
 import { clearPopup } from './commands/popup';
 import {
+  getLoopbackGnoConnectChainId,
   GnoArgumentInfo,
   GnoConnectInfo,
   GnoMessageInfo,
@@ -113,7 +114,13 @@ export class CommandHandler {
 
     const currentUrl = window?.location?.href || '';
     const currentOrigin = window?.location?.origin || '';
-    if (!isAllowedGnoConnectOrigin(currentOrigin)) {
+
+    // Remote (https) gno origins are trusted statically. Loopback origins (local
+    // dev nodes) are trusted only after the runtime gate below confirms the
+    // wallet's active network is the one that declares this origin.
+    const loopbackChainId = getLoopbackGnoConnectChainId(currentOrigin);
+    const isLoopbackOrigin = loopbackChainId !== null;
+    if (!isAllowedGnoConnectOrigin(currentOrigin) && !isLoopbackOrigin) {
       return;
     }
 
@@ -135,6 +142,22 @@ export class CommandHandler {
     ) {
       console.info('response: ', addEstablishResponse);
       return;
+    }
+
+    // Runtime trust gate for loopback origins: only honor a local node's
+    // gnoconnect declarations when the wallet is currently on the matching
+    // network. Prevents an arbitrary process holding the local port from driving
+    // the wallet flow when the user is on another network.
+    if (isLoopbackOrigin) {
+      const networkResponse = await executor.getNetwork();
+      const activeChainId =
+        networkResponse.type === WalletResponseSuccessType.GET_NETWORK_SUCCESS
+          ? networkResponse.data?.chainId
+          : undefined;
+      if (activeChainId !== loopbackChainId) {
+        console.info('Loopback gnoconnect origin is not the active network; ignoring');
+        return;
+      }
     }
 
     const switchNetworkResponse = await executor.switchNetwork(gnoConnectInfo.chainId);

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
@@ -1,4 +1,5 @@
 import {
+  getLoopbackGnoConnectChainId,
   GnoMessageInfo,
   isAllowedGnoConnectOrigin,
   normalizeGnoConnectRpc,
@@ -258,6 +259,22 @@ describe('isAllowedGnoConnectOrigin', () => {
 
   it('rejects subdomain takeover patterns', () => {
     expect(isAllowedGnoConnectOrigin('https://malicious.gno.land')).toBe(false);
+  });
+
+  it('never statically trusts loopback origins', () => {
+    expect(isAllowedGnoConnectOrigin('http://127.0.0.1:8888')).toBe(false);
+    expect(isAllowedGnoConnectOrigin('http://localhost:8888')).toBe(false);
+  });
+});
+
+describe('getLoopbackGnoConnectChainId', () => {
+  it('returns the chainId a known loopback origin may act as', () => {
+    expect(getLoopbackGnoConnectChainId('http://127.0.0.1:8888')).toBe('dev');
+  });
+
+  it('returns null for non-loopback or unknown origins', () => {
+    expect(getLoopbackGnoConnectChainId('https://gno.land')).toBeNull();
+    expect(getLoopbackGnoConnectChainId('http://127.0.0.1:9999')).toBeNull();
   });
 });
 

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
@@ -1,6 +1,7 @@
 import {
   GnoMessageInfo,
   isAllowedGnoConnectOrigin,
+  normalizeGnoConnectRpc,
   parseGnoMessageInfo,
 } from './gno-connect';
 
@@ -257,5 +258,37 @@ describe('isAllowedGnoConnectOrigin', () => {
 
   it('rejects subdomain takeover patterns', () => {
     expect(isAllowedGnoConnectOrigin('https://malicious.gno.land')).toBe(false);
+  });
+});
+
+describe('normalizeGnoConnectRpc', () => {
+  it('keeps http(s) endpoints as-is', () => {
+    expect(normalizeGnoConnectRpc('https://rpc.gno.land')).toBe('https://rpc.gno.land');
+    expect(normalizeGnoConnectRpc('http://127.0.0.1:26657')).toBe('http://127.0.0.1:26657');
+  });
+
+  it('maps a non-http scheme on a loopback host to http://', () => {
+    // Local gno nodes commonly advertise their RPC as tcp://; downstream RPC
+    // clients require http(s), so it must be rewritten rather than stripped bare.
+    expect(normalizeGnoConnectRpc('tcp://127.0.0.1:26657')).toBe('http://127.0.0.1:26657');
+    expect(normalizeGnoConnectRpc('tcp://localhost:26657')).toBe('http://localhost:26657');
+  });
+
+  it('adds a protocol to a bare loopback host', () => {
+    expect(normalizeGnoConnectRpc('127.0.0.1:26657')).toBe('http://127.0.0.1:26657');
+  });
+
+  it('assumes https for non-loopback hosts missing a protocol', () => {
+    expect(normalizeGnoConnectRpc('tcp://rpc.gno.land')).toBe('https://rpc.gno.land');
+    expect(normalizeGnoConnectRpc('rpc.gno.land')).toBe('https://rpc.gno.land');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeGnoConnectRpc('  http://127.0.0.1:26657  ')).toBe('http://127.0.0.1:26657');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(normalizeGnoConnectRpc('')).toBe('');
+    expect(normalizeGnoConnectRpc('   ')).toBe('');
   });
 });

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
@@ -2,6 +2,7 @@ import {
   getLoopbackGnoConnectChainId,
   GnoMessageInfo,
   isAllowedGnoConnectOrigin,
+  isLoopbackGnoConnectTrusted,
   normalizeGnoConnectRpc,
   parseGnoMessageInfo,
 } from './gno-connect';
@@ -275,6 +276,33 @@ describe('getLoopbackGnoConnectChainId', () => {
   it('returns null for non-loopback or unknown origins', () => {
     expect(getLoopbackGnoConnectChainId('https://gno.land')).toBeNull();
     expect(getLoopbackGnoConnectChainId('http://127.0.0.1:9999')).toBeNull();
+  });
+});
+
+describe('isLoopbackGnoConnectTrusted', () => {
+  const LOOPBACK_CHAIN_ID = 'dev';
+
+  it('trusts a loopback origin when both the meta chainId and the active network match', () => {
+    expect(isLoopbackGnoConnectTrusted(LOOPBACK_CHAIN_ID, 'dev', 'dev')).toBe(true);
+  });
+
+  it('rejects a foreign meta chainId even when the active network matches the origin', () => {
+    // Regression: a page served from http://127.0.0.1:8888 (origin -> dev) while
+    // the wallet is already on dev must not be allowed to declare a different
+    // chainId (e.g. gnoland1) and switch/sign against a foreign network.
+    expect(isLoopbackGnoConnectTrusted(LOOPBACK_CHAIN_ID, 'gnoland1', 'dev')).toBe(false);
+  });
+
+  it('rejects when the active network is not the loopback chainId', () => {
+    expect(isLoopbackGnoConnectTrusted(LOOPBACK_CHAIN_ID, 'dev', 'gnoland1')).toBe(false);
+  });
+
+  it('rejects when the active network is unavailable (e.g. wallet locked)', () => {
+    expect(isLoopbackGnoConnectTrusted(LOOPBACK_CHAIN_ID, 'dev', undefined)).toBe(false);
+  });
+
+  it('rejects when neither the meta chainId nor the active network match', () => {
+    expect(isLoopbackGnoConnectTrusted(LOOPBACK_CHAIN_ID, 'gnoland1', 'gnoland1')).toBe(false);
   });
 });
 

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.ts
@@ -1,4 +1,5 @@
 import {
+  getLoopbackOriginChainId,
   GNO_CONNECT_ALLOWED_ORIGINS,
   LOOPBACK_LOCAL_HOST_PATTERN,
 } from '@common/constants/gno-connect-allowlist.constant';
@@ -362,11 +363,25 @@ export function shouldInterceptExecForm(target: EventTarget | null): boolean {
 }
 
 /**
- * Checks whether the given dApp origin is allowed to declare RPC/chainId via
- * gnoconnect meta tags. Strict equality on the full origin (scheme + host + port).
+ * Checks whether the given dApp origin is unconditionally allowed to declare
+ * RPC/chainId via gnoconnect meta tags. Only remote (https) gno origins qualify;
+ * strict equality on the full origin (scheme + host + port). Loopback origins are
+ * never statically trusted — use getLoopbackGnoConnectChainId with a runtime
+ * active-network check instead.
  */
 export function isAllowedGnoConnectOrigin(origin: string): boolean {
   return GNO_CONNECT_ALLOWED_ORIGINS.includes(origin);
+}
+
+/**
+ * For a loopback gno origin (e.g. a local dev node), returns the chainId it is
+ * permitted to act as, per chains.json, or null if the origin is not a known
+ * loopback gno origin. Callers MUST additionally verify this chainId is the
+ * wallet's active network before honoring the origin's gnoconnect declarations,
+ * so an arbitrary local process holding the port cannot drive the wallet.
+ */
+export function getLoopbackGnoConnectChainId(origin: string): string | null {
+  return getLoopbackOriginChainId(origin);
 }
 
 /**

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.ts
@@ -385,6 +385,29 @@ export function getLoopbackGnoConnectChainId(origin: string): string | null {
 }
 
 /**
+ * Runtime trust decision for a loopback gnoconnect origin.
+ *
+ * A loopback origin (e.g. a local dev node) is honored only when BOTH hold:
+ * - the meta-declared chainId equals the chainId chains.json maps the origin to
+ *   (the meta tag is attacker-controllable, so it must not act as a foreign
+ *   chain), and
+ * - that same chainId is the wallet's currently active network (so an arbitrary
+ *   process holding the local port cannot drive the flow while the user is
+ *   elsewhere).
+ *
+ * @param loopbackChainId chainId the origin is permitted to act as (from chains.json)
+ * @param metaChainId chainId the page declares via gnoconnect meta tag
+ * @param activeChainId chainId of the wallet's active network (undefined if unavailable/locked)
+ */
+export function isLoopbackGnoConnectTrusted(
+  loopbackChainId: string,
+  metaChainId: string,
+  activeChainId: string | undefined,
+): boolean {
+  return metaChainId === loopbackChainId && activeChainId === loopbackChainId;
+}
+
+/**
  * Normalizes a gnoconnect RPC endpoint (declared via meta tag) into a fetchable
  * http(s) URL.
  *

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.ts
@@ -1,4 +1,7 @@
-import { GNO_CONNECT_ALLOWED_ORIGINS } from '@common/constants/gno-connect-allowlist.constant';
+import {
+  GNO_CONNECT_ALLOWED_ORIGINS,
+  LOOPBACK_LOCAL_HOST_PATTERN,
+} from '@common/constants/gno-connect-allowlist.constant';
 import {
   GNO_CHAIN_ID_META_TAG,
   GNO_CONNECT_PREFIX,
@@ -64,7 +67,7 @@ export function parseGnoConnectInfo(): GnoConnectInfo | null {
 
     switch (name) {
       case GNO_RPC_META_TAG:
-        gnoConnectInfo.rpc = getUrlPathWithoutProtocol(content);
+        gnoConnectInfo.rpc = normalizeGnoConnectRpc(content);
         break;
       case GNO_CHAIN_ID_META_TAG:
         gnoConnectInfo.chainId = content;
@@ -366,12 +369,26 @@ export function isAllowedGnoConnectOrigin(origin: string): boolean {
   return GNO_CONNECT_ALLOWED_ORIGINS.includes(origin);
 }
 
-export function getUrlPathWithoutProtocol(url: string): string {
+/**
+ * Normalizes a gnoconnect RPC endpoint (declared via meta tag) into a fetchable
+ * http(s) URL.
+ *
+ * gnoweb may declare the RPC with an http(s) scheme (kept as-is), a non-http
+ * scheme such as `tcp://` (as local gno nodes commonly do), or no scheme at all.
+ * Downstream RPC clients (tm2-rpc HttpClient, fetch, axios) reject anything
+ * without an http(s) protocol, so any non-http input has its scheme replaced:
+ * loopback hosts map to http://, all others to https://.
+ */
+export function normalizeGnoConnectRpc(url: string): string {
   const trimmedUrl = url.trim();
 
-  if (hasHttpProtocol(trimmedUrl)) {
+  if (trimmedUrl === '' || hasHttpProtocol(trimmedUrl)) {
     return trimmedUrl;
   }
 
-  return trimmedUrl.replace(/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//, '');
+  const withoutScheme = trimmedUrl.replace(/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//, '');
+  const host = withoutScheme.split('/')[0];
+  const protocol = LOOPBACK_LOCAL_HOST_PATTERN.test(host) ? 'http://' : 'https://';
+
+  return `${protocol}${withoutScheme}`;
 }


### PR DESCRIPTION
## Summary

gnoconnect **tx links** (clicking a `$help&func=...` link on gnoweb to open the
signing popup) did not work against a **Local** gno node. This PR makes them work
while keeping the origin-trust hardening introduced in the security review (#836).

Two independent bugs blocked the Local flow, plus a security-conscious redesign of
how loopback origins are trusted.

## Root causes & fixes

### 1. Loopback origin was blocked by the gnoconnect origin gate

`command-handler` gates the tx-link flow on `isAllowedGnoConnectOrigin(origin)`.
The allowlist trusted loopback origins only in development builds, so a
production build silently dropped the flow for `http://127.0.0.1:8888` (the
built-in Local network), even though `dev` ships as a default network.

**Fix:** the allowlist is now derived purely from `chains.json`, and loopback
trust no longer depends on the build mode (see the runtime gate below for how it
is kept safe).

### 2. Local RPC endpoint reached the RPC client without a protocol

gnoweb declares the RPC via the `gnoconnect:rpc` meta tag. Local gno nodes
commonly advertise it as `tcp://127.0.0.1:26657` (or without any scheme). The old
`getUrlPathWithoutProtocol` stripped non-http schemes down to a bare host, which
then flowed into `GnoProvider` / `networkInfo.rpcUrl`. Downstream RPC clients
(`@gnolang/tm2-rpc` `HttpClient`, `fetch`, `axios`) reject an endpoint without an
`http(s)://` protocol, throwing:

> `Endpoint URL is missing a protocol. Expected 'https://' or 'http://'.`

gno.land was unaffected because it declares `https://…` in the meta tag, so only
Local broke.

**Fix:** replaced `getUrlPathWithoutProtocol` with `normalizeGnoConnectRpc`, which
always returns a fetchable `http(s)` URL — http(s) inputs are kept as-is, and any
non-http/bare input has its scheme (re)applied: loopback hosts → `http://`, all
others → `https://`.

## Security: runtime-gated loopback trust

Statically trusting loopback origins in production would reintroduce exactly the
risk #836 flagged: any local process holding the port could drive the wallet flow.
Instead of a static allowlist, loopback origins are now trusted **only at
runtime**:

- **Remote (https) gno origins** — trusted unconditionally (team-controlled).
- **Loopback origins** — honored only when the wallet's **currently active
  network** is the one that `chains.json` maps to that origin
  (`http://127.0.0.1:8888` → `dev`). The check reads the active `chainId` from the
  wallet (trusted background), not from attacker-controllable meta tags, and fails
  closed.

### Effect

- A malicious `http://127.0.0.1:8888` page cannot drive the wallet while the user
  is on another network (e.g. mainnet) — the flow is silently dropped.
- Loopback is trusted only when the user has **explicitly opted into the Local
  (`dev`) network**, which is the only scenario where a local tx link is expected.

## Notes / behavioral changes

- A loopback tx link requires the wallet to be **unlocked and on the `dev`
  network**. While locked, `getNetwork()` returns `WALLET_LOCKED`, so the gate
  fails closed; unlock and retry.
- Trust is keyed to the exact `chains.json` gnoUrl (`http://127.0.0.1:8888`).
  Serving gnoweb under a different host/port (e.g. `localhost`) requires adding
  that origin to `chains.json`.
- This intentionally relaxes #836's "loopback only in dev builds" stance and
  replaces it with a tighter runtime, active-network gate.

## Changes

- `common/constants/gno-connect-allowlist.constant.ts` — split trust into static
  https allowlist + loopback→chainId map; add `isLoopbackOrigin` /
  `getLoopbackOriginChainId`.
- `inject/message/methods/gno-connect.ts` — add `normalizeGnoConnectRpc` and
  `getLoopbackGnoConnectChainId`; `isAllowedGnoConnectOrigin` now covers https
  origins only.
- `inject/message/command-handler.ts` — runtime active-network gate for loopback
  origins before honoring gnoconnect data.
