### PR TITLE
fix: enhance account addresses popover with copy functionality

### DIFF
--- a/packages/adena-extension/src/components/pages/router/top-menu/account-addresses-popover/account-addresses-popover.styles.ts
+++ b/packages/adena-extension/src/components/pages/router/top-menu/account-addresses-popover/account-addresses-popover.styles.ts
@@ -35,7 +35,8 @@ export const ChainRow = styled.div`
   gap: 8px;
   transition: color 0.15s ease;
 
-  &:hover {
+  &:hover .chain-right,
+  .chain-right.copied {
     .address {
       color: ${getTheme('neutral', '_1')};
     }
@@ -66,6 +67,20 @@ export const ChainRow = styled.div`
     ${mixins.flex({ direction: 'row', align: 'center', justify: 'flex-end' })};
     gap: 6px;
     flex-shrink: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+
+    svg {
+      width: 14px;
+      height: 14px;
+
+      path {
+        transition: stroke 0.2s;
+        stroke: ${getTheme('neutral', 'a')};
+      }
+    }
   }
 
   .address {

--- a/packages/adena-extension/src/components/pages/router/top-menu/account-addresses-popover/account-addresses-popover.tsx
+++ b/packages/adena-extension/src/components/pages/router/top-menu/account-addresses-popover/account-addresses-popover.tsx
@@ -1,14 +1,18 @@
+import IconCopy from '@assets/icon-copy';
+import IconCopyCheck from '@assets/icon-copy-check';
 import { CHAIN_ICON_MAP } from '@assets/icons/cosmos-icons';
-import { CopyIconButton, Portal } from '@components/atoms';
 import { formatAddress } from '@common/utils/client-utils';
+import { Portal } from '@components/atoms';
 import { ChainAddressEntry } from '@hooks/use-account-chain-addresses';
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ChainRow, PopoverWrapper } from './account-addresses-popover.styles';
 
 const CHAIN_SHORT_NAME: Record<string, string> = {
   gno: 'Gno.land',
   atomone: 'AtomOne',
 };
+
+const COPY_FEEDBACK_MS = 2000;
 
 interface AccountAddressesPopoverProps {
   open: boolean;
@@ -37,25 +41,57 @@ export const AccountAddressesPopover: React.FC<AccountAddressesPopoverProps> = (
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        {entries.map(({ chain, address, id, label }) => (
-          <ChainRow key={id ?? chain.id}>
-            <div className='chain-left'>
-              <img
-                className='chain-icon'
-                src={CHAIN_ICON_MAP[chain.id] ?? chain.chainIconUrl}
-                alt={chain.displayName}
-              />
-              <span className='chain-name'>
-                {label ?? CHAIN_SHORT_NAME[chain.chainGroup] ?? chain.displayName}
-              </span>
-            </div>
-            <div className='chain-right'>
-              <span className='address'>{formatAddress(address, 6)}</span>
-              <CopyIconButton copyText={address} size={14} />
-            </div>
-          </ChainRow>
+        {entries.map((entry) => (
+          <ChainAddressRow key={entry.id ?? entry.chain.id} entry={entry} />
         ))}
       </PopoverWrapper>
     </Portal>
+  );
+};
+
+const ChainAddressRow: React.FC<{ entry: ChainAddressEntry }> = ({ entry }) => {
+  const { chain, address, label } = entry;
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+
+    const timer = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [copied]);
+
+  // The whole right cell (truncated address + icon) is the copy target, so users
+  // no longer have to hit the small icon. Copy the full, non-truncated address.
+  const onClickCopy = useCallback(() => {
+    setCopied(true);
+    navigator.clipboard.writeText(address);
+  }, [address]);
+
+  return (
+    <ChainRow>
+      <div className='chain-left'>
+        <img
+          className='chain-icon'
+          src={CHAIN_ICON_MAP[chain.id] ?? chain.chainIconUrl}
+          alt={chain.displayName}
+        />
+        <span className='chain-name'>
+          {label ?? CHAIN_SHORT_NAME[chain.chainGroup] ?? chain.displayName}
+        </span>
+      </div>
+      <button
+        type='button'
+        className={copied ? 'chain-right copied' : 'chain-right'}
+        onClick={onClickCopy}
+        aria-label={`Copy ${chain.displayName} address`}
+      >
+        <span className='address'>{formatAddress(address, 6)}</span>
+        {copied ? <IconCopyCheck /> : <IconCopy />}
+      </button>
+    </ChainRow>
   );
 };


### PR DESCRIPTION
## Problem

In the header's account-address hover popover, each chain row shows a truncated
address and a small copy icon. Only the **icon** was clickable, so copying an
address required hitting a tiny target — an awkward, easy-to-miss hit area.

## Fix

Make the entire right cell — the truncated address (`g1jg8m…jvsqf5`) **and** the
icon — a single clickable copy target.

- Replaced the right-cell `<div>` with a `<button>` that copies on click, so the
  address text itself is now part of the clickable area.
- The full, non-truncated address is copied (`navigator.clipboard.writeText`),
  even though the UI shows the truncated form.
- Copy feedback (copy → check icon, auto-reverting after 2s) is now tracked per
  row and shared across the whole cell, so clicking either the address or the
  icon gives the same confirmation.
- Extracted each row into a `ChainAddressRow` component to hold its own copy
  state.
- Kept the reusable `CopyIconButton` atom untouched (it is a fixed-size icon used
  across many screens); the copy logic is handled locally in the popover instead.
- Added an `aria-label` on the button for accessibility.

## Changes

- `account-addresses-popover.tsx` — new `ChainAddressRow` with per-row copy state;
  the right cell is now a clickable button wrapping the address + icon.
- `account-addresses-popover.styles.ts` — reset the `.chain-right` button
  (padding/border/background) and add `cursor: pointer` + icon sizing; extend the
  hover/`copied` highlight to the address and icon.
