### PR TITLE
fix: register custom gno networks into chainRegistry so dApp establish works

### DIFF
--- a/packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx
+++ b/packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx
@@ -2,17 +2,18 @@ import { AdenaWallet, Wallet } from 'adena-module';
 import React, { createContext, useEffect, useState } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
-import { AtomoneNetworkMetainfoMapper } from '@repositories/common/mapper/atomone-network-metainfo-mapper';
-import { useAdenaContext } from '@hooks/use-context';
-import {
-  atomoneNetworkToProfile,
-  atomoneNetworkToTokenProfiles,
-} from '@hooks/helpers/atomone-to-profile';
+import { toGnoNetworkProfile } from '@common/mapper/network-profile-mapper';
 import {
   normalizeStoredId,
   pickDefaultByMode,
   resolveNetworkMode,
 } from '@common/utils/network-default';
+import {
+  atomoneNetworkToProfile,
+  atomoneNetworkToTokenProfiles,
+} from '@hooks/helpers/atomone-to-profile';
+import { useAdenaContext } from '@hooks/use-context';
+import { AtomoneNetworkMetainfoMapper } from '@repositories/common/mapper/atomone-network-metainfo-mapper';
 import { NetworkState, TokenState, WalletState } from '@states';
 import { AtomoneNetworkMetainfo, NetworkMetainfo, StateType, TokenModel } from '@types';
 import { GnoProvider } from '../gno/gno-provider';
@@ -35,8 +36,13 @@ export interface WalletContextProps {
 export const WalletContext = createContext<WalletContextProps | null>(null);
 
 export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
-  const { walletService, accountService, chainService, chainRegistry, tokenRegistry } =
-    useAdenaContext();
+  const {
+    walletService,
+    accountService,
+    chainService,
+    chainRegistry,
+    tokenRegistry,
+  } = useAdenaContext();
 
   const [gnoProvider, setGnoProvider] = useState<GnoProvider>();
 
@@ -104,8 +110,7 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
     if (!selected) {
       selected = candidates.find((network) => network.isMainnet === wantsMainnet) ?? null;
     } else if (selected.isMainnet !== wantsMainnet) {
-      selected =
-        candidates.find((network) => network.isMainnet === wantsMainnet) ?? selected;
+      selected = candidates.find((network) => network.isMainnet === wantsMainnet) ?? selected;
     }
     if (selected) {
       setCurrentAtomoneNetwork(selected);
@@ -188,6 +193,12 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
 
     setNetworkMetainfos(networkMetainfos);
     chainService.updateNetworks(networkMetainfos);
+
+    // Mirror every persisted gno network (defaults + user-added customs) into chainRegistry.
+    for (const network of networkMetainfos) {
+      if (network.deleted) continue;
+      chainRegistry.register(toGnoNetworkProfile(network));
+    }
 
     const atomoneNetworks = await loadAtomoneNetworks();
 

--- a/packages/adena-extension/src/hooks/use-network.ts
+++ b/packages/adena-extension/src/hooks/use-network.ts
@@ -194,6 +194,11 @@ export const useNetwork = (): NetworkResponse => {
       await chainService.addGnoNetwork(parsedName, changedRpcUrl, chainId, extra.indexerUrl ?? '');
       const updatedNetworks = await chainService.getNetworks();
       setNetworkMetainfos(updatedNetworks);
+
+      for (const network of updatedNetworks) {
+        if (network.deleted) continue;
+        chainRegistry.register(toGnoNetworkProfile(network));
+      }
     },
     [networkMetainfos, atomoneNetworks, chainService],
   );

--- a/packages/adena-extension/src/inject/message/methods/core.ts
+++ b/packages/adena-extension/src/inject/message/methods/core.ts
@@ -1,6 +1,7 @@
 import { Account, ChainRegistry, createChainRegistry } from 'adena-module';
 import axios from 'axios';
 
+import { toGnoNetworkProfile } from '@common/mapper/network-profile-mapper';
 import { GnoProvider } from '@common/provider/gno/gno-provider';
 import { MemoryProvider } from '@common/provider/memory/memory-provider';
 import { AdenaStorage } from '@common/storage';
@@ -10,6 +11,7 @@ import {
   makeAtomOneNetworkProfiles,
   makeGnoNetworkProfiles,
 } from '@common/utils/chain-utils';
+import { atomoneNetworkToProfile } from '@hooks/helpers/atomone-to-profile';
 import { ChainRepository, TokenRepository } from '@repositories/common';
 import {
   WalletAccountRepository,
@@ -100,6 +102,28 @@ export class InjectCore {
 
   public async getInMemoryKey(): Promise<CryptoKey | null> {
     return getInMemoryKey(this.inMemoryProvider);
+  }
+
+  public async hydrateChainRegistry(): Promise<void> {
+    try {
+      const gnoNetworks = await this.chainService.getNetworks();
+      for (const network of gnoNetworks) {
+        if (network.deleted) continue;
+        this.chainRegistry.register(toGnoNetworkProfile(network));
+      }
+    } catch (e) {
+      console.error(e);
+    }
+
+    try {
+      const atomoneNetworks = await this.chainService.getAtomoneNetworks();
+      for (const network of atomoneNetworks) {
+        if (network.deleted) continue;
+        this.chainRegistry.register(atomoneNetworkToProfile(network));
+      }
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   public async initGnoProvider(): Promise<boolean> {

--- a/packages/adena-extension/src/inject/message/methods/wallet.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/wallet.spec.ts
@@ -79,6 +79,7 @@ type FakeCore = {
   getCurrentAccountId: jest.Mock;
   getInMemoryKey: jest.Mock;
   isLockedBy: jest.Mock;
+  hydrateChainRegistry: jest.Mock;
 };
 
 function makeCore(overrides?: Partial<FakeCore>): FakeCore {
@@ -100,6 +101,7 @@ function makeCore(overrides?: Partial<FakeCore>): FakeCore {
     getCurrentAccountId: jest.fn(async () => 'acc-1'),
     getInMemoryKey: jest.fn(async () => null),
     isLockedBy: jest.fn(async () => false),
+    hydrateChainRegistry: jest.fn(async () => undefined),
     ...overrides,
   };
 }

--- a/packages/adena-extension/src/inject/message/methods/wallet.ts
+++ b/packages/adena-extension/src/inject/message/methods/wallet.ts
@@ -141,6 +141,10 @@ export const addEstablish = async (
 
   const isLocked = await core.isLockedBy(inMemoryKey);
 
+  // Merge user-added custom networks into the registry so getChainByChainId resolves them below.
+  // Without this the multi-chain path rejects a network the user already added with UNADDED_NETWORK.
+  await core.hydrateChainRegistry();
+
   const accountId = await core.getCurrentAccountId();
   const siteName = getSiteName(message.protocol, message.hostname);
 


### PR DESCRIPTION
## Summary

Fixes an error that occurred after adding a **custom (user-added) gno network**, switching to it, and having a dApp call `adena.AddEstablish()`.

Custom gno networks were persisted to storage and the recoil atom, but they were **never registered into the `chainRegistry`**. The registry was seeded only from the bundled `chains.json`, so `getChainByChainId(chainId)` returned `undefined` for any custom chainId. This broke the establish flow in two places:

- **Background `InjectCore`** (`addEstablish`): the multi-chain path rejected the *already added* network with `UNADDED_NETWORK`.
- **`approve-establish` popup** (`establishBy` → `resolveSiblingChainIds`): threw `Unknown chainId` when persisting the connection.

AtomOne networks already self-registered on add / update / hydrate; gno only did so on `updateNetwork`. This PR makes the gno path symmetric.

## Root cause

`chainRegistry` is built from static bundled data only:

```ts
createChainRegistry({
  chains: [GNO_CHAIN, ATOMONE_CHAIN],
  gnoNetworkProfiles: makeGnoNetworkProfiles(GNO_CHAIN_DATA), // chains.json only
  atomoneNetworkProfiles: makeAtomOneNetworkProfiles(ATOMONE_CHAIN_DATA),
});
```

Custom gno networks live only in `NetworkState.networkMetainfos`, so the registry never learns their chainId.

## Changes

| Layer | Before | After |
| --- | --- | --- |
| App/popup load (`WalletProvider.initNetworkMetainfos`) | gno not registered | registers every persisted gno network |
| `useNetwork.addNetwork` (gno branch) | not registered | registers newly added gno networks immediately |
| Background `InjectCore` | static registry only | new `hydrateChainRegistry()` merges persisted gno + atomone networks; `addEstablish` calls it before consulting the registry |

- `packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx`
- `packages/adena-extension/src/hooks/use-network.ts`
- `packages/adena-extension/src/inject/message/methods/core.ts`
- `packages/adena-extension/src/inject/message/methods/wallet.ts`

`register()` overwrites by profile id, so re-registering bundled defaults is a no-op.

## Reproduction (before this fix)

1. Add a Custom Network
2. `adena.SwitchNetwork('<chainId>')`
3. `adena.AddEstablish()` → error (`UNADDED_NETWORK` / `Unknown chainId`)

After this fix, the establish completes normally on custom gno networks.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Manual: add custom gno network → switch → `AddEstablish()` succeeds
- [ ] Regression: bundled networks (gnoland1, topaz, etc.) and AtomOne establish still work