### PR TITLE
fix: prevent multiple register tabs from opening on wallet reset

### DIFF
--- a/packages/adena-extension/src/App/popup.tsx
+++ b/packages/adena-extension/src/App/popup.tsx
@@ -1,13 +1,13 @@
-import React, { ReactElement } from 'react';
 import { PopupRouter } from '@router/popup/index';
+import { ReactElement, useEffect, useRef } from 'react';
 
-import AppProvider from './app-provider';
-import useApp from './use-app';
+import { useInitWallet } from '@hooks/use-init-wallet';
+import useLink from '@hooks/use-link';
+import { useWallet } from '@hooks/use-wallet';
 import { GlobalPopupStyle } from '@styles/global-style';
 import { HashRouter } from 'react-router-dom';
-import { useInitWallet } from '@hooks/use-init-wallet';
-import { useWallet } from '@hooks/use-wallet';
-import useLink from '@hooks/use-link';
+import AppProvider from './app-provider';
+import useApp from './use-app';
 
 const RunApp = (): ReactElement => {
   useApp();
@@ -15,10 +15,17 @@ const RunApp = (): ReactElement => {
   const { existWallet, isLoadingExistWallet, isLoadingLockedWallet } = useWallet();
   const { openRegister } = useLink();
 
-  if (isLoadingExistWallet === false && existWallet === false) {
-    openRegister();
-    window.close();
-  }
+  // Guards the register-tab side effect so it runs exactly once.
+  const hasOpenedRegisterRef = useRef(false);
+  const shouldOpenRegister = isLoadingExistWallet === false && existWallet === false;
+
+  useEffect(() => {
+    if (shouldOpenRegister && !hasOpenedRegisterRef.current) {
+      hasOpenedRegisterRef.current = true;
+      openRegister();
+      window.close();
+    }
+  }, [shouldOpenRegister, openRegister]);
 
   if (isLoadingLockedWallet || !existWallet) {
     return <></>;


### PR DESCRIPTION
## Summary

Resetting the wallet (Settings > Security & Privacy > Reset Wallet) opened 4 register tabs.

## Root Cause

In `App/popup.tsx`, `openRegister()` (which calls `window.open`) and `window.close()` were invoked **directly in the React render body** instead of inside an effect:

```tsx
if (isLoadingExistWallet === false && existWallet === false) {
  openRegister();
  window.close();
}
```

When the wallet is reset, `clear()` sequentially resets multiple Recoil/react-query states, causing `RunApp` to re-render several times. While `existWallet === false`, every re-render fires `window.open` again.

The number of opened tabs was effectively determined by how many times the component re-rendered before `window.close()` took effect, which is platform/browser-timing dependent.

## Changes

- Moved the register-tab side effect from the render body into a `useEffect`.
- Added a `useRef` guard so the effect runs **exactly once**, regardless of re-render count or `window.close()` timing.
