### PR TITLE
fix: return broadcast tx hash as base64 to keep the doContract result stable

### DIFF
--- a/packages/adena-extension/src/common/provider/gno/gno-provider.spec.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.spec.ts
@@ -1,4 +1,5 @@
 import { stringToBase64 } from '@gnolang/tm2-js-client';
+import axios from 'axios';
 import { GnoProvider } from './gno-provider';
 import { postABCIResponse } from './utils';
 
@@ -7,11 +8,33 @@ jest.mock('./utils', () => ({
   postABCIResponse: jest.fn(),
 }));
 
+jest.mock('axios');
+
 describe('GnoProvider', () => {
   const postABCIResponseMock = postABCIResponse as jest.Mock;
+  const axiosPostMock = axios.post as jest.Mock;
 
   beforeEach(() => {
     postABCIResponseMock.mockReset();
+    axiosPostMock.mockReset();
+  });
+
+  describe('sendTransactionSync', () => {
+    it('returns the broadcast tx hash as canonical base64, not uppercase hex', async () => {
+      // Regression guard: sendTransactionSync must hand dApps the same base64 hash
+      // the tm2-js-client path produced. A direct broadcast previously ran the hash
+      // through base64->hex, which changed the value returned to callers.
+      const base64Hash = '2dD/aBpjSdCTwYdaF64b+bekuBdenwWbYezWfn3JHWE=';
+      axiosPostMock.mockResolvedValue({
+        data: { result: { error: null, data: null, log: '', hash: base64Hash } },
+      });
+
+      const provider = new GnoProvider('https://rpc.example', 'test-13');
+      const result = await provider.sendTransactionSync('encoded-tx');
+
+      expect(result.hash).toBe(base64Hash);
+      expect(result.hash).not.toMatch(/^[0-9A-Fa-f]{64}$/);
+    });
   });
 
   describe('getSessions', () => {

--- a/packages/adena-extension/src/common/provider/gno/gno-provider.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.ts
@@ -47,21 +47,6 @@ function isBase64JSONNull(data: string): boolean {
   return data === BASE64_JSON_NULL;
 }
 
-function base64ToUpperHex(b64: string): string {
-  if (!b64) {
-    return '';
-  }
-
-  let hex = '';
-
-  const bin = atob(b64);
-  for (let i = 0; i < bin.length; i++) {
-    hex += bin.charCodeAt(i).toString(16).padStart(2, '0');
-  }
-
-  return hex.toUpperCase();
-}
-
 type Tm2ClientConstructor = new (client: HttpClient) => Tm2Client;
 type GnoSessionAccountInfoResponse = GnoSessionAccountResponse & SessionAccountInfo;
 
@@ -407,7 +392,7 @@ export class GnoProvider extends GnoJSONRPCProvider {
       error: null,
       data: result.data ?? null,
       Log: log,
-      hash: base64ToUpperHex(result.hash),
+      hash: result.hash,
     };
   }
 


### PR DESCRIPTION
## Problem

After the direct `broadcast_tx_sync` path was introduced (#853), the transaction
hash returned from an approved transaction (`doContract`) changed format:

- Before: `2dD/aBpjSdCTwYdaF64b+bekuBdenwWbYezWfn3JHWE=` (base64)
- After:  `44EFCD9630F1AA2DA14482205C158F500935FE8B5D00AFFA514F79F115B28C10` (uppercase hex)

`sendTransactionSync` was rewritten to call the RPC directly (to work around a
library parsing bug for Gno nodes), and in doing so it ran the hash through a
`base64ToUpperHex` conversion. That conversion leaked into the value handed back
to dApps, breaking consumers that expect the canonical base64 tx hash.

## Fix

Return the raw base64 hash from `sendTransactionSync`, matching the previous
tm2-js-client path. The hex conversion is unnecessary: every Gnoscan link already
normalizes the hash via `normalizeGnoscanTxHash` (`use-link`), which converts hex
to base64 and passes base64 through unchanged. So the "View on Gnoscan" and
session-revoke scanner links keep working with a base64 hash.

- `gno-provider.ts` — `sendTransactionSync` returns `result.hash` (base64) instead
  of `base64ToUpperHex(result.hash)`.
- Removed the now-unused `base64ToUpperHex` helper (dead code).

## Testing

- Added `gno-provider.spec.ts` › `sendTransactionSync` — asserts the broadcast tx
  hash is returned as base64 and is not the uppercase-hex form (regression guard).
- Existing `gnoscan-url.spec.ts` already covers `normalizeGnoscanTxHash` (hex →
  base64 and base64 pass-through), which the Gnoscan links rely on.
- `tsc --noEmit` and `eslint` pass on the touched files.
- [ ] Manual: approve a transaction → returned hash is base64; "View on Gnoscan"
  opens the correct tx detail page.