### PR TITLE
fix: prevent deposits to Session Account addresses

### DIFF
--- a/packages/adena-extension/src/components/atoms/main-action-button/index.tsx
+++ b/packages/adena-extension/src/components/atoms/main-action-button/index.tsx
@@ -28,7 +28,7 @@ const StyledButton = styled.button`
   cursor: pointer;
   transition: background 0.2s ease;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: ${getTheme('neutral', '_6')};
   }
 

--- a/packages/adena-extension/src/components/pages/account-details/account-details/account-details.spec.tsx
+++ b/packages/adena-extension/src/components/pages/account-details/account-details/account-details.spec.tsx
@@ -14,6 +14,7 @@ describe('AccountDetails Component', () => {
     originName: '',
     name: '',
     address: '',
+    isSessionAccount: false,
     moveGnoscan: () => {
       return;
     },

--- a/packages/adena-extension/src/components/pages/account-details/account-details/account-details.styles.ts
+++ b/packages/adena-extension/src/components/pages/account-details/account-details/account-details.styles.ts
@@ -16,7 +16,7 @@ export const AccountDetailsWrapper = styled.div`
   .qrcode-wrapper {
     ${mixins.flex()};
     width: 100%;
-    padding: 12px 0;
+    padding: 12px 0 0 0;
 
     .qrcode-background {
       display: flex;
@@ -43,5 +43,9 @@ export const AccountDetailsWrapper = styled.div`
         text-overflow: ellipsis;
       }
     }
+  }
+
+  .button-group-wrapper {
+    padding: 12px 0 0 0;
   }
 `;

--- a/packages/adena-extension/src/components/pages/account-details/account-details/index.tsx
+++ b/packages/adena-extension/src/components/pages/account-details/account-details/index.tsx
@@ -11,6 +11,7 @@ export interface AccountDetailsProps {
   originName: string;
   name: string;
   address: string;
+  isSessionAccount: boolean;
   moveGnoscan: () => void;
   moveRevealSeedPhrase: () => void;
   moveExportPrivateKey: () => void;
@@ -26,6 +27,7 @@ const AccountDetails: React.FC<AccountDetailsProps> = ({
   originName,
   name,
   address,
+  isSessionAccount,
   setName,
   reset,
   moveGnoscan,
@@ -57,15 +59,17 @@ const AccountDetails: React.FC<AccountDetailsProps> = ({
         <AccountNameInput originName={originName} name={name} setName={setName} reset={reset} />
       </div>
 
-      <div className='qrcode-wrapper'>
-        <div className='qrcode-background'>
-          <QRCodeSVG value={address} size={150} />
+      {!isSessionAccount && (
+        <div className='qrcode-wrapper'>
+          <div className='qrcode-background'>
+            <QRCodeSVG value={address} size={150} />
+          </div>
+          <div className='qrcode-address-wrapper'>
+            <span className='address'>{address}</span>
+            <CopyIconButton copyText={address} />
+          </div>
         </div>
-        <div className='qrcode-address-wrapper'>
-          <span className='address'>{address}</span>
-          <CopyIconButton copyText={address} />
-        </div>
-      </div>
+      )}
 
       <div className='button-group-wrapper'>
         <FullButtonRightIcon

--- a/packages/adena-extension/src/components/pages/nft/nft-header/nft-header.tsx
+++ b/packages/adena-extension/src/components/pages/nft/nft-header/nft-header.tsx
@@ -9,24 +9,36 @@ import { NFTHeaderWrapper } from './nft-header.styles';
 export interface NFTHeaderProps {
   openGnoscan: () => void;
   moveDepositPage: () => void;
+  isSessionAccount?: boolean;
 }
 
-const NFTHeader: React.FC<NFTHeaderProps> = ({ openGnoscan, moveDepositPage }) => {
-  const dropdownOptions = useMemo(
-    () => [
+const NFTHeader: React.FC<NFTHeaderProps> = ({
+  openGnoscan,
+  moveDepositPage,
+  isSessionAccount = false,
+}) => {
+  const dropdownOptions = useMemo(() => {
+    const gnoscanOption = {
+      text: 'View on GnoScan',
+      icon: <IconLink />,
+      onClick: openGnoscan,
+    };
+
+    // A SessionAccount address can never receive tokens, so the deposit entry
+    // point is hidden; users deposit NFTs to the Master Account instead.
+    if (isSessionAccount) {
+      return [gnoscanOption];
+    }
+
+    return [
       {
         text: 'Deposit NFT',
         icon: <IconQRCode />,
         onClick: moveDepositPage,
       },
-      {
-        text: 'View on GnoScan',
-        icon: <IconLink />,
-        onClick: openGnoscan,
-      },
-    ],
-    [openGnoscan, moveDepositPage],
-  );
+      gnoscanOption,
+    ];
+  }, [openGnoscan, moveDepositPage, isSessionAccount]);
 
   return (
     <NFTHeaderWrapper>

--- a/packages/adena-extension/src/components/pages/router/side-menu-account-item/side-menu-account-item.styles.ts
+++ b/packages/adena-extension/src/components/pages/router/side-menu-account-item/side-menu-account-item.styles.ts
@@ -79,6 +79,12 @@ export const SideMenuAccountItemWrapper = styled.div`
         }
       }
 
+      /* Session accounts hide the address block, so the type chip sits directly
+         after the name and needs its own left spacing. */
+      .name + .label {
+        margin-left: 8px;
+      }
+
       .label {
         display: flex;
         height: 16px;

--- a/packages/adena-extension/src/components/pages/router/side-menu-account-item/side-menu-account-item.tsx
+++ b/packages/adena-extension/src/components/pages/router/side-menu-account-item/side-menu-account-item.tsx
@@ -54,6 +54,10 @@ const SideMenuAccountItem: React.FC<SideMenuAccountItemProps> = ({
     return name;
   }, [name]);
 
+  // A SessionAccount address can never receive tokens, so it is hidden in the
+  // account list to avoid users copying it as a deposit destination.
+  const isSession = type === 'SESSION';
+
   const labels = useMemo(() => {
     const typeLabel = ((): string | null => {
       switch (type) {
@@ -127,10 +131,12 @@ const SideMenuAccountItem: React.FC<SideMenuAccountItemProps> = ({
       <div className='info-wrapper'>
         <div className='address-wrapper'>
           <span className='name'>{displayName}</span>
-          <div className='address-copy' onClick={onClickCopy}>
-            <span className='address'>{formatAddress(address, 6)}</span>
-            <span className='copy-icon'>{copied ? <IconCopyCheck /> : <IconCopy />}</span>
-          </div>
+          {!isSession && (
+            <div className='address-copy' onClick={onClickCopy}>
+              <span className='address'>{formatAddress(address, 6)}</span>
+              <span className='copy-icon'>{copied ? <IconCopyCheck /> : <IconCopy />}</span>
+            </div>
+          )}
           {labels.map((text) => (
             <span key={text} className='label'>
               {text}

--- a/packages/adena-extension/src/components/pages/router/top-menu/session-address-warning-popover/index.ts
+++ b/packages/adena-extension/src/components/pages/router/top-menu/session-address-warning-popover/index.ts
@@ -1,0 +1,1 @@
+export { SessionAddressWarningPopover } from './session-address-warning-popover';

--- a/packages/adena-extension/src/components/pages/router/top-menu/session-address-warning-popover/session-address-warning-popover.styles.ts
+++ b/packages/adena-extension/src/components/pages/router/top-menu/session-address-warning-popover/session-address-warning-popover.styles.ts
@@ -1,0 +1,41 @@
+import { fonts, getTheme } from '@styles/theme';
+import styled from 'styled-components';
+
+export const WarningPopoverWrapper = styled.div<{ $caretX: number; $positionY: number }>`
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  top: ${({ $positionY }): string => `${$positionY}px`};
+  width: 320px;
+  padding: 10px 18px;
+  background-color: ${getTheme('neutral', '_9')};
+  border-radius: 8px;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 99;
+  overflow: visible;
+
+  .warning-text {
+    ${fonts.body3Reg}
+    color: ${getTheme('neutral', '_1')};
+    text-align: left;
+    white-space: normal;
+
+    b {
+      font-weight: 600;
+    }
+  }
+
+  /* Caret fill */
+  &::after {
+    content: '';
+    position: absolute;
+    top: -12px;
+    left: ${({ $caretX }): string => `${$caretX}px`};
+    transform: translateX(-50%);
+    width: 0;
+    height: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 12px solid ${getTheme('neutral', '_9')};
+  }
+`;

--- a/packages/adena-extension/src/components/pages/router/top-menu/session-address-warning-popover/session-address-warning-popover.tsx
+++ b/packages/adena-extension/src/components/pages/router/top-menu/session-address-warning-popover/session-address-warning-popover.tsx
@@ -4,8 +4,6 @@ import { WarningPopoverWrapper } from './session-address-warning-popover.styles'
 
 // A SessionAccount address can never receive tokens, so the header copy affordance
 // is replaced by this warning instead of copying an address on hover.
-const SESSION_DEPOSIT_WARNING = `Do not send tokens to your Session Account. Use the <b>Master Account’s</b> address to receive tokens.`;
-
 interface SessionAddressWarningPopoverProps {
   open: boolean;
   positionX: number;

--- a/packages/adena-extension/src/components/pages/router/top-menu/session-address-warning-popover/session-address-warning-popover.tsx
+++ b/packages/adena-extension/src/components/pages/router/top-menu/session-address-warning-popover/session-address-warning-popover.tsx
@@ -1,0 +1,41 @@
+import { Portal } from '@components/atoms';
+import React from 'react';
+import { WarningPopoverWrapper } from './session-address-warning-popover.styles';
+
+// A SessionAccount address can never receive tokens, so the header copy affordance
+// is replaced by this warning instead of copying an address on hover.
+const SESSION_DEPOSIT_WARNING = `Do not send tokens to your Session Account. Use the <b>Master Account’s</b> address to receive tokens.`;
+
+interface SessionAddressWarningPopoverProps {
+  open: boolean;
+  positionX: number;
+  positionY: number;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+export const SessionAddressWarningPopover: React.FC<SessionAddressWarningPopoverProps> = ({
+  open,
+  positionX,
+  positionY,
+  onMouseEnter,
+  onMouseLeave,
+}) => {
+  if (!open) return null;
+
+  return (
+    <Portal selector='portal-popup'>
+      <WarningPopoverWrapper
+        $caretX={positionX}
+        $positionY={positionY}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        <span className='warning-text'>
+          Do not send tokens to your Session Account. Use the <b>Master Account’s</b> address to
+          receive tokens.
+        </span>
+      </WarningPopoverWrapper>
+    </Portal>
+  );
+};

--- a/packages/adena-extension/src/pages/popup/wallet/account-details/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/account-details/index.tsx
@@ -60,6 +60,11 @@ const AccountDetailsContainer: React.FC = () => {
     return !isSessionAccount(account);
   }, [account]);
 
+  const isSession = useMemo(() => {
+    if (!account) return false;
+    return isSessionAccount(account);
+  }, [account]);
+
   const masterAddress = useMemo(() => {
     if (!isMasterAccount) return undefined;
     if (!address) return undefined;
@@ -149,6 +154,7 @@ const AccountDetailsContainer: React.FC = () => {
         moveManageSessions={moveManageSessions}
         setName={changeName}
         reset={reset}
+        isSessionAccount={isSession}
       />
     </CommonFullContentLayout>
   );

--- a/packages/adena-extension/src/pages/popup/wallet/deposit/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/deposit/index.tsx
@@ -1,4 +1,3 @@
-import { isSessionAccount } from 'adena-module';
 import { QRCodeSVG } from 'qrcode.react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
@@ -6,8 +5,6 @@ import styled, { useTheme } from 'styled-components';
 import { CHAIN_ICON_BY_GROUP } from '@assets/icons/cosmos-icons';
 import { formatAddress, formatNickname } from '@common/utils/client-utils';
 import { Button, Copy, inputStyle, Text } from '@components/atoms';
-import InfoTooltip from '@components/atoms/info-tooltip/info-tooltip';
-import { InfoTooltipStrong } from '@components/atoms/info-tooltip/info-tooltip.styles';
 import { useAccountChainAddresses } from '@hooks/use-account-chain-addresses';
 import { useAccountName } from '@hooks/use-account-name';
 import useAppNavigate from '@hooks/use-app-navigate';
@@ -22,17 +19,6 @@ const CHAIN_DISPLAY_NAME: Record<string, string> = {
   gno: 'Gno.land',
   atomone: 'AtomOne',
 };
-
-// A SessionAccount address can never receive deposits, so the Deposit screen
-// shows the master address. Label it explicitly so the user understands whose
-// address the QR encodes.
-const MASTER_DEPOSIT_TOOLTIP = (
-  <>
-    This is the address of the <InfoTooltipStrong>Master Account</InfoTooltipStrong> of this
-    session. Tokens sent to this address will arrive in your{' '}
-    <InfoTooltipStrong>Master Account</InfoTooltipStrong>.
-  </>
-);
 
 const Wrapper = styled.main`
   ${mixins.flex({ justify: 'stretch' })};
@@ -59,12 +45,6 @@ const CopyInputBox = styled.div`
   }
 
   margin-bottom: 8px;
-`;
-
-const MasterLabel = styled.span`
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
 `;
 
 const ChainNoticeText = styled.p`
@@ -103,10 +83,6 @@ export const Deposit = (): JSX.Element => {
   const { accountNames } = useAccountName();
   const { currentNetwork } = useNetwork();
   const chainAddressEntries = useAccountChainAddresses();
-
-  const isSession = useMemo(() => (currentAccount ? isSessionAccount(currentAccount) : false), [
-    currentAccount,
-  ]);
 
   const chainGroup = useMemo(() => {
     const lookupNetworkId = params?.token?.networkId ?? currentNetwork.networkId;
@@ -151,14 +127,7 @@ export const Deposit = (): JSX.Element => {
       <CopyInputBox>
         {currentAccount && (
           <Text type='body2Reg' display='inline-flex'>
-            {isSession ? (
-              <MasterLabel>
-                Master
-                <InfoTooltip content={MASTER_DEPOSIT_TOOLTIP} variant='popover' />
-              </MasterLabel>
-            ) : (
-              formatNickname(accountNames[currentAccount.id] || currentAccount.name, 12)
-            )}
+            {formatNickname(accountNames[currentAccount.id] || currentAccount.name, 12)}
             <Text type='body2Reg' color={theme.neutral.a}>
               {` (${displayAddr})`}
             </Text>

--- a/packages/adena-extension/src/pages/popup/wallet/deposit/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/deposit/index.tsx
@@ -1,3 +1,4 @@
+import { isSessionAccount } from 'adena-module';
 import { QRCodeSVG } from 'qrcode.react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
@@ -109,6 +110,15 @@ export const Deposit = (): JSX.Element => {
       setDisplayAddr(formatAddress(depositAddress, 6));
     }
   }, [depositAddress]);
+
+  // Defense in depth: a SessionAccount address can never receive tokens, so the
+  // Deposit page must not be reachable in a session context even if some entry
+  // point is missed. Redirect back to the wallet if we get here.
+  useEffect(() => {
+    if (currentAccount && isSessionAccount(currentAccount)) {
+      navigate(RoutePath.Wallet);
+    }
+  }, [currentAccount, navigate]);
 
   const closeButtonClick = useCallback(() => {
     if (params?.type === 'wallet') {

--- a/packages/adena-extension/src/pages/popup/wallet/nft/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/nft/index.tsx
@@ -1,3 +1,4 @@
+import { isSessionAccount } from 'adena-module';
 import styled from 'styled-components';
 
 import NFTCollections from '@components/pages/nft/nft-collections/nft-collections';
@@ -32,10 +33,17 @@ const Wrapper = styled.main<{ $dimmed: boolean }>`
 `;
 
 export const Nft = (): JSX.Element => {
-  const { currentFundingAddress } = useCurrentAccount();
+  const { currentAccount, currentFundingAddress } = useCurrentAccount();
   const { navigate } = useAppNavigate();
   const { openScannerLink } = useLink();
   const sessionRevoked = useIsCurrentSessionRevoked();
+
+  // A SessionAccount address can never receive tokens, so the NFT deposit entry
+  // point is hidden and navigation to the Deposit page is blocked.
+  const isSession = useMemo(
+    () => (currentAccount ? isSessionAccount(currentAccount) : false),
+    [currentAccount],
+  );
 
   const { data: collections, isFetched: isFetchedCollections } = useGetGRC721Collections({
     refetchOnMount: true,
@@ -80,6 +88,9 @@ export const Nft = (): JSX.Element => {
   }, [currentFundingAddress, openScannerLink]);
 
   const moveDepositPage = useCallback(() => {
+    if (isSession) {
+      return;
+    }
     navigate(RoutePath.Deposit, {
       state: {
         token: {
@@ -88,7 +99,7 @@ export const Nft = (): JSX.Element => {
         type: 'token',
       },
     });
-  }, [navigate]);
+  }, [navigate, isSession]);
 
   const moveCollectionPage = useCallback(
     (collection: GRC721CollectionModel) => {
@@ -103,7 +114,11 @@ export const Nft = (): JSX.Element => {
 
   return (
     <Wrapper $dimmed={sessionRevoked}>
-      <NFTHeader openGnoscan={openGnoscan} moveDepositPage={moveDepositPage} />
+      <NFTHeader
+        openGnoscan={openGnoscan}
+        moveDepositPage={moveDepositPage}
+        isSessionAccount={isSession}
+      />
       <NFTCollections
         collections={collections}
         isFetchedCollections={isFinishFetchedCollections}

--- a/packages/adena-extension/src/pages/popup/wallet/token-details/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/token-details/index.tsx
@@ -1,4 +1,4 @@
-import { isAirgapAccount, isMultisigAccount } from 'adena-module';
+import { isAirgapAccount, isMultisigAccount, isSessionAccount } from 'adena-module';
 import BigNumber from 'bignumber.js';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
@@ -107,6 +107,10 @@ export const TokenDetails = (): JSX.Element => {
   // users can still see balances but immediately understand they can't send.
   const isMultisigCosmosBlocked =
     isCosmosNative && !!currentAccount && isMultisigAccount(currentAccount);
+
+  // A SessionAccount address can never receive tokens, so depositing to it is
+  // blocked; users deposit to the Master Account instead.
+  const isSession = !!currentAccount && isSessionAccount(currentAccount);
 
   const tokenPath = useMemo(() => {
     if (!tokenBalance || !isGRC20TokenModel(tokenBalance)) {
@@ -256,7 +260,11 @@ export const TokenDetails = (): JSX.Element => {
 
       <DoubleButton
         margin='20px 0px 25px'
-        leftProps={{ onClick: DepositButtonClick, text: 'Deposit' }}
+        leftProps={{
+          onClick: DepositButtonClick,
+          text: 'Deposit',
+          props: { disabled: isSession },
+        }}
         rightProps={{
           onClick: SendButtonClick,
           text: 'Send',

--- a/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
@@ -1,4 +1,4 @@
-import { isAirgapAccount, isMultisigAccount } from 'adena-module';
+import { isAirgapAccount, isMultisigAccount, isSessionAccount } from 'adena-module';
 import BigNumber from 'bignumber.js';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useRecoilState } from 'recoil';
@@ -105,6 +105,12 @@ export const WalletMain = (): JSX.Element => {
   const networkUnresponsive = failedNetwork === true;
   const sessionRevoked = useIsCurrentSessionRevoked();
   const actionsDisabled = networkUnresponsive || sessionRevoked;
+  // A SessionAccount address can never receive tokens, so depositing to it is
+  // blocked; users deposit to the Master Account instead.
+  const isSession = useMemo(
+    () => (currentAccount ? isSessionAccount(currentAccount) : false),
+    [currentAccount],
+  );
 
   const { addLoadingImages, completeImageLoading } = useLoadImages();
 
@@ -295,7 +301,7 @@ export const WalletMain = (): JSX.Element => {
           icon={<IconDeposit />}
           label='Deposit'
           onClick={onClickDepositButton}
-          disabled={actionsDisabled}
+          disabled={actionsDisabled || isSession}
         />
         <MainActionButton
           icon={<IconSend />}

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-mapper.spec.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-mapper.spec.ts
@@ -18,13 +18,18 @@ const baseItem = (overrides: Partial<TransactionHistoryItem> = {}): TransactionH
   ...overrides,
 });
 
-const mapOne = (item: TransactionHistoryItem): ReturnType<
-  typeof TransactionHistoryMapper.fromResponse
->['transactions'][number] =>
+const mapWith = (
+  item: TransactionHistoryItem,
+  accountAddress: string,
+): ReturnType<typeof TransactionHistoryMapper.fromResponse>['transactions'][number] =>
   TransactionHistoryMapper.fromResponse(
     { page: { cursor: '', hasNext: false }, items: [item] },
-    'g1master',
+    accountAddress,
   ).transactions[0];
+
+const mapOne = (item: TransactionHistoryItem): ReturnType<
+  typeof TransactionHistoryMapper.fromResponse
+>['transactions'][number] => mapWith(item, 'g1master');
 
 describe('TransactionHistoryMapper session attribution', () => {
   // The rows must come from the transaction, not the current account, so a
@@ -50,5 +55,53 @@ describe('TransactionHistoryMapper session attribution', () => {
 
     expect(mapped.callerAddress).toBe('');
     expect(mapped.sessionAddress).toBe('');
+  });
+});
+
+describe('TransactionHistoryMapper transfer counterparty (To/From)', () => {
+  // Direction is decided relative to the queried account: to === account means a
+  // Receive (show the sender), otherwise a Send (show the recipient).
+  const transferItem = { fromAddress: 'g1sender', toAddress: 'g1recipient' };
+
+  it('shows the recipient (To) for a sent bank.MsgSend', () => {
+    const mapped = mapWith(baseItem(transferItem), 'g1sender');
+
+    expect(mapped.typeName).toBe('Send');
+    expect(mapped.description).toBe('To: g1recipient');
+  });
+
+  it('shows the sender (From) for a received bank.MsgSend', () => {
+    const mapped = mapWith(baseItem(transferItem), 'g1recipient');
+
+    expect(mapped.typeName).toBe('Receive');
+    expect(mapped.description).toBe('From: g1sender');
+  });
+
+  it('shows the recipient (To) for a sent GRC20 transfer', () => {
+    const mapped = mapWith(
+      baseItem({
+        ...transferItem,
+        isGRC20Transfer: true,
+        func: [{ funcType: 'Transfer', messageType: '/vm.m_call', pkgPath: '' }],
+      }),
+      'g1sender',
+    );
+
+    expect(mapped.typeName).toBe('Send');
+    expect(mapped.description).toBe('To: g1recipient');
+  });
+
+  it('shows the sender (From) for a received GRC20 transfer', () => {
+    const mapped = mapWith(
+      baseItem({
+        ...transferItem,
+        isGRC20Transfer: true,
+        func: [{ funcType: 'Transfer', messageType: '/vm.m_call', pkgPath: '' }],
+      }),
+      'g1recipient',
+    );
+
+    expect(mapped.typeName).toBe('Receive');
+    expect(mapped.description).toBe('From: g1sender');
   });
 });

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-mapper.ts
@@ -212,10 +212,12 @@ export class TransactionHistoryMapper {
       valueType = isReceived ? 'ACTIVE' : 'DEFAULT';
     }
 
-    const description =
-      historyItem.func[0].messageType === '/bank.MsgSend'
-        ? `To: ${formatAddress(historyItem.toAddress, 4)}`
-        : `From: ${formatAddress(historyItem.fromAddress, 4)}`;
+    // Show the counterparty: on a Send the recipient (To), on a Receive the
+    // sender (From). Direction is derived from the queried account, so keying the
+    // label off isReceived keeps it correct for both bank sends and GRC20 transfers.
+    const description = isReceived
+      ? `From: ${formatAddress(historyItem.fromAddress, 4)}`
+      : `To: ${formatAddress(historyItem.toAddress, 4)}`;
 
     const amount = isReceived ? historyItem.amountIn : historyItem.amountOut;
 

--- a/packages/adena-extension/src/router/popup/header/top-menu/index.tsx
+++ b/packages/adena-extension/src/router/popup/header/top-menu/index.tsx
@@ -16,6 +16,7 @@ import { AdenaStorage } from '@common/storage';
 import { isRevokedSessionAccount } from '@common/utils/account-session';
 import { formatNickname, getSiteName } from '@common/utils/client-utils';
 import { AccountAddressesPopover } from '@components/pages/router/top-menu/account-addresses-popover';
+import { SessionAddressWarningPopover } from '@components/pages/router/top-menu/session-address-warning-popover';
 import { SessionOverviewPopover } from '@components/pages/router/top-menu/session-overview-popover';
 import { useAccountChainAddresses } from '@hooks/use-account-chain-addresses';
 import { useAccountListInfos } from '@hooks/use-account-list-infos';
@@ -100,6 +101,7 @@ const StyledCopyIconButton = styled.button.withConfig({
 `;
 
 const COPY_POPOVER_WIDTH = 220;
+const SESSION_WARNING_POPOVER_WIDTH = 320;
 const SESSION_POPOVER_RIGHT_MARGIN = 16;
 
 export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
@@ -157,16 +159,18 @@ export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
 
   const chainAddressEntries = useAccountChainAddresses();
   const [addressCopied, setAddressCopied] = useState(false);
+  const isSession = currentAccount !== null && isSessionAccount(currentAccount);
 
-  // The funding address is the one that can actually receive tokens: the master
-  // address for a SessionAccount, the account's own Gno address otherwise.
+  // A SessionAccount address can never receive tokens, so copying it is disabled;
+  // hovering the icon shows a warning to use the Master Account instead. For every
+  // other account the funding address is the one that can actually receive tokens.
   const handleCopyIconClick = useCallback(() => {
-    if (!currentFundingAddress) {
+    if (isSession || !currentFundingAddress) {
       return;
     }
     navigator.clipboard.writeText(currentFundingAddress);
     setAddressCopied(true);
-  }, [currentFundingAddress]);
+  }, [isSession, currentFundingAddress]);
 
   useEffect(() => {
     if (!addressCopied) {
@@ -182,11 +186,14 @@ export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
     if (anchor) {
       const rect = anchor.getBoundingClientRect();
       const iconCenterX = rect.left + rect.width / 2;
-      const popoverLeft = (window.innerWidth - COPY_POPOVER_WIDTH) / 2;
+      // Both popovers are centered on screen (left: 50% + translateX(-50%)), so the
+      // caret offset must be measured against each popover's own width.
+      const popoverWidth = isSession ? SESSION_WARNING_POPOVER_WIDTH : COPY_POPOVER_WIDTH;
+      const popoverLeft = (window.innerWidth - popoverWidth) / 2;
       setCopyPosition({ x: iconCenterX - popoverLeft, y: rect.bottom + 16 });
     }
     copyPopover.setOpen(true);
-  }, [copyPopover]);
+  }, [copyPopover, isSession]);
 
   const handleSessionIconMouseEnter = useCallback(() => {
     sessionPopover.cancelClose();
@@ -260,7 +267,6 @@ export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
   };
 
   const displayHostname = hostname && hostname.includes('.') ? hostname : 'chrome-extension';
-  const isSession = currentAccount !== null && isSessionAccount(currentAccount);
   const sessionMetadata =
     isSession && currentAddress
       ? sessions.find((s) => s.sessionAddr === currentAddress)
@@ -317,9 +323,9 @@ export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
             onClick={handleCopyIconClick}
             onMouseEnter={handleCopyIconMouseEnter}
             onMouseLeave={copyPopover.onAnchorMouseLeave}
-            aria-label='Copy address'
+            aria-label={isSession ? 'Session account address info' : 'Copy address'}
           >
-            {addressCopied ? <IconCopyCheck /> : <IconCopy />}
+            {addressCopied && !isSession ? <IconCopyCheck /> : <IconCopy />}
           </StyledCopyIconButton>
         </StyledLeftSideWrapper>
         <StyledRightSideWrapper>
@@ -339,14 +345,24 @@ export const TopMenu = ({ disabled }: { disabled?: boolean }): JSX.Element => {
           <HamburgerMenuBtn type='button' onClick={goToSettings} />
         </StyledRightSideWrapper>
       </Header>
-      <AccountAddressesPopover
-        open={copyPopover.open}
-        positionX={copyPosition.x}
-        positionY={copyPosition.y}
-        onMouseEnter={copyPopover.onPopoverMouseEnter}
-        onMouseLeave={copyPopover.onPopoverMouseLeave}
-        entries={chainAddressEntries}
-      />
+      {isSession ? (
+        <SessionAddressWarningPopover
+          open={copyPopover.open}
+          positionX={copyPosition.x}
+          positionY={copyPosition.y}
+          onMouseEnter={copyPopover.onPopoverMouseEnter}
+          onMouseLeave={copyPopover.onPopoverMouseLeave}
+        />
+      ) : (
+        <AccountAddressesPopover
+          open={copyPopover.open}
+          positionX={copyPosition.x}
+          positionY={copyPosition.y}
+          onMouseEnter={copyPopover.onPopoverMouseEnter}
+          onMouseLeave={copyPopover.onPopoverMouseLeave}
+          entries={chainAddressEntries}
+        />
+      )}
       {sessionConfig && (
         <SessionOverviewPopover
           open={sessionPopover.open}


### PR DESCRIPTION
## Summary

A Session Account address can never receive tokens — funds must be sent to the
Master Account instead. This PR removes every UI affordance that could lead a
user to deposit into a session address and clarifies the intended flow.

## Changes

### Header
- Removed the copy action for session accounts. The copy icon no longer copies
  the address; hovering it now shows a warning popover instead:
  _"Do not send tokens to your Session Account. Use the Master Account's address
  to receive tokens."_
- Non-session accounts keep the existing per-chain address copy popover.

### Deposit entry points
- Disabled the **Deposit** button for session accounts on both the Wallet Main
  and Token Details screens.

### Account lists & details
- Hid the session account address (and copy icon) in the side menu account list.
- Hid the QR code and address block in the Account Details page for session
  accounts.

### Deposit token page
- Removed the now-deprecated master-address branch (Master label + tooltip).
  Session accounts can no longer reach this page, so the special-case UI was
  dead code.

### Fix
- `MainActionButton` still applied its `:hover` background while `disabled`
  because the `:disabled` rule did not override the background. Scoped the hover
  to `:not(:disabled)` so disabled buttons (e.g. Deposit on a session account)
  no longer react to hover.
