### PR TITLE
Never present an unfetched balance as a real one

### DIFF
--- a/packages/adena-extension/src/App/web.tsx
+++ b/packages/adena-extension/src/App/web.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { WebRouter } from '@router/web/index';
+import OfflineBanner from '@components/atoms/offline-banner';
 
 import AppProvider from './app-provider';
 import useApp from './use-app';
@@ -8,7 +9,12 @@ import { MemoryRouter } from 'react-router-dom';
 
 const RunApp = (): ReactElement => {
   useApp();
-  return <WebRouter />;
+  return (
+    <>
+      <OfflineBanner />
+      <WebRouter />
+    </>
+  );
 };
 
 const App = (): ReactElement => {

--- a/packages/adena-extension/src/App/web.tsx
+++ b/packages/adena-extension/src/App/web.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 import { WebRouter } from '@router/web/index';
-import { OfflineBanner } from '@components/atoms';
 
 import AppProvider from './app-provider';
 import useApp from './use-app';
@@ -9,12 +8,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 const RunApp = (): ReactElement => {
   useApp();
-  return (
-    <>
-      <OfflineBanner />
-      <WebRouter />
-    </>
-  );
+  return <WebRouter />;
 };
 
 const App = (): ReactElement => {

--- a/packages/adena-extension/src/App/web.tsx
+++ b/packages/adena-extension/src/App/web.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { WebRouter } from '@router/web/index';
-import OfflineBanner from '@components/atoms/offline-banner';
+import { OfflineBanner } from '@components/atoms';
 
 import AppProvider from './app-provider';
 import useApp from './use-app';

--- a/packages/adena-extension/src/components/atoms/index.ts
+++ b/packages/adena-extension/src/components/atoms/index.ts
@@ -33,6 +33,7 @@ export * from './main-action-button';
 export * from './skeleton-box';
 export * from './secure-textarea';
 export * from './warning-triangle-icon';
+export * from './offline-banner';
 export * from './base';
 // web
 export * from './web-text';

--- a/packages/adena-extension/src/components/atoms/offline-banner/index.tsx
+++ b/packages/adena-extension/src/components/atoms/offline-banner/index.tsx
@@ -9,40 +9,16 @@ import { OfflineBannerWrapper } from './offline-banner.styles';
 
 const SPINNER_SIZE = 14;
 
-/**
- * A TOP-LEVEL BAR FOR THE OFFLINE CASE, because Adena had no offline UI at all.
- *
- * Nothing in this extension read navigator.onLine or react-query's onlineManager,
- * and no screen said "offline" anywhere. react-query's default networkMode is
- * 'online', which PAUSES a query while the browser reports offline: it never
- * runs, never errors, and its status stays 'loading' for ever. Combined with
- * screens that render an empty container while loading, an offline browser saw
- * blank pages with nothing in the console.
- *
- * VISIBILITY FOLLOWS THE BROWSER, NOT react-query's FLAG. The first version of
- * this bar hid itself as soon as Retry was pressed, because Retry calls
- * onlineManager.setOnline(true) and the bar was keyed on onlineManager. So a
- * user still offline pressed Retry and the warning vanished — the interface
- * asserting a connection it had no evidence for, which is precisely the silent
- * lie this component exists to end. The raw browser signal decides whether the
- * bar shows; the override only changes what it SAYS.
- *
- * WHY AN OVERRIDE AT ALL. navigator.onLine is the OS's "is there any route"
- * signal and it is wrong often enough to matter — a wedged Chrome network
- * notifier reports offline on a perfectly connected machine, and then every
- * paused query hangs until the browser is restarted. Retry tells react-query to
- * proceed regardless. A user who can see their connection working should not be
- * blocked by a signal they can observe to be false; but they should also be told,
- * for as long as it lasts, that they are running against the browser's claim.
- *
- * The bar carries no positioning of its own: hosts differ (the popup pins a
- * fixed header and network label above it, the web pages do not), so each one
- * places it. See wallet-main for the popup slot.
- */
-
 const isBrowserOffline = (): boolean =>
   typeof navigator !== 'undefined' && navigator.onLine === false;
 
+/**
+ * Offline notice. Carries no positioning; each host places it.
+ *
+ * Visibility is keyed on the raw browser signal, not on onlineManager: Retry
+ * sets the manager online, so keying on it would hide the warning while still
+ * offline. Retry only changes what the bar says.
+ */
 export const OfflineBanner = (): ReactElement | null => {
   const queryClient = useQueryClient();
   const [offline, setOffline] = useState(isBrowserOffline);
@@ -50,8 +26,6 @@ export const OfflineBanner = (): ReactElement | null => {
 
   useEffect(() => {
     const onOnline = (): void => {
-      // A REAL recovery: drop the override so the next genuine outage is
-      // reported honestly rather than silently suppressed by an old click.
       setOffline(false);
       setOverridden(false);
       onlineManager.setOnline(undefined);
@@ -59,12 +33,8 @@ export const OfflineBanner = (): ReactElement | null => {
     };
     const onOffline = (): void => {
       setOffline(true);
-      // THE OVERRIDE MUST NOT SURVIVE A NEW OUTAGE. setOnline(true) is sticky
-      // for the session, so a Retry pressed during an earlier wedge left the
-      // manager claiming online for ever after. The next real disconnection
-      // then went undetected: nothing was paused, keepPreviousData kept showing
-      // the last figures, and a chain only admitted it was stale when it
-      // happened to error on its own. Hand the decision back to the signal.
+      // setOnline(true) is sticky for the session, so an old Retry would leave
+      // the manager claiming online and the next outage would go unreported.
       onlineManager.setOnline(undefined);
       setOverridden(false);
     };
@@ -77,11 +47,9 @@ export const OfflineBanner = (): ReactElement | null => {
     };
   }, [queryClient]);
 
+  // navigator.onLine reports offline on a connected machine often enough to
+  // matter, and every paused query then hangs. Proceed regardless.
   const retry = useCallback((): void => {
-    // Force react-query to proceed, then refetch. If the browser was telling the
-    // truth the requests fail into their own error states; if it was not,
-    // everything works again. Either way the bar stays up while the browser
-    // still claims to be offline.
     onlineManager.setOnline(true);
     setOverridden(true);
     queryClient.refetchQueries({ type: 'active' });
@@ -101,9 +69,8 @@ export const OfflineBanner = (): ReactElement | null => {
       <span className='indicator'>
         {overridden ? <Spinner size={SPINNER_SIZE} /> : <WarningTriangleIcon size={SPINNER_SIZE} />}
       </span>
+      {/* Kept to one line: every wrapped line costs 21px of a 540px popup. */}
       <span className='message'>
-        {/* Kept to roughly one line: the popup is 360px wide and every wrapped
-            line costs 21px of a 540px screen. The long form ran to four. */}
         {overridden ? (
           <>
             <span className='headline'>Retrying anyway.</span> Your browser still reports no

--- a/packages/adena-extension/src/components/atoms/offline-banner/index.tsx
+++ b/packages/adena-extension/src/components/atoms/offline-banner/index.tsx
@@ -1,37 +1,13 @@
 import { onlineManager, useQueryClient } from '@tanstack/react-query';
-import { ReactElement, useCallback, useEffect, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 
-const SPIN_STYLE_ID = 'adena-offline-spin';
+import { Button } from '@components/atoms/button';
+import { Spinner } from '@components/atoms/spinner';
+import { WarningTriangleIcon } from '@components/atoms/warning-triangle-icon';
 
-/** Injected once: @keyframes cannot be expressed in an inline style attribute. */
-const ensureSpinKeyframes = (): void => {
-  if (typeof document === 'undefined' || document.getElementById(SPIN_STYLE_ID)) {
-    return;
-  }
-  const el = document.createElement('style');
-  el.id = SPIN_STYLE_ID;
-  el.textContent =
-    '@keyframes adena-offline-spin{to{transform:rotate(360deg)}}' +
-    '@media (prefers-reduced-motion: reduce){' +
-    '.adena-offline-spinner{animation:none!important;opacity:.6}}';
-  document.head.appendChild(el);
-};
+import { OfflineBannerWrapper } from './offline-banner.styles';
 
-const Spinner = (): ReactElement => (
-  <span
-    className='adena-offline-spinner'
-    aria-hidden='true'
-    style={{
-      width: 12,
-      height: 12,
-      flex: '0 0 auto',
-      borderRadius: '50%',
-      border: '2px solid rgba(245, 200, 106, 0.3)',
-      borderTopColor: '#f5c86a',
-      animation: 'adena-offline-spin 0.8s linear infinite',
-    }}
-  />
-);
+const SPINNER_SIZE = 14;
 
 /**
  * A TOP-LEVEL BAR FOR THE OFFLINE CASE, because Adena had no offline UI at all.
@@ -58,6 +34,10 @@ const Spinner = (): ReactElement => (
  * proceed regardless. A user who can see their connection working should not be
  * blocked by a signal they can observe to be false; but they should also be told,
  * for as long as it lasts, that they are running against the browser's claim.
+ *
+ * The bar carries no positioning of its own: hosts differ (the popup pins a
+ * fixed header and network label above it, the web pages do not), so each one
+ * places it. See wallet-main for the popup slot.
  */
 
 const isBrowserOffline = (): boolean =>
@@ -67,8 +47,6 @@ export const OfflineBanner = (): ReactElement | null => {
   const queryClient = useQueryClient();
   const [offline, setOffline] = useState(isBrowserOffline);
   const [overridden, setOverridden] = useState(false);
-
-  useEffect(ensureSpinKeyframes, []);
 
   useEffect(() => {
     const onOnline = (): void => {
@@ -119,56 +97,34 @@ export const OfflineBanner = (): ReactElement | null => {
   }
 
   return (
-    <div
-      role='status'
-      style={{
-        // STICKY, NOT STATIC, and in its own stacking context. In flow it was
-        // drawn under the "You are on <network>" label, which is also in flow
-        // and paints later.
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        padding: '8px 12px',
-        background: '#3a2f1a',
-        borderBottom: '1px solid #6b5426',
-        color: '#f5c86a',
-        fontSize: 12,
-        lineHeight: 1.4,
-      }}
-    >
-      {overridden ? <Spinner /> : null}
-      <span style={{ flex: 1 }}>
+    <OfflineBannerWrapper role='status'>
+      <span className='indicator'>
+        {overridden ? <Spinner size={SPINNER_SIZE} /> : <WarningTriangleIcon size={SPINNER_SIZE} />}
+      </span>
+      <span className='message'>
         {overridden ? (
           <>
-            <strong style={{ fontWeight: 600 }}>Retrying anyway.</strong> Your
-            browser still reports no connection. Chain requests are being sent
-            regardless — if they fail, that signal was right.
+            <span className='headline'>Retrying anyway.</span> Your browser still reports no
+            connection. Chain requests are being sent regardless — if they fail, that signal was
+            right.
           </>
         ) : (
           <>
-            <strong style={{ fontWeight: 600 }}>No network connection.</strong>{' '}
-            Your accounts and addresses are shown from local storage; balances
-            and chain data are paused until you reconnect.
+            <span className='headline'>No network connection.</span> Your accounts and addresses are
+            shown from local storage; balances and chain data are paused until you reconnect.
           </>
         )}
       </span>
-      <button
-        type='button'
+      <Button
+        className='action-button'
+        hierarchy='ghost'
+        height='26px'
+        radius='6px'
         onClick={overridden ? stop : retry}
-        style={{
-          flex: '0 0 auto',
-          padding: '5px 12px',
-          borderRadius: 5,
-          border: '1px solid #6b5426',
-          background: 'transparent',
-          color: '#f5c86a',
-          cursor: 'pointer',
-          fontSize: 12,
-        }}
       >
         {overridden ? 'Stop' : 'Retry'}
-      </button>
-    </div>
+      </Button>
+    </OfflineBannerWrapper>
   );
 };
 

--- a/packages/adena-extension/src/components/atoms/offline-banner/index.tsx
+++ b/packages/adena-extension/src/components/atoms/offline-banner/index.tsx
@@ -1,0 +1,175 @@
+import { onlineManager, useQueryClient } from '@tanstack/react-query';
+import { ReactElement, useCallback, useEffect, useState } from 'react';
+
+const SPIN_STYLE_ID = 'adena-offline-spin';
+
+/** Injected once: @keyframes cannot be expressed in an inline style attribute. */
+const ensureSpinKeyframes = (): void => {
+  if (typeof document === 'undefined' || document.getElementById(SPIN_STYLE_ID)) {
+    return;
+  }
+  const el = document.createElement('style');
+  el.id = SPIN_STYLE_ID;
+  el.textContent =
+    '@keyframes adena-offline-spin{to{transform:rotate(360deg)}}' +
+    '@media (prefers-reduced-motion: reduce){' +
+    '.adena-offline-spinner{animation:none!important;opacity:.6}}';
+  document.head.appendChild(el);
+};
+
+const Spinner = (): ReactElement => (
+  <span
+    className='adena-offline-spinner'
+    aria-hidden='true'
+    style={{
+      width: 12,
+      height: 12,
+      flex: '0 0 auto',
+      borderRadius: '50%',
+      border: '2px solid rgba(245, 200, 106, 0.3)',
+      borderTopColor: '#f5c86a',
+      animation: 'adena-offline-spin 0.8s linear infinite',
+    }}
+  />
+);
+
+/**
+ * A TOP-LEVEL BAR FOR THE OFFLINE CASE, because Adena had no offline UI at all.
+ *
+ * Nothing in this extension read navigator.onLine or react-query's onlineManager,
+ * and no screen said "offline" anywhere. react-query's default networkMode is
+ * 'online', which PAUSES a query while the browser reports offline: it never
+ * runs, never errors, and its status stays 'loading' for ever. Combined with
+ * screens that render an empty container while loading, an offline browser saw
+ * blank pages with nothing in the console.
+ *
+ * VISIBILITY FOLLOWS THE BROWSER, NOT react-query's FLAG. The first version of
+ * this bar hid itself as soon as Retry was pressed, because Retry calls
+ * onlineManager.setOnline(true) and the bar was keyed on onlineManager. So a
+ * user still offline pressed Retry and the warning vanished — the interface
+ * asserting a connection it had no evidence for, which is precisely the silent
+ * lie this component exists to end. The raw browser signal decides whether the
+ * bar shows; the override only changes what it SAYS.
+ *
+ * WHY AN OVERRIDE AT ALL. navigator.onLine is the OS's "is there any route"
+ * signal and it is wrong often enough to matter — a wedged Chrome network
+ * notifier reports offline on a perfectly connected machine, and then every
+ * paused query hangs until the browser is restarted. Retry tells react-query to
+ * proceed regardless. A user who can see their connection working should not be
+ * blocked by a signal they can observe to be false; but they should also be told,
+ * for as long as it lasts, that they are running against the browser's claim.
+ */
+
+const isBrowserOffline = (): boolean =>
+  typeof navigator !== 'undefined' && navigator.onLine === false;
+
+export const OfflineBanner = (): ReactElement | null => {
+  const queryClient = useQueryClient();
+  const [offline, setOffline] = useState(isBrowserOffline);
+  const [overridden, setOverridden] = useState(false);
+
+  useEffect(ensureSpinKeyframes, []);
+
+  useEffect(() => {
+    const onOnline = (): void => {
+      // A REAL recovery: drop the override so the next genuine outage is
+      // reported honestly rather than silently suppressed by an old click.
+      setOffline(false);
+      setOverridden(false);
+      onlineManager.setOnline(undefined);
+      queryClient.refetchQueries({ type: 'active' });
+    };
+    const onOffline = (): void => {
+      setOffline(true);
+      // THE OVERRIDE MUST NOT SURVIVE A NEW OUTAGE. setOnline(true) is sticky
+      // for the session, so a Retry pressed during an earlier wedge left the
+      // manager claiming online for ever after. The next real disconnection
+      // then went undetected: nothing was paused, keepPreviousData kept showing
+      // the last figures, and a chain only admitted it was stale when it
+      // happened to error on its own. Hand the decision back to the signal.
+      onlineManager.setOnline(undefined);
+      setOverridden(false);
+    };
+
+    window.addEventListener('online', onOnline);
+    window.addEventListener('offline', onOffline);
+    return (): void => {
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('offline', onOffline);
+    };
+  }, [queryClient]);
+
+  const retry = useCallback((): void => {
+    // Force react-query to proceed, then refetch. If the browser was telling the
+    // truth the requests fail into their own error states; if it was not,
+    // everything works again. Either way the bar stays up while the browser
+    // still claims to be offline.
+    onlineManager.setOnline(true);
+    setOverridden(true);
+    queryClient.refetchQueries({ type: 'active' });
+  }, [queryClient]);
+
+  const stop = useCallback((): void => {
+    onlineManager.setOnline(undefined);
+    setOverridden(false);
+  }, []);
+
+  if (!offline) {
+    return null;
+  }
+
+  return (
+    <div
+      role='status'
+      style={{
+        // STICKY, NOT STATIC, and in its own stacking context. In flow it was
+        // drawn under the "You are on <network>" label, which is also in flow
+        // and paints later.
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '8px 12px',
+        background: '#3a2f1a',
+        borderBottom: '1px solid #6b5426',
+        color: '#f5c86a',
+        fontSize: 12,
+        lineHeight: 1.4,
+      }}
+    >
+      {overridden ? <Spinner /> : null}
+      <span style={{ flex: 1 }}>
+        {overridden ? (
+          <>
+            <strong style={{ fontWeight: 600 }}>Retrying anyway.</strong> Your
+            browser still reports no connection. Chain requests are being sent
+            regardless — if they fail, that signal was right.
+          </>
+        ) : (
+          <>
+            <strong style={{ fontWeight: 600 }}>No network connection.</strong>{' '}
+            Your accounts and addresses are shown from local storage; balances
+            and chain data are paused until you reconnect.
+          </>
+        )}
+      </span>
+      <button
+        type='button'
+        onClick={overridden ? stop : retry}
+        style={{
+          flex: '0 0 auto',
+          padding: '5px 12px',
+          borderRadius: 5,
+          border: '1px solid #6b5426',
+          background: 'transparent',
+          color: '#f5c86a',
+          cursor: 'pointer',
+          fontSize: 12,
+        }}
+      >
+        {overridden ? 'Stop' : 'Retry'}
+      </button>
+    </div>
+  );
+};
+
+export default OfflineBanner;

--- a/packages/adena-extension/src/components/atoms/offline-banner/index.tsx
+++ b/packages/adena-extension/src/components/atoms/offline-banner/index.tsx
@@ -102,16 +102,17 @@ export const OfflineBanner = (): ReactElement | null => {
         {overridden ? <Spinner size={SPINNER_SIZE} /> : <WarningTriangleIcon size={SPINNER_SIZE} />}
       </span>
       <span className='message'>
+        {/* Kept to roughly one line: the popup is 360px wide and every wrapped
+            line costs 21px of a 540px screen. The long form ran to four. */}
         {overridden ? (
           <>
             <span className='headline'>Retrying anyway.</span> Your browser still reports no
-            connection. Chain requests are being sent regardless — if they fail, that signal was
-            right.
+            connection.
           </>
         ) : (
           <>
-            <span className='headline'>No network connection.</span> Your accounts and addresses are
-            shown from local storage; balances and chain data are paused until you reconnect.
+            <span className='headline'>No network connection.</span> Balances and chain data are
+            paused until you reconnect.
           </>
         )}
       </span>

--- a/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.spec.tsx
+++ b/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.spec.tsx
@@ -1,0 +1,72 @@
+import { onlineManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { PropsWithChildren } from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import theme from '@styles/theme';
+import { OfflineBanner } from '.';
+
+const setBrowserOnline = (online: boolean): void => {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value: online,
+  });
+};
+
+const Wrapper = ({ children }: PropsWithChildren): JSX.Element => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe('OfflineBanner', () => {
+  afterEach(() => {
+    // onlineManager is a module-level singleton; hand the decision back to the
+    // browser signal so one test's override cannot leak into the next.
+    onlineManager.setOnline(undefined);
+    setBrowserOnline(true);
+  });
+
+  it('renders nothing while the browser reports a connection', () => {
+    setBrowserOnline(true);
+
+    const { container } = render(<OfflineBanner />, { wrapper: Wrapper });
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('states the outage while the browser reports no connection', () => {
+    setBrowserOnline(false);
+
+    render(<OfflineBanner />, { wrapper: Wrapper });
+
+    expect(screen.getByRole('status').textContent).toContain('No network connection.');
+    expect(screen.getByRole('button').textContent).toContain('Retry');
+  });
+
+  it('keeps the bar up after Retry, saying it is running against the signal', () => {
+    setBrowserOnline(false);
+
+    render(<OfflineBanner />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole('button'));
+
+    // Visibility follows the browser, not the override: still offline, still shown.
+    expect(screen.getByRole('status').textContent).toContain('Retrying anyway.');
+    expect(screen.getByRole('button').textContent).toContain('Stop');
+    expect(onlineManager.isOnline()).toBe(true);
+  });
+
+  it('hands the decision back to the browser when Retry is stopped', () => {
+    setBrowserOnline(false);
+
+    render(<OfflineBanner />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('status').textContent).toContain('No network connection.');
+    expect(onlineManager.isOnline()).toBe(false);
+  });
+});

--- a/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.spec.tsx
+++ b/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.spec.tsx
@@ -24,8 +24,7 @@ const Wrapper = ({ children }: PropsWithChildren): JSX.Element => {
 
 describe('OfflineBanner', () => {
   afterEach(() => {
-    // onlineManager is a module-level singleton; hand the decision back to the
-    // browser signal so one test's override cannot leak into the next.
+    // onlineManager is a module-level singleton; reset it between tests.
     onlineManager.setOnline(undefined);
     setBrowserOnline(true);
   });
@@ -53,7 +52,6 @@ describe('OfflineBanner', () => {
     render(<OfflineBanner />, { wrapper: Wrapper });
     fireEvent.click(screen.getByRole('button'));
 
-    // Visibility follows the browser, not the override: still offline, still shown.
     expect(screen.getByRole('status').textContent).toContain('Retrying anyway.');
     expect(screen.getByRole('button').textContent).toContain('Stop');
     expect(onlineManager.isOnline()).toBe(true);

--- a/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.styles.ts
+++ b/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.styles.ts
@@ -6,10 +6,7 @@ import { fonts, getTheme } from '@styles/theme';
 export const OfflineBannerWrapper = styled.div`
   ${mixins.flex({ direction: 'row', justify: 'flex-start' })};
   width: 100%;
-  /* Hosts differ by an order of magnitude in width: the popup is 360px with a
-     20px gutter, the web pages run full-screen behind a header with a 74px one.
-     Track whichever it is instead of leaving a 12px gutter under a 74px header. */
-  padding: 8px clamp(12px, 4vw, 74px);
+  padding: 8px 12px;
   gap: 8px;
   background: ${getTheme('neutral', '_9')};
   border-bottom: 1px solid ${getTheme('neutral', '_7')};

--- a/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.styles.ts
+++ b/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.styles.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+import mixins from '@styles/mixins';
+import { fonts, getTheme } from '@styles/theme';
+
+export const OfflineBannerWrapper = styled.div`
+  ${mixins.flex({ direction: 'row', justify: 'flex-start' })};
+  width: 100%;
+  padding: 8px 12px;
+  gap: 8px;
+  background: ${getTheme('neutral', '_9')};
+  border-bottom: 1px solid ${getTheme('neutral', '_7')};
+  text-align: left;
+
+  .indicator {
+    ${mixins.flex({ direction: 'row' })};
+    flex: 0 0 auto;
+
+    /* The shared spinner icon animates itself. Hold it still for viewers who
+       ask for reduced motion, but keep it on screen as a state indicator. */
+    @media (prefers-reduced-motion: reduce) {
+      svg {
+        animation: none;
+        opacity: 0.6;
+      }
+    }
+  }
+
+  .message {
+    ${fonts.body3Reg};
+    flex: 1;
+    color: ${getTheme('neutral', '_3')};
+  }
+
+  .headline {
+    ${fonts.body3Bold};
+    color: ${getTheme('webWarning', '_100')};
+  }
+
+  .action-button {
+    ${fonts.body3Reg};
+    flex: 0 0 auto;
+    padding: 0 12px;
+  }
+`;

--- a/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.styles.ts
+++ b/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.styles.ts
@@ -6,7 +6,10 @@ import { fonts, getTheme } from '@styles/theme';
 export const OfflineBannerWrapper = styled.div`
   ${mixins.flex({ direction: 'row', justify: 'flex-start' })};
   width: 100%;
-  padding: 8px 12px;
+  /* Hosts differ by an order of magnitude in width: the popup is 360px with a
+     20px gutter, the web pages run full-screen behind a header with a 74px one.
+     Track whichever it is instead of leaving a 12px gutter under a 74px header. */
+  padding: 8px clamp(12px, 4vw, 74px);
   gap: 8px;
   background: ${getTheme('neutral', '_9')};
   border-bottom: 1px solid ${getTheme('neutral', '_7')};

--- a/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.styles.ts
+++ b/packages/adena-extension/src/components/atoms/offline-banner/offline-banner.styles.ts
@@ -16,8 +16,7 @@ export const OfflineBannerWrapper = styled.div`
     ${mixins.flex({ direction: 'row' })};
     flex: 0 0 auto;
 
-    /* The shared spinner icon animates itself. Hold it still for viewers who
-       ask for reduced motion, but keep it on screen as a state indicator. */
+    /* The shared spinner icon animates itself. */
     @media (prefers-reduced-motion: reduce) {
       svg {
         animation: none;

--- a/packages/adena-extension/src/hooks/use-balance-input.ts
+++ b/packages/adena-extension/src/hooks/use-balance-input.ts
@@ -290,11 +290,8 @@ export const useBalanceInput = (
       return false;
     }
 
-    // getGnotTokenBalance now rejects on a transport failure instead of
-    // resolving null, so this call can throw where it previously could not.
-    // Leave the balance undefined rather than propagating: the amount field
-    // already renders `currentBalance?.amount.value || 0`, and an unhandled
-    // rejection here would break the send screen outright.
+    // getGnotTokenBalance now rejects on a transport failure, so leave the
+    // balance undefined rather than letting the rejection break the screen.
     const currentBalance = await fetchBalanceBy(currentFundingAddress, tokenMetainfo).catch(
       () => undefined,
     );
@@ -313,11 +310,7 @@ export const useBalanceInput = (
     }
     const label = isSessionNativeTransfer ? 'Spendable' : 'Balance';
 
-    // A balance that could not be read is not a zero balance. updateCurrentBalance
-    // leaves this undefined when the fetch rejects, and `undefined || 0` used to
-    // format as a confident "0" — the same lie this branch removes from the main
-    // screen. Undefined before the first fetch resolves reads the same way, and
-    // "-" is honest there too.
+    // A balance that could not be read is not a zero balance.
     if (!currentBalance) {
       return `${label}: - ${tokenMetainfo.symbol}`;
     }

--- a/packages/adena-extension/src/hooks/use-balance-input.ts
+++ b/packages/adena-extension/src/hooks/use-balance-input.ts
@@ -287,7 +287,14 @@ export const useBalanceInput = (
       return false;
     }
 
-    const currentBalance = await fetchBalanceBy(currentFundingAddress, tokenMetainfo);
+    // getGnotTokenBalance now rejects on a transport failure instead of
+    // resolving null, so this call can throw where it previously could not.
+    // Leave the balance undefined rather than propagating: the amount field
+    // already renders `currentBalance?.amount.value || 0`, and an unhandled
+    // rejection here would break the send screen outright.
+    const currentBalance = await fetchBalanceBy(currentFundingAddress, tokenMetainfo).catch(
+      () => undefined,
+    );
     setCurrentBalance(currentBalance);
     return true;
   }, [wallet, balanceService, currentFundingAddress, tokenMetainfo]);

--- a/packages/adena-extension/src/hooks/use-balance-input.ts
+++ b/packages/adena-extension/src/hooks/use-balance-input.ts
@@ -78,89 +78,92 @@ export const useBalanceInput = (
     !!tokenMetainfo &&
     isNativeTokenModel(tokenMetainfo);
 
-  const {
-    data: currentSessionMetadata = null,
-    isLoading: isLoadingCurrentSessionMetadata,
-  } = useQuery<SessionMetadataV021 | null>(
-    ['sessionMetadataForBalanceInput', currentAccount?.id, currentNetwork.chainId],
-    async () => {
-      if (!currentAccount || !isSessionAccount(currentAccount)) {
-        return null;
-      }
-
-      const sessionAddr = await currentAccount.getAddress('g').catch(() => null);
-      if (!sessionAddr) {
-        return null;
-      }
-
-      const stored = await sessionRepository.get(sessionAddr);
-      if (!gnoProvider) {
-        return stored;
-      }
-
-      let record;
-      try {
-        record = await gnoProvider.getSession(currentAccount.getMasterAddress(), sessionAddr);
-      } catch {
-        return stored;
-      }
-      if (!record) {
-        const revoked = await shouldMarkSessionRevoked(
-          stored,
-          async () =>
-            !!(await gnoProvider.getSession(currentAccount.getMasterAddress(), sessionAddr)),
-        );
-        if (revoked && stored) {
-          await sessionRepository.setStatus(sessionAddr, 'REVOKED').catch(() => undefined);
-          // Without this the dim, the popover and the balance address only catch
-          // up on the next SESSIONS refetch.
-          await queryClient.invalidateQueries({ queryKey: [SESSIONS_QUERY_KEY] });
-          return { ...stored, status: 'REVOKED' };
+  const { data: currentSessionMetadata = null, isLoading: isLoadingCurrentSessionMetadata } =
+    useQuery<SessionMetadataV021 | null>(
+      ['sessionMetadataForBalanceInput', currentAccount?.id, currentNetwork.chainId],
+      async () => {
+        if (!currentAccount || !isSessionAccount(currentAccount)) {
+          return null;
         }
-        return stored;
-      }
 
-      const base = record.BaseSessionAccount;
-      const nowSeconds = Math.floor(Date.now() / 1000);
-      const expiresAt = Number(base.expires_at ?? stored?.expiresAt ?? 0);
-      const status: SessionMetadataV021['status'] =
-        stored?.status === 'REVOKED'
-          ? 'REVOKED'
-          : expiresAt > 0 && nowSeconds >= expiresAt
-          ? 'EXPIRED'
-          : 'ACTIVE';
-      const spendUsed = base.spend_used === '' ? undefined : base.spend_used;
-      const spendReset =
-        base.spend_reset != null && base.spend_reset !== '' ? Number(base.spend_reset) : undefined;
+        const sessionAddr = await currentAccount.getAddress('g').catch(() => null);
+        if (!sessionAddr) {
+          return null;
+        }
 
-      if (stored) {
-        await sessionRepository
-          .syncFromChain(sessionAddr, { spendUsed, spendReset, status })
-          .catch(() => undefined);
-      }
+        const stored = await sessionRepository.get(sessionAddr);
+        if (!gnoProvider) {
+          return stored;
+        }
 
-      return {
-        masterAddress: stored?.masterAddress ?? currentAccount.getMasterAddress(),
-        chainId: stored?.chainId ?? currentAccount.sessionConfig.chainId,
-        allowPaths: stored?.allowPaths ?? currentAccount.sessionConfig.allowPaths ?? [],
-        spendLimit:
-          base.spend_limit ?? stored?.spendLimit ?? currentAccount.sessionConfig.spendLimit ?? '',
-        spendPeriod: Number(
-          base.spend_period ?? stored?.spendPeriod ?? currentAccount.sessionConfig.spendPeriod ?? 0,
-        ),
-        spendUsed,
-        spendReset,
-        expiresAt,
-        status,
-        createdAt: stored?.createdAt ?? nowSeconds,
-        txHash: stored?.txHash,
-      };
-    },
-    {
-      enabled: currentAccount !== null && isSessionAccount(currentAccount),
-      refetchInterval: 30_000,
-    },
-  );
+        let record;
+        try {
+          record = await gnoProvider.getSession(currentAccount.getMasterAddress(), sessionAddr);
+        } catch {
+          return stored;
+        }
+        if (!record) {
+          const revoked = await shouldMarkSessionRevoked(
+            stored,
+            async () =>
+              !!(await gnoProvider.getSession(currentAccount.getMasterAddress(), sessionAddr)),
+          );
+          if (revoked && stored) {
+            await sessionRepository.setStatus(sessionAddr, 'REVOKED').catch(() => undefined);
+            // Without this the dim, the popover and the balance address only catch
+            // up on the next SESSIONS refetch.
+            await queryClient.invalidateQueries({ queryKey: [SESSIONS_QUERY_KEY] });
+            return { ...stored, status: 'REVOKED' };
+          }
+          return stored;
+        }
+
+        const base = record.BaseSessionAccount;
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        const expiresAt = Number(base.expires_at ?? stored?.expiresAt ?? 0);
+        const status: SessionMetadataV021['status'] =
+          stored?.status === 'REVOKED'
+            ? 'REVOKED'
+            : expiresAt > 0 && nowSeconds >= expiresAt
+              ? 'EXPIRED'
+              : 'ACTIVE';
+        const spendUsed = base.spend_used === '' ? undefined : base.spend_used;
+        const spendReset =
+          base.spend_reset != null && base.spend_reset !== ''
+            ? Number(base.spend_reset)
+            : undefined;
+
+        if (stored) {
+          await sessionRepository
+            .syncFromChain(sessionAddr, { spendUsed, spendReset, status })
+            .catch(() => undefined);
+        }
+
+        return {
+          masterAddress: stored?.masterAddress ?? currentAccount.getMasterAddress(),
+          chainId: stored?.chainId ?? currentAccount.sessionConfig.chainId,
+          allowPaths: stored?.allowPaths ?? currentAccount.sessionConfig.allowPaths ?? [],
+          spendLimit:
+            base.spend_limit ?? stored?.spendLimit ?? currentAccount.sessionConfig.spendLimit ?? '',
+          spendPeriod: Number(
+            base.spend_period ??
+              stored?.spendPeriod ??
+              currentAccount.sessionConfig.spendPeriod ??
+              0,
+          ),
+          spendUsed,
+          spendReset,
+          expiresAt,
+          status,
+          createdAt: stored?.createdAt ?? nowSeconds,
+          txHash: stored?.txHash,
+        };
+      },
+      {
+        enabled: currentAccount !== null && isSessionAccount(currentAccount),
+        refetchInterval: 30_000,
+      },
+    );
 
   const sessionSpendConfig = useMemo<SessionSpendConfig | null>(() => {
     if (!currentAccount || !isSessionAccount(currentAccount)) {
@@ -309,7 +312,17 @@ export const useBalanceInput = (
       return errorMessage;
     }
     const label = isSessionNativeTransfer ? 'Spendable' : 'Balance';
-    const balanceAmount = BigNumber(currentBalance?.amount.value || 0);
+
+    // A balance that could not be read is not a zero balance. updateCurrentBalance
+    // leaves this undefined when the fetch rejects, and `undefined || 0` used to
+    // format as a confident "0" — the same lie this branch removes from the main
+    // screen. Undefined before the first fetch resolves reads the same way, and
+    // "-" is honest there too.
+    if (!currentBalance) {
+      return `${label}: - ${tokenMetainfo.symbol}`;
+    }
+
+    const balanceAmount = BigNumber(currentBalance.amount.value || 0);
     const descriptionAmount = isSessionNativeTransfer
       ? availAmountNumber
       : getLimitedAmount(balanceAmount, sessionSpendableAmount);

--- a/packages/adena-extension/src/hooks/use-token-balance.ts
+++ b/packages/adena-extension/src/hooks/use-token-balance.ts
@@ -37,14 +37,7 @@ export const useTokenBalance = (): {
   currentBalances: TokenBalanceType[];
   loadingTokenKeys: Set<string>;
   errorNetworkIds: Set<string>;
-  /**
-   * The native token's balance could not be established. Derived from the same
-   * nativeToken the headline balance reads, because the native token is
-   * admitted to the metainfo list by its `main` flag and keeps whatever
-   * networkId it was registered under — asking errorNetworkIds about
-   * currentNetwork.networkId answers a different question and matches only by
-   * coincidence.
-   */
+  /** The native token's balance could not be established. */
   mainTokenUnavailable: boolean;
   refetchBalances: () => Promise<QueryObserverResult<TokenBalanceType[], unknown>>;
   fetchBalanceBy: (address: string, token: TokenModel) => Promise<TokenBalanceType>;
@@ -115,8 +108,7 @@ export const useTokenBalance = (): {
     {
       refetchInterval: GNO_REFETCH_INTERVAL,
       keepPreviousData: true,
-      enabled:
-        availableBalanceFetching && currentBalanceAddress !== null && nativeToken !== null,
+      enabled: availableBalanceFetching && currentBalanceAddress !== null && nativeToken !== null,
     },
   );
 
@@ -151,9 +143,7 @@ export const useTokenBalance = (): {
       // addresses for it is meaningless and wastes LCD bandwidth. Skip the
       // query entirely so the Cosmos token rows stay empty in this mode.
       enabled:
-        availableBalanceFetching &&
-        currentAccount !== null &&
-        !isSessionAccount(currentAccount),
+        availableBalanceFetching && currentAccount !== null && !isSessionAccount(currentAccount),
       // Default retry (3) causes excessive delay and traffic during LCD outages.
       retry: 1,
     },
@@ -166,36 +156,20 @@ export const useTokenBalance = (): {
     [refetchGnoBalances, refetchCosmosBalances],
   );
 
-  // Networks whose balances could not be established, so the UI can show "-"
-  // and a warning rather than a figure it cannot vouch for.
-  //
-  // Cosmos has always reported this through CosmosFetchResult.error. Gno had no
-  // equivalent, so a failed Gno fetch left its rows at EMPTY_AMOUNT with no
-  // network here, which loadingTokenKeys reads as "still loading" — the native
-  // token then rendered 0 indefinitely while the same outage showed ATONE
-  // honestly as unknown.
-  //
-  // A PAUSED query counts as well as an errored one: react-query's default
-  // networkMode pauses rather than fails while the browser reports offline, so
-  // there is no error to observe. It counts only while we still believe we are
-  // offline — the two chains resume at different intervals, and marking any
-  // paused query would flag whichever had not resumed yet, which is a race
-  // rather than an outage.
+  // Networks whose balances could not be established, so the UI can show "-".
+  // Cosmos reports this through CosmosFetchResult.error; Gno had no equivalent.
+  // A paused query counts too — react-query's default networkMode pauses rather
+  // than fails while offline, so there is no error to observe. Only while we
+  // still believe we are offline: the two chains resume on different intervals.
   const errorNetworkIds = useMemo(() => {
     const ids = new Set(cosmosResults.filter((r) => r.error).map((r) => r.networkId));
     const believedOffline = !onlineManager.isOnline();
 
     if (isGnoBalanceError || (believedOffline && gnoFetchStatus === 'paused')) {
-      // The ids the ROWS carry, not currentNetwork.networkId. gnoRows is built
-      // by mapping tokenMetainfos, and use-token-metainfo admits the native
-      // token by its `main` flag regardless of network, so it keeps whatever
-      // networkId it was registered under; keying on the current network marks
-      // every Gno row except the one that matters.
+      // The ids the rows carry, not currentNetwork.networkId: the native token
+      // is admitted by its `main` flag and keeps the networkId it was
+      // registered under, so keying on the current network misses it.
       for (const meta of tokenMetainfos) {
-        // Gno rows only. currentTokenMetainfos and cosmosShellTokens are drawn
-        // from the same metainfo list by different predicates and are disjoint
-        // today; skipping Cosmos models explicitly means a Gno outage can never
-        // flag a Cosmos row if that ever stops being true.
         if (isCosmosNativeTokenModel(meta)) {
           continue;
         }
@@ -203,9 +177,8 @@ export const useTokenBalance = (): {
       }
     }
 
-    // Cosmos rows come from the retained results (keepPreviousData), which
-    // carry exactly the networks on screen. cosmosShellTokens is declared later
-    // in this hook and cannot be read here.
+    // Retained results (keepPreviousData) carry exactly the networks on screen;
+    // cosmosShellTokens is declared later and cannot be read here.
     if (believedOffline && cosmosFetchStatus === 'paused') {
       for (const r of cosmosResults) {
         ids.add(r.networkId);
@@ -213,13 +186,7 @@ export const useTokenBalance = (): {
     }
 
     return ids;
-  }, [
-    cosmosResults,
-    cosmosFetchStatus,
-    isGnoBalanceError,
-    gnoFetchStatus,
-    tokenMetainfos,
-  ]);
+  }, [cosmosResults, cosmosFetchStatus, isGnoBalanceError, gnoFetchStatus, tokenMetainfos]);
 
   // Stable string key for the effect below. The Set above is rebuilt on every
   // render where cosmosResults's reference changes (React Query refetches
@@ -358,10 +325,7 @@ export const useTokenBalance = (): {
     // by both tokenId and networkId to disambiguate same-symbol tokens that
     // exist on multiple chains (e.g. ATONE on mainnet vs testnet).
     const changedTokenInfos: TokenModel[] = allTokenMetainfos.map((tokenMetainfo) => {
-      if (
-        token.tokenId === tokenMetainfo.tokenId &&
-        token.networkId === tokenMetainfo.networkId
-      ) {
+      if (token.tokenId === tokenMetainfo.tokenId && token.networkId === tokenMetainfo.networkId) {
         return {
           ...tokenMetainfo,
           display: activated,

--- a/packages/adena-extension/src/hooks/use-token-balance.ts
+++ b/packages/adena-extension/src/hooks/use-token-balance.ts
@@ -37,6 +37,15 @@ export const useTokenBalance = (): {
   currentBalances: TokenBalanceType[];
   loadingTokenKeys: Set<string>;
   errorNetworkIds: Set<string>;
+  /**
+   * The native token's balance could not be established. Derived from the same
+   * nativeToken the headline balance reads, because the native token is
+   * admitted to the metainfo list by its `main` flag and keeps whatever
+   * networkId it was registered under — asking errorNetworkIds about
+   * currentNetwork.networkId answers a different question and matches only by
+   * coincidence.
+   */
+  mainTokenUnavailable: boolean;
   refetchBalances: () => Promise<QueryObserverResult<TokenBalanceType[], unknown>>;
   fetchBalanceBy: (address: string, token: TokenModel) => Promise<TokenBalanceType>;
   toggleDisplayOption: (account: Account, token: TokenModel, activated: boolean) => void;
@@ -183,6 +192,13 @@ export const useTokenBalance = (): {
       // networkId it was registered under; keying on the current network marks
       // every Gno row except the one that matters.
       for (const meta of tokenMetainfos) {
+        // Gno rows only. currentTokenMetainfos and cosmosShellTokens are drawn
+        // from the same metainfo list by different predicates and are disjoint
+        // today; skipping Cosmos models explicitly means a Gno outage can never
+        // flag a Cosmos row if that ever stops being true.
+        if (isCosmosNativeTokenModel(meta)) {
+          continue;
+        }
         ids.add(meta.networkId);
       }
     }
@@ -312,6 +328,13 @@ export const useTokenBalance = (): {
     return keys;
   }, [currentBalances, errorNetworkIds]);
 
+  const mainTokenUnavailable = useMemo((): boolean => {
+    if (nativeToken === null) {
+      return false;
+    }
+    return errorNetworkIds.has(nativeToken.networkId);
+  }, [errorNetworkIds, nativeToken]);
+
   const mainTokenBalance = useMemo((): Amount | null => {
     if (nativeToken === null) {
       return null;
@@ -424,6 +447,7 @@ export const useTokenBalance = (): {
 
   return {
     mainTokenBalance,
+    mainTokenUnavailable,
     currentBalances,
     loadingTokenKeys,
     errorNetworkIds,

--- a/packages/adena-extension/src/hooks/use-token-balance.ts
+++ b/packages/adena-extension/src/hooks/use-token-balance.ts
@@ -1,4 +1,4 @@
-import { QueryObserverResult, useQuery } from '@tanstack/react-query';
+import { onlineManager, QueryObserverResult, useQuery } from '@tanstack/react-query';
 import { Account, isSessionAccount } from 'adena-module';
 import BigNumber from 'bignumber.js';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -82,6 +82,8 @@ export const useTokenBalance = (): {
   const {
     data: gnoBalances = [],
     refetch: refetchGnoBalances,
+    isError: isGnoBalanceError,
+    fetchStatus: gnoFetchStatus,
   } = useQuery<TokenBalanceType[]>(
     // 'gno' discriminator keeps this cache entry separate from the Cosmos query
     // even though both share the 'balances' prefix.
@@ -112,6 +114,7 @@ export const useTokenBalance = (): {
   const {
     data: cosmosResults = [],
     refetch: refetchCosmosBalances,
+    fetchStatus: cosmosFetchStatus,
   } = useQuery<CosmosFetchResult[]>(
     // Keyed by account id (not the object reference) to avoid spurious refetches
     // when a new Account instance is created from the same underlying data.
@@ -154,10 +157,53 @@ export const useTokenBalance = (): {
     [refetchGnoBalances, refetchCosmosBalances],
   );
 
-  const errorNetworkIds = useMemo(
-    () => new Set(cosmosResults.filter((r) => r.error).map((r) => r.networkId)),
-    [cosmosResults],
-  );
+  // Networks whose balances could not be established, so the UI can show "-"
+  // and a warning rather than a figure it cannot vouch for.
+  //
+  // Cosmos has always reported this through CosmosFetchResult.error. Gno had no
+  // equivalent, so a failed Gno fetch left its rows at EMPTY_AMOUNT with no
+  // network here, which loadingTokenKeys reads as "still loading" — the native
+  // token then rendered 0 indefinitely while the same outage showed ATONE
+  // honestly as unknown.
+  //
+  // A PAUSED query counts as well as an errored one: react-query's default
+  // networkMode pauses rather than fails while the browser reports offline, so
+  // there is no error to observe. It counts only while we still believe we are
+  // offline — the two chains resume at different intervals, and marking any
+  // paused query would flag whichever had not resumed yet, which is a race
+  // rather than an outage.
+  const errorNetworkIds = useMemo(() => {
+    const ids = new Set(cosmosResults.filter((r) => r.error).map((r) => r.networkId));
+    const believedOffline = !onlineManager.isOnline();
+
+    if (isGnoBalanceError || (believedOffline && gnoFetchStatus === 'paused')) {
+      // The ids the ROWS carry, not currentNetwork.networkId. gnoRows is built
+      // by mapping tokenMetainfos, and use-token-metainfo admits the native
+      // token by its `main` flag regardless of network, so it keeps whatever
+      // networkId it was registered under; keying on the current network marks
+      // every Gno row except the one that matters.
+      for (const meta of tokenMetainfos) {
+        ids.add(meta.networkId);
+      }
+    }
+
+    // Cosmos rows come from the retained results (keepPreviousData), which
+    // carry exactly the networks on screen. cosmosShellTokens is declared later
+    // in this hook and cannot be read here.
+    if (believedOffline && cosmosFetchStatus === 'paused') {
+      for (const r of cosmosResults) {
+        ids.add(r.networkId);
+      }
+    }
+
+    return ids;
+  }, [
+    cosmosResults,
+    cosmosFetchStatus,
+    isGnoBalanceError,
+    gnoFetchStatus,
+    tokenMetainfos,
+  ]);
 
   // Stable string key for the effect below. The Set above is rebuilt on every
   // render where cosmosResults's reference changes (React Query refetches

--- a/packages/adena-extension/src/hooks/use-wallet.ts
+++ b/packages/adena-extension/src/hooks/use-wallet.ts
@@ -22,13 +22,16 @@ export const useWallet = (): UseWalletReturn => {
     return wallet.hasHDWallet();
   }, [wallet]);
 
+  // networkMode: 'always' — see landing-screen. Both of these read
+  // chrome.storage; paused offline they leave the POPUP blank, because
+  // App/popup returns <></> while isLoadingLockedWallet is true.
   const { data: existWallet, isLoading: isLoadingExistWallet } = useQuery(
     ['wallet/existWallet', walletService.id],
     async () => {
       const existWallet = await walletService.existsWallet().catch(() => false);
       return existWallet;
     },
-    {},
+    { networkMode: 'always' },
   );
 
   const { data: lockedWallet, isLoading: isLoadingLockedWallet } = useQuery(
@@ -37,7 +40,7 @@ export const useWallet = (): UseWalletReturn => {
       const lockedWallet = await walletService.isLocked();
       return lockedWallet;
     },
-    {},
+    { networkMode: 'always' },
   );
 
   return {

--- a/packages/adena-extension/src/hooks/use-wallet.ts
+++ b/packages/adena-extension/src/hooks/use-wallet.ts
@@ -27,9 +27,9 @@ export const useWallet = (): UseWalletReturn => {
     return wallet.hasHDWallet();
   }, [wallet]);
 
-  // networkMode: 'always' — see landing-screen. Both of these read
-  // chrome.storage; paused offline they leave the POPUP blank, because
-  // App/popup returns <></> while isLoadingLockedWallet is true.
+  // networkMode 'always': both read chrome.storage, never the network. Paused
+  // offline they leave the popup blank, since App/popup renders <></> while
+  // isLoadingLockedWallet is true.
   const { data: existWallet, isLoading: isLoadingExistWallet } = useQuery(
     makeWalletExistsQueryKey(walletService.id),
     async () => {

--- a/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
@@ -9,12 +9,11 @@ import IconDeposit from '@assets/icon-deposit';
 import IconSend from '@assets/icon-send';
 import IconSign from '@assets/icon-sign';
 import { CHAIN_ICON_MAP, COSMOS_TOKEN_ICON_MAP } from '@assets/icons/cosmos-icons';
-import { MainActionButton } from '@components/atoms';
+import { MainActionButton, OfflineBanner } from '@components/atoms';
 import MainManageTokenButton from '@components/pages/main/main-manage-token-button/main-manage-token-button';
 import MainNetworkLabel from '@components/pages/main/main-network-label/main-network-label';
 import MainTokenBalance from '@components/pages/main/main-token-balance/main-token-balance';
 import TokenList, { TokenListItemState } from '@components/pages/wallet-main/token-list/token-list';
-import OfflineBanner from '@components/atoms/offline-banner';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { useLoadImages } from '@hooks/use-load-images';
@@ -50,12 +49,43 @@ function readCachedRowCount(): number {
   }
 }
 
+// The network label is position: fixed, so the flow reserves its slot with
+// padding instead. Named because the offline banner sticks to the bottom of
+// that same slot and the two must not drift apart.
+const NETWORK_LABEL_SLOT_HEIGHT = 37;
+// `main` gets `padding: 0 20px` from GlobalPopupStyle; full-bleed children
+// cancel it.
+const MAIN_SIDE_PADDING = 20;
+
 const Wrapper = styled.main<{ $dimmed: boolean }>`
-  padding-top: 37px;
+  padding-top: ${NETWORK_LABEL_SLOT_HEIGHT}px;
   text-align: center;
   overflow: auto;
 
   ${revokedDimStyle}
+
+  .offline-banner-slot {
+    /* Full-bleed, because a warning bar that stops short of both edges reads as
+       a card rather than a bar, and its bottom border stops working as a
+       divider. The negative margins exactly cancel the global main padding, so
+       the slot spans the scrollport without overflowing it.
+
+       Sticky with top: 0 pins it at the top of this element's own flow
+       position — the bottom of the slot reserved above — so nothing moves at
+       rest and the warning survives scrolling the token list. A positive
+       offset would push it down by that much instead, opening a gap for
+       content to scroll through. Below the label (z-index 10) and the header
+       (20), above the scrolling content. */
+    position: sticky;
+    top: 0;
+    z-index: 9;
+    margin: 0 -${MAIN_SIDE_PADDING}px 12px;
+  }
+
+  /* Online, the banner renders null. Collapse the slot so it costs no space. */
+  .offline-banner-slot:empty {
+    display: none;
+  }
 
   .network-label-wrapper {
     position: fixed;
@@ -287,7 +317,9 @@ export const WalletMain = (): JSX.Element => {
 
   return (
     <Wrapper $dimmed={sessionRevoked}>
-      <OfflineBanner />
+      <div className='offline-banner-slot'>
+        <OfflineBanner />
+      </div>
       <div className='network-label-wrapper'>
         <MainNetworkLabel
           networkName={currentNetwork.networkName}

--- a/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
@@ -94,8 +94,13 @@ export const WalletMain = (): JSX.Element => {
   const [state] = useRecoilState(WalletState.state);
   const { currentNetwork } = useNetwork();
   const { currentAccount } = useCurrentAccount();
-  const { mainTokenBalance, currentBalances, loadingTokenKeys, errorNetworkIds } =
-    useTokenBalance();
+  const {
+    mainTokenBalance,
+    mainTokenUnavailable,
+    currentBalances,
+    loadingTokenKeys,
+    errorNetworkIds,
+  } = useTokenBalance();
   const { failedNetwork } = useNetwork();
   const { updateAllTokenMetainfos, getTokenImage } = useTokenMetainfo();
 
@@ -269,7 +274,7 @@ export const WalletMain = (): JSX.Element => {
   // Zero is exactly where this matters most. An account with no record on chain
   // and an account whose balance could not be fetched both render "0", and only
   // one of those is a fact.
-  const gnoBalanceUnavailable = errorNetworkIds.has(currentNetwork.networkId);
+  const gnoBalanceUnavailable = mainTokenUnavailable;
   const isMainBalanceLoading = mainTokenBalance === null && !gnoBalanceUnavailable;
   // Same NaN guard as the row mapping above — a malformed numeric string
   // would otherwise render as the literal "NaN" in the headline balance.

--- a/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
@@ -14,6 +14,7 @@ import MainManageTokenButton from '@components/pages/main/main-manage-token-butt
 import MainNetworkLabel from '@components/pages/main/main-network-label/main-network-label';
 import MainTokenBalance from '@components/pages/main/main-token-balance/main-token-balance';
 import TokenList, { TokenListItemState } from '@components/pages/wallet-main/token-list/token-list';
+import OfflineBanner from '@components/atoms/offline-banner';
 import useAppNavigate from '@hooks/use-app-navigate';
 import { useCurrentAccount } from '@hooks/use-current-account';
 import { useLoadImages } from '@hooks/use-load-images';
@@ -257,17 +258,31 @@ export const WalletMain = (): JSX.Element => {
     }
   }, [tokens.length]);
 
-  const isMainBalanceLoading = mainTokenBalance === null;
+  // A STALE BALANCE MUST NOT LOOK LIKE A FRESH ONE. The Gno query sets
+  // keepPreviousData, so when a fetch fails or is paused the last good figure
+  // stays on screen — rendered identically to one just confirmed. Offline that
+  // produced the wallet's worst asymmetry: ATONE showed "-" because its fetch
+  // reported an error, while GNOT showed a confident number nobody could
+  // currently verify. The token ROW already respects errorNetworkIds; this
+  // headline read straight from the cached amount and bypassed it.
+  //
+  // Zero is exactly where this matters most. An account with no record on chain
+  // and an account whose balance could not be fetched both render "0", and only
+  // one of those is a fact.
+  const gnoBalanceUnavailable = errorNetworkIds.has(currentNetwork.networkId);
+  const isMainBalanceLoading = mainTokenBalance === null && !gnoBalanceUnavailable;
   // Same NaN guard as the row mapping above — a malformed numeric string
   // would otherwise render as the literal "NaN" in the headline balance.
   const mainBalanceValue = ((): string => {
-    if (isMainBalanceLoading) return '';
+    if (gnoBalanceUnavailable) return '-';
+    if (mainTokenBalance === null) return '';
     const parsed = BigNumber(mainTokenBalance.value);
     return parsed.isFinite() ? parsed.toFormat() : '-';
   })();
 
   return (
     <Wrapper $dimmed={sessionRevoked}>
+      <OfflineBanner />
       <div className='network-label-wrapper'>
         <MainNetworkLabel
           networkName={currentNetwork.networkName}
@@ -278,7 +293,7 @@ export const WalletMain = (): JSX.Element => {
         <MainTokenBalance
           amount={{
             value: mainBalanceValue,
-            denom: isMainBalanceLoading ? '' : mainTokenBalance.denom,
+            denom: mainTokenBalance === null ? '' : mainTokenBalance.denom,
           }}
           loading={isMainBalanceLoading}
         />

--- a/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/wallet-main/index.tsx
@@ -49,12 +49,9 @@ function readCachedRowCount(): number {
   }
 }
 
-// The network label is position: fixed, so the flow reserves its slot with
-// padding instead. Named because the offline banner sticks to the bottom of
-// that same slot and the two must not drift apart.
+// The network label is position: fixed, so the flow reserves its slot with padding.
 const NETWORK_LABEL_SLOT_HEIGHT = 37;
-// `main` gets `padding: 0 20px` from GlobalPopupStyle; full-bleed children
-// cancel it.
+// `main` gets `padding: 0 20px` from GlobalPopupStyle; full-bleed children cancel it.
 const MAIN_SIDE_PADDING = 20;
 
 const Wrapper = styled.main<{ $dimmed: boolean }>`
@@ -64,25 +61,18 @@ const Wrapper = styled.main<{ $dimmed: boolean }>`
 
   ${revokedDimStyle}
 
+  /* Negative margins cancel the global main padding so the bar spans the
+     scrollport. top: 0 holds it at its own flow position (the bottom of the
+     reserved slot); a positive offset would push it down and open a gap for
+     content to scroll through. z-index stays under the label (10). */
   .offline-banner-slot {
-    /* Full-bleed, because a warning bar that stops short of both edges reads as
-       a card rather than a bar, and its bottom border stops working as a
-       divider. The negative margins exactly cancel the global main padding, so
-       the slot spans the scrollport without overflowing it.
-
-       Sticky with top: 0 pins it at the top of this element's own flow
-       position — the bottom of the slot reserved above — so nothing moves at
-       rest and the warning survives scrolling the token list. A positive
-       offset would push it down by that much instead, opening a gap for
-       content to scroll through. Below the label (z-index 10) and the header
-       (20), above the scrolling content. */
     position: sticky;
     top: 0;
     z-index: 9;
     margin: 0 -${MAIN_SIDE_PADDING}px 12px;
   }
 
-  /* Online, the banner renders null. Collapse the slot so it costs no space. */
+  /* The banner renders null when online. */
   .offline-banner-slot:empty {
     display: none;
   }
@@ -293,17 +283,9 @@ export const WalletMain = (): JSX.Element => {
     }
   }, [tokens.length]);
 
-  // A STALE BALANCE MUST NOT LOOK LIKE A FRESH ONE. The Gno query sets
-  // keepPreviousData, so when a fetch fails or is paused the last good figure
-  // stays on screen — rendered identically to one just confirmed. Offline that
-  // produced the wallet's worst asymmetry: ATONE showed "-" because its fetch
-  // reported an error, while GNOT showed a confident number nobody could
-  // currently verify. The token ROW already respects errorNetworkIds; this
-  // headline read straight from the cached amount and bypassed it.
-  //
-  // Zero is exactly where this matters most. An account with no record on chain
-  // and an account whose balance could not be fetched both render "0", and only
-  // one of those is a fact.
+  // keepPreviousData keeps the last good figure on screen when a fetch fails or
+  // pauses, rendered identically to a confirmed one. The token rows already
+  // respect errorNetworkIds; this headline read the cached amount directly.
   const gnoBalanceUnavailable = mainTokenUnavailable;
   const isMainBalanceLoading = mainTokenBalance === null && !gnoBalanceUnavailable;
   // Same NaN guard as the row mapping above — a malformed numeric string

--- a/packages/adena-extension/src/pages/web/landing-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/landing-screen/index.tsx
@@ -28,10 +28,8 @@ const LandingScreen = (): ReactElement => {
   const { navigate } = useAppNavigate();
   const { walletService } = useAdenaContext();
 
-  // networkMode 'always': this reads chrome.storage, never the network.
-  // react-query's default 'online' PAUSES a query while the browser reports
-  // offline — it never runs, never errors, and status stays 'loading' — so this
-  // screen rendered an empty <WebMain /> under the header for the whole session.
+  // networkMode 'always': this reads chrome.storage, never the network. The
+  // default 'online' pauses offline, leaving isLoading true for the session.
   const { data: existWallet, isLoading } = useQuery(
     ['existWallet', walletService.id],
     async () => walletService.existsWallet(),
@@ -55,9 +53,7 @@ const LandingScreen = (): ReactElement => {
             />
           </StyledAnimationWrapper>
           <View style={{ rowGap: 8 }}>
-            <WebText type='headline4'>
-              {existWallet ? 'Add Account' : 'Welcome to Adena'}
-            </WebText>
+            <WebText type='headline4'>{existWallet ? 'Add Account' : 'Welcome to Adena'}</WebText>
             <WebText type='body4' color='#8D9199'>
               {existWallet
                 ? 'Select a method to add a new account to Adena.'

--- a/packages/adena-extension/src/pages/web/landing-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/landing-screen/index.tsx
@@ -28,10 +28,14 @@ const LandingScreen = (): ReactElement => {
   const { navigate } = useAppNavigate();
   const { walletService } = useAdenaContext();
 
+  // networkMode 'always': this reads chrome.storage, never the network.
+  // react-query's default 'online' PAUSES a query while the browser reports
+  // offline — it never runs, never errors, and status stays 'loading' — so this
+  // screen rendered an empty <WebMain /> under the header for the whole session.
   const { data: existWallet, isLoading } = useQuery(
-    ['existWallet', walletService],
+    ['existWallet', walletService.id],
     async () => walletService.existsWallet(),
-    {},
+    { networkMode: 'always' },
   );
 
   if (isLoading) {

--- a/packages/adena-extension/src/pages/web/session-add-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/session-add-screen/index.tsx
@@ -337,11 +337,8 @@ const SessionAddScreen = (): ReactElement => {
         paddingBottom: 80,
       }}
     >
-      {/* The only web route that talks to the chain: reading the session back
-          off it, and broadcasting the transaction that creates it. Everywhere
-          else in the register flow — mnemonic, import, password, Ledger,
-          export — is local and finishes offline, so the bar lives here rather
-          than over the whole app. */}
+      {/* The only web route that talks to the chain; the rest of the register
+          flow is local and finishes offline. */}
       <OfflineBanner />
 
       <WebMainHeader

--- a/packages/adena-extension/src/pages/web/session-add-screen/index.tsx
+++ b/packages/adena-extension/src/pages/web/session-add-screen/index.tsx
@@ -2,9 +2,7 @@ import BigNumber from 'bignumber.js';
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import IconError from '@assets/web/error.svg';
-import {
-  GNO_ADDRESS_PREFIX as GNO_PREFIX,
-} from '@common/constants/chain.constant';
+import { GNO_ADDRESS_PREFIX as GNO_PREFIX } from '@common/constants/chain.constant';
 import { ADENA_DOCS_PAGE } from '@common/constants/resource.constant';
 import { GNOT_TOKEN } from '@common/constants/token.constant';
 import { isSessionMasterAccount, isSessionSupportedChainId } from '@common/utils/account-session';
@@ -12,6 +10,7 @@ import { encodeParameter } from '@common/utils/client-utils';
 import { stringToBase64 } from '@common/utils/encoding-util';
 import { resolveSessionAdminGasInfo } from '@common/utils/session-admin-gas';
 import {
+  OfflineBanner,
   Row,
   View,
   WebButton,
@@ -63,14 +62,50 @@ import {
 } from './session-import-utils';
 
 import {
-  AmountInput, AmountInputWrapper, Card, ChangeUnitIcon, ConfigureCard, DisableTransferToggleWrapper, DropdownChevronIcon, ErrorBanner, Field, IconButton, ImportErrorList,
-  ImportErrorRow, ImportSessionAddress, InlineErrorRow, KeyActionRow, MasterAddressWrapper, MasterInfoIcon,
-  MasterInputField, MasterInputRow,
-  MasterLabelArea, MasterLabelCell,
-  MasterLabelInfoIcon, MasterTooltipBox, MinusIcon, PlusIcon, RealmInputBox,
-  RealmInputInner, SelectField, SelectMenu,
-  SelectOption, SelectTrigger, SessionCard, SessionCardBody, SessionCardHeader, SessionRows, SpendPeriodInput, SpendPeriodInputWrapper, Spinner, TabButton, TabRow, TooltipBox,
-  TooltipBoxAbove, TooltipWrapper, UnitToggle,
+  AmountInput,
+  AmountInputWrapper,
+  Card,
+  ChangeUnitIcon,
+  ConfigureCard,
+  DisableTransferToggleWrapper,
+  DropdownChevronIcon,
+  ErrorBanner,
+  Field,
+  IconButton,
+  ImportErrorList,
+  ImportErrorRow,
+  ImportSessionAddress,
+  InlineErrorRow,
+  KeyActionRow,
+  MasterAddressWrapper,
+  MasterInfoIcon,
+  MasterInputField,
+  MasterInputRow,
+  MasterLabelArea,
+  MasterLabelCell,
+  MasterLabelInfoIcon,
+  MasterTooltipBox,
+  MinusIcon,
+  PlusIcon,
+  RealmInputBox,
+  RealmInputInner,
+  SelectField,
+  SelectMenu,
+  SelectOption,
+  SelectTrigger,
+  SessionCard,
+  SessionCardBody,
+  SessionCardHeader,
+  SessionRows,
+  SpendPeriodInput,
+  SpendPeriodInputWrapper,
+  Spinner,
+  TabButton,
+  TabRow,
+  TooltipBox,
+  TooltipBoxAbove,
+  TooltipWrapper,
+  UnitToggle,
 } from './session-add-screen.styles';
 
 const MAX_REALM_PATHS_GAS_ONLY = 8;
@@ -207,12 +242,7 @@ const SessionAddScreen = (): ReactElement => {
         return { ok: false, error: errorMessageOf(reason) };
       }
     },
-    [
-      currentNetwork,
-      walletSessionService,
-      errorMessageOf,
-      getSessionImportErrorReason,
-    ],
+    [currentNetwork, walletSessionService, errorMessageOf, getSessionImportErrorReason],
   );
 
   // Import handler that branches on wallet presence:
@@ -224,8 +254,7 @@ const SessionAddScreen = (): ReactElement => {
       requests: SessionImportRequest[],
       masterAddress: string,
     ): Promise<
-      | { ok: true }
-      | { ok: false; error: string; errorBySessionAddr?: Record<string, string> }
+      { ok: true } | { ok: false; error: string; errorBySessionAddr?: Record<string, string> }
     > => {
       if (!currentNetwork) {
         return { ok: false, error: errorMessageOf('unsupported_network') };
@@ -308,6 +337,13 @@ const SessionAddScreen = (): ReactElement => {
         paddingBottom: 80,
       }}
     >
+      {/* The only web route that talks to the chain: reading the session back
+          off it, and broadcasting the transaction that creates it. Everywhere
+          else in the register flow — mnemonic, import, password, Ledger,
+          export — is local and finishes offline, so the bar lives here rather
+          than over the whole app. */}
+      <OfflineBanner />
+
       <WebMainHeader
         stepLength={0}
         onClickGoBack={
@@ -336,10 +372,7 @@ const SessionAddScreen = (): ReactElement => {
 
           {hasMasterCandidate && (
             <TabRow>
-              <TabButton
-                $active={activeTab === 'create'}
-                onClick={(): void => setTab('create')}
-              >
+              <TabButton $active={activeTab === 'create'} onClick={(): void => setTab('create')}>
                 Create New Session
               </TabButton>
               <TabButton $active={activeTab === 'import'} onClick={(): void => setTab('import')}>
@@ -486,9 +519,7 @@ const approveSessionViaPopup = (
     let resolved = false;
     let popupId: number | undefined;
 
-    const settle = (
-      result: { ok: true; hash?: string } | { ok: false; reason: string },
-    ): void => {
+    const settle = (result: { ok: true; hash?: string } | { ok: false; reason: string }): void => {
       if (resolved) return;
       resolved = true;
       chrome.runtime.onMessage.removeListener(messageListener);
@@ -574,12 +605,8 @@ const CreateTab = ({
   currentChainId,
   onComplete,
 }: CreateTabProps): ReactElement => {
-  const {
-    sessionRepository,
-    accountService,
-    transactionService,
-    transactionGasService,
-  } = useAdenaContext();
+  const { sessionRepository, accountService, transactionService, transactionGasService } =
+    useAdenaContext();
   const { wallet, updateWallet, gnoProvider } = useWalletContext();
   const { changeCurrentAccount } = useCurrentAccount();
   const { currentNetwork } = useNetwork();
@@ -628,7 +655,10 @@ const CreateTab = ({
   const realmPathsRef = useRef<string[]>(realmPaths);
   const realmValidationCacheRef = useRef<Map<string, RealmValidationResult>>(new Map());
 
-  const isSupportedSessionAccount = useMemo(() => isSessionSupportedChainId(currentChainId), [currentChainId]);
+  const isSupportedSessionAccount = useMemo(
+    () => isSessionSupportedChainId(currentChainId),
+    [currentChainId],
+  );
 
   const selectedMaster = useMemo(
     () => masterCandidates.find((a) => a.id === selectedMasterId),
@@ -1050,8 +1080,8 @@ const CreateTab = ({
       // are indistinguishable in the UI.
       const err = e as { message?: string; log?: string };
       setSubmitError(
-        (err.log ? `${err.message ?? 'broadcast failed'}\n${err.log}` : err.message)
-          ?? 'Failed to create session account.',
+        (err.log ? `${err.message ?? 'broadcast failed'}\n${err.log}` : err.message) ??
+          'Failed to create session account.',
       );
     } finally {
       setSubmitting(false);
@@ -1112,13 +1142,7 @@ const CreateTab = ({
                 strokeLinejoin='round'
               />
               <circle cx='8' cy='6' r='0.5' fill='currentColor' />
-              <circle
-                cx='8'
-                cy='8'
-                r='5'
-                stroke='currentColor'
-                strokeWidth='1.25'
-              />
+              <circle cx='8' cy='8' r='5' stroke='currentColor' strokeWidth='1.25' />
             </svg>
           </MasterLabelInfoIcon>
         </MasterLabelCell>
@@ -1127,10 +1151,7 @@ const CreateTab = ({
             The Session Account will control this account with limited scope and time.
           </MasterTooltipBox>
         )}
-        <SelectTrigger
-          type='button'
-          onClick={(): void => setMasterMenuOpen((v) => !v)}
-        >
+        <SelectTrigger type='button' onClick={(): void => setMasterMenuOpen((v) => !v)}>
           {selectedMaster ? (
             <Row style={{ columnGap: 6, alignItems: 'center' }}>
               <span style={{ fontWeight: 600 }}>{selectedMaster.name}</span>
@@ -1182,10 +1203,7 @@ const CreateTab = ({
             This session will be active for
           </WebText>
           <SelectField ref={expiresSelectRef}>
-            <SelectTrigger
-              type='button'
-              onClick={(): void => setExpiresMenuOpen((v) => !v)}
-            >
+            <SelectTrigger type='button' onClick={(): void => setExpiresMenuOpen((v) => !v)}>
               <Row style={{ columnGap: 6, alignItems: 'center' }}>
                 <span>{`${expiresDays} ${expiresDays === 1 ? 'day' : 'days'}`}</span>
                 <span style={{ color: '#51555c' }}>{`(${formatExpiryLabel(expiresDays)})`}</span>
@@ -1293,12 +1311,7 @@ const CreateTab = ({
                 style={{ color: '#878D99' }}
               >
                 <circle cx='8' cy='8' r='6' stroke='currentColor' strokeWidth='1.25' />
-                <path
-                  d='M8 7.5V11'
-                  stroke='currentColor'
-                  strokeWidth='1.5'
-                  strokeLinecap='round'
-                />
+                <path d='M8 7.5V11' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' />
                 <circle cx='8' cy='5.25' r='0.6' fill='currentColor' />
               </svg>
               {showSpendTooltip && (
@@ -1319,10 +1332,7 @@ const CreateTab = ({
               }}
               placeholder='Enter a time period. Leave this empty for a one-time limit.'
             />
-            <UnitToggle
-              type='button'
-              onClick={(): void => setSpendPeriodUnit(otherUnit)}
-            >
+            <UnitToggle type='button' onClick={(): void => setSpendPeriodUnit(otherUnit)}>
               <span>{unitLabel}</span>
               <ChangeUnitIcon />
             </UnitToggle>
@@ -1398,13 +1408,9 @@ const CreateTab = ({
       </Field>
 
       <Row style={{ columnGap: 8, alignItems: 'center' }}>
-        <WebCheckBox
-          checked={acknowledged}
-          onClick={(): void => setAcknowledged(!acknowledged)}
-        />
+        <WebCheckBox checked={acknowledged} onClick={(): void => setAcknowledged(!acknowledged)} />
         <WebText type='body5' color='#878D99'>
-          Your session key will only be stored on this device. Adena can&apos;t recover it for
-          you.
+          Your session key will only be stored on this device. Adena can&apos;t recover it for you.
         </WebText>
       </Row>
 
@@ -1452,8 +1458,7 @@ interface ImportTabProps {
     requests: SessionImportRequest[],
     masterAddress: string,
   ) => Promise<
-    | { ok: true }
-    | { ok: false; error: string; errorBySessionAddr?: Record<string, string> }
+    { ok: true } | { ok: false; error: string; errorBySessionAddr?: Record<string, string> }
   >;
 }
 
@@ -1487,10 +1492,31 @@ const MasterAddressInput = ({
             onMouseEnter={(): void => setShowTooltip(true)}
             onMouseLeave={(): void => setShowTooltip(false)}
           >
-            <svg width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'>
-              <path d='M10 10.834V12.5007' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
-              <path d='M10.4173 7.50065C10.4173 7.73077 10.2308 7.91732 10.0007 7.91732C9.77053 7.91732 9.58398 7.73077 9.58398 7.50065C9.58398 7.27053 9.77053 7.08398 10.0007 7.08398C10.2308 7.08398 10.4173 7.27053 10.4173 7.50065Z' stroke='currentColor' />
-              <path d='M16.0423 10.0007C16.0423 13.3374 13.3374 16.0423 10.0007 16.0423C6.66393 16.0423 3.95898 13.3374 3.95898 10.0007C3.95898 6.66393 6.66393 3.95898 10.0007 3.95898C13.3374 3.95898 16.0423 6.66393 16.0423 10.0007Z' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' strokeLinejoin='round' />
+            <svg
+              width='20'
+              height='20'
+              viewBox='0 0 20 20'
+              fill='none'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <path
+                d='M10 10.834V12.5007'
+                stroke='currentColor'
+                strokeWidth='2'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              />
+              <path
+                d='M10.4173 7.50065C10.4173 7.73077 10.2308 7.91732 10.0007 7.91732C9.77053 7.91732 9.58398 7.73077 9.58398 7.50065C9.58398 7.27053 9.77053 7.08398 10.0007 7.08398C10.2308 7.08398 10.4173 7.27053 10.4173 7.50065Z'
+                stroke='currentColor'
+              />
+              <path
+                d='M16.0423 10.0007C16.0423 13.3374 13.3374 16.0423 10.0007 16.0423C6.66393 16.0423 3.95898 13.3374 3.95898 10.0007C3.95898 6.66393 6.66393 3.95898 10.0007 3.95898C13.3374 3.95898 16.0423 6.66393 16.0423 10.0007Z'
+                stroke='currentColor'
+                strokeWidth='1.5'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              />
             </svg>
           </MasterInfoIcon>
         </MasterLabelArea>
@@ -1594,12 +1620,7 @@ const ImportTab = ({
 
   const selectedRequests = useMemo<SessionImportRequest[]>(() => {
     return rows
-      .filter(
-        (row) =>
-          row.selected &&
-          !row.alreadyImported &&
-          row.privKey.trim().length > 0,
-      )
+      .filter((row) => row.selected && !row.alreadyImported && row.privKey.trim().length > 0)
       .map((row) => ({
         sessionAddr: row.sessionAddr,
         privKey: row.privKey,
@@ -1622,9 +1643,7 @@ const ImportTab = ({
     const sanitized = sanitizeSessionPrivateKeyInput(value);
     setRows((prev) =>
       prev.map((row) =>
-        row.sessionAddr === sessionAddr
-          ? { ...row, privKey: sanitized, error: '' }
-          : row,
+        row.sessionAddr === sessionAddr ? { ...row, privKey: sanitized, error: '' } : row,
       ),
     );
   }, []);

--- a/packages/adena-extension/src/services/wallet/wallet-balance.spec.ts
+++ b/packages/adena-extension/src/services/wallet/wallet-balance.spec.ts
@@ -2,16 +2,8 @@ import { GnoProvider } from '@common/provider/gno/gno-provider';
 import { WalletBalanceService } from './wallet-balance';
 
 /**
- * A TRANSPORT FAILURE IS NOT A ZERO BALANCE.
- *
- * getGnotTokenBalance used to end `.catch(() => null)`, and its callers render
- * `${balanceAmount || 0}`. A failed RPC call therefore reached the UI as a
- * confident "0 GNOT" — indistinguishable from an account that genuinely holds
- * nothing, and produced while offline, when no balance had been read at all.
- *
- * What these pin:
- *   - the request fails      -> reject, so the query errors and the UI can warn
- *   - the response is absurd -> null, a real answer this method cannot convert
+ * A transport failure is not a zero balance: a failed request must reject so the
+ * query errors, and null is reserved for a response that is not an integer.
  */
 const serviceWith = (getBalance: jest.Mock): WalletBalanceService => {
   const service = new WalletBalanceService();

--- a/packages/adena-extension/src/services/wallet/wallet-balance.spec.ts
+++ b/packages/adena-extension/src/services/wallet/wallet-balance.spec.ts
@@ -1,50 +1,46 @@
+import { GnoProvider } from '@common/provider/gno/gno-provider';
 import { WalletBalanceService } from './wallet-balance';
 
 /**
  * A TRANSPORT FAILURE IS NOT A ZERO BALANCE.
  *
  * getGnotTokenBalance used to end `.catch(() => null)`, and its callers render
- * `${balanceAmount || 0}`. A failed RPC call therefore arrived at the UI as a
+ * `${balanceAmount || 0}`. A failed RPC call therefore reached the UI as a
  * confident "0 GNOT" — indistinguishable from an account that genuinely holds
  * nothing, and produced while offline, when no balance had been read at all.
  *
- * The distinction these tests pin:
+ * What these pin:
  *   - the request fails      -> reject, so the query errors and the UI can warn
  *   - the response is absurd -> null, a real answer this method cannot convert
  */
-const makeService = (getBalance: jest.Mock): WalletBalanceService => {
-  const provider = { getBalance };
-  const service = new WalletBalanceService({} as never);
-  // The provider is resolved through a private getter; substituting it keeps
-  // this a unit test of the failure contract rather than of network plumbing.
-  (service as unknown as { getGnoProvider: () => unknown }).getGnoProvider = (): unknown =>
-    provider;
+const serviceWith = (getBalance: jest.Mock): WalletBalanceService => {
+  const service = new WalletBalanceService();
+  service.setGnoProvider({ getBalance } as unknown as GnoProvider);
   return service;
 };
 
 describe('WalletBalanceService.getGnotTokenBalance', () => {
   it('rejects when the request fails, rather than reporting a zero balance', async () => {
-    const boom = new Error('network unreachable');
-    const service = makeService(jest.fn().mockRejectedValue(boom));
+    const service = serviceWith(jest.fn().mockRejectedValue(new Error('network unreachable')));
 
     await expect(service.getGnotTokenBalance('g1abc')).rejects.toThrow('network unreachable');
   });
 
   it('returns the converted amount when the request succeeds', async () => {
-    const service = makeService(jest.fn().mockResolvedValue('1500000'));
-
     // 6 decimals: 1_500_000 ugnot is 1.5 GNOT.
+    const service = serviceWith(jest.fn().mockResolvedValue('1500000'));
+
     await expect(service.getGnotTokenBalance('g1abc')).resolves.toBe(1.5);
   });
 
   it('reports zero as zero, which must stay distinguishable from a failure', async () => {
-    const service = makeService(jest.fn().mockResolvedValue('0'));
+    const service = serviceWith(jest.fn().mockResolvedValue('0'));
 
     await expect(service.getGnotTokenBalance('g1abc')).resolves.toBe(0);
   });
 
   it('returns null for a non-integer response, the one case null still means', async () => {
-    const service = makeService(jest.fn().mockResolvedValue('not-a-number'));
+    const service = serviceWith(jest.fn().mockResolvedValue('not-a-number'));
 
     await expect(service.getGnotTokenBalance('g1abc')).resolves.toBeNull();
   });

--- a/packages/adena-extension/src/services/wallet/wallet-balance.spec.ts
+++ b/packages/adena-extension/src/services/wallet/wallet-balance.spec.ts
@@ -1,0 +1,51 @@
+import { WalletBalanceService } from './wallet-balance';
+
+/**
+ * A TRANSPORT FAILURE IS NOT A ZERO BALANCE.
+ *
+ * getGnotTokenBalance used to end `.catch(() => null)`, and its callers render
+ * `${balanceAmount || 0}`. A failed RPC call therefore arrived at the UI as a
+ * confident "0 GNOT" — indistinguishable from an account that genuinely holds
+ * nothing, and produced while offline, when no balance had been read at all.
+ *
+ * The distinction these tests pin:
+ *   - the request fails      -> reject, so the query errors and the UI can warn
+ *   - the response is absurd -> null, a real answer this method cannot convert
+ */
+const makeService = (getBalance: jest.Mock): WalletBalanceService => {
+  const provider = { getBalance };
+  const service = new WalletBalanceService({} as never);
+  // The provider is resolved through a private getter; substituting it keeps
+  // this a unit test of the failure contract rather than of network plumbing.
+  (service as unknown as { getGnoProvider: () => unknown }).getGnoProvider = (): unknown =>
+    provider;
+  return service;
+};
+
+describe('WalletBalanceService.getGnotTokenBalance', () => {
+  it('rejects when the request fails, rather than reporting a zero balance', async () => {
+    const boom = new Error('network unreachable');
+    const service = makeService(jest.fn().mockRejectedValue(boom));
+
+    await expect(service.getGnotTokenBalance('g1abc')).rejects.toThrow('network unreachable');
+  });
+
+  it('returns the converted amount when the request succeeds', async () => {
+    const service = makeService(jest.fn().mockResolvedValue('1500000'));
+
+    // 6 decimals: 1_500_000 ugnot is 1.5 GNOT.
+    await expect(service.getGnotTokenBalance('g1abc')).resolves.toBe(1.5);
+  });
+
+  it('reports zero as zero, which must stay distinguishable from a failure', async () => {
+    const service = makeService(jest.fn().mockResolvedValue('0'));
+
+    await expect(service.getGnotTokenBalance('g1abc')).resolves.toBe(0);
+  });
+
+  it('returns null for a non-integer response, the one case null still means', async () => {
+    const service = makeService(jest.fn().mockResolvedValue('not-a-number'));
+
+    await expect(service.getGnotTokenBalance('g1abc')).resolves.toBeNull();
+  });
+});

--- a/packages/adena-extension/src/services/wallet/wallet-balance.ts
+++ b/packages/adena-extension/src/services/wallet/wallet-balance.ts
@@ -56,8 +56,7 @@ export class WalletBalanceService {
             .toNumber();
         }
         return null;
-      })
-      .catch(() => null);
+      });
   }
 
   /**


### PR DESCRIPTION
Three related problems, all of which make the wallet lie or go blank when the
browser reports no connection.

### 1. A failed balance fetch was shown as a real balance

`getGnotTokenBalance` ended in `.catch(() => null)`, and its callers render
`` `${balanceAmount || 0}` ``. So a failed RPC call became a confident **0 GNOT** —
identical on screen to an account that genuinely holds nothing. The query
*succeeded*, so there was no error or paused state for the UI to notice.

Cosmos never had this: `fetch-cosmos-balances` propagates errors and sets
`error: true`. During the same outage ATONE correctly showed `-` with a warning
while GNOT showed `0`.

A request that doesn't complete now rejects. `null` is kept for the one thing it
legitimately means: a response that isn't an integer.

Three follow-on fixes so the error reaches the screen: `errorNetworkIds` was
built from Cosmos results only, so a Gno failure had nowhere to go; the headline
balance bypassed it and kept showing a stale figure; and the send flow awaited
`fetchBalanceBy` unguarded, so it now degrades instead of breaking.

### 2. Wallet state was gated on connectivity

The popup and the setup page decide what to render from two `chrome.storage`
reads. Both used react-query's default `networkMode: 'online'`, which *pauses* a
query while the browser reports offline — it never runs, never errors, status
stays `loading`. Both screens render an empty container in exactly that state, so
an offline browser gets a blank popup and a setup page showing only the logo,
with nothing in the console because nothing threw.

Wallet existence and lock state live on disk. They're now `networkMode: 'always'`.

### 3. Nothing ever said "offline"

No screen read `navigator.onLine` or react-query's `onlineManager`. Being offline
was expressed only as data that never arrived. There's now a bar saying so, and
saying what's still trustworthy: accounts and addresses are local and valid, chain
data is paused.

**Retry overrides the signal**, which matters more than it sounds: `navigator.onLine`
is the OS's "is there any route" answer, and a wedged Chrome network notifier
reports offline on a perfectly connected machine — every paused query then hangs
until the browser restarts. The bar stays visible while the browser still claims
offline, so the override is never mistaken for a restored connection, and it's
dropped on the next real outage.

### Deliberately not changed

- The same swallow exists twice for GRC20 (`wallet-balance.ts:72,110`). Left
  alone: `null` is overloaded there (it also means "not an integer") and
  `getGRC20RawBalance` uses a catch for registry→direct-realm *fallback*, which is
  legitimate control flow. Same class of bug, but I couldn't verify a fix.
- `router/web/index.tsx`'s final branch renders a bare `<Route>` outside
  `<Routes>`, which draws nothing. Real, unrelated, separate issue.
