### PR TITLE
fix(gnoconnect): say why a loopback TxLink was declined

### DIFF
--- a/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
+++ b/packages/adena-extension/src/common/constants/gno-connect-allowlist.constant.ts
@@ -53,3 +53,15 @@ const LOOPBACK_ORIGIN_CHAIN_IDS: ReadonlyMap<string, string> = new Map(
 // before honoring the origin's gnoconnect data.
 export const getLoopbackOriginChainId = (origin: string): string | null =>
   LOOPBACK_ORIGIN_CHAIN_IDS.get(origin) ?? null;
+
+// chainId -> the label the network picker shows for it ("dev" is "Local").
+// Diagnostics only: it lets a message name the network the way the user sees it
+// in the UI, instead of quoting a chainId they would have to translate.
+const CHAIN_NETWORK_NAMES: ReadonlyMap<string, string> = new Map(
+  CHAIN_DATA.map((chain) => [chain.chainId, chain.networkName] as const),
+);
+
+// Returns the network picker's label for a chainId, or null when the chainId is
+// not one of the bundled chains (a network the user added by hand).
+export const getChainNetworkName = (chainId: string): string | null =>
+  CHAIN_NETWORK_NAMES.get(chainId) ?? null;

--- a/packages/adena-extension/src/inject/message/command-handler.ts
+++ b/packages/adena-extension/src/inject/message/command-handler.ts
@@ -17,14 +17,15 @@ import {
 import { clearPopup } from './commands/popup';
 import {
   getLoopbackGnoConnectChainId,
+  getLoopbackGnoConnectRejection,
   GnoArgumentInfo,
   GnoConnectInfo,
   GnoMessageInfo,
   isAllowedGnoConnectOrigin,
-  isLoopbackGnoConnectTrusted,
   parseGnoConnectInfo,
   parseGnoMessageInfo,
 } from './methods/gno-connect';
+import { describeLoopbackRejection, showGnoConnectNotice } from './methods/gno-connect-notice';
 
 export class CommandHandler {
   public static createHandler = async (
@@ -153,13 +154,31 @@ export class CommandHandler {
     // user is on another network.
     if (isLoopbackOrigin) {
       const networkResponse = await executor.getNetwork();
-      const activeChainId =
-        networkResponse.type === WalletResponseSuccessType.GET_NETWORK_SUCCESS
-          ? networkResponse.data?.chainId
-          : undefined;
+      const isNetworkKnown =
+        networkResponse.type === WalletResponseSuccessType.GET_NETWORK_SUCCESS;
+      const activeChainId = isNetworkKnown ? networkResponse.data?.chainId : undefined;
 
-      if (!isLoopbackGnoConnectTrusted(loopbackChainId, gnoConnectInfo.chainId, activeChainId)) {
-        console.info('Loopback gnoconnect origin is not trusted for the active network; ignoring');
+      // The gate is unchanged; only its silence is. A rejection used to end here
+      // as a bare console.info, which is easy to miss in the page's console and
+      // leaves the user with a link that does nothing and no way to tell whether
+      // their wallet is locked, on another network, or too old to support
+      // loopback TxLinks at all.
+      const rejection = getLoopbackGnoConnectRejection(
+        loopbackChainId,
+        gnoConnectInfo.chainId,
+        activeChainId,
+      );
+
+      if (rejection !== null) {
+        const notice = describeLoopbackRejection(rejection, {
+          requiredChainId: loopbackChainId,
+          metaChainId: gnoConnectInfo.chainId,
+          activeChainId,
+          activeNetworkName: isNetworkKnown ? networkResponse.data?.networkName : undefined,
+        });
+
+        console.warn(`[Adena] ${notice.title}: ${notice.body} (${rejection})`);
+        showGnoConnectNotice(notice);
         return;
       }
     }

--- a/packages/adena-extension/src/inject/message/methods/gno-connect-notice.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect-notice.spec.ts
@@ -1,0 +1,105 @@
+import { describeLoopbackRejection, showGnoConnectNotice } from './gno-connect-notice';
+
+describe('describeLoopbackRejection', () => {
+  const REQUIRED = 'dev';
+
+  it('tells the user which network to switch to, and which one they are on', () => {
+    const notice = describeLoopbackRejection('ACTIVE_NETWORK_MISMATCH', {
+      requiredChainId: REQUIRED,
+      metaChainId: 'dev',
+      activeChainId: 'sapphire-1',
+      activeNetworkName: 'Sapphire',
+    });
+
+    // Named the way the network picker names them, so the instruction can be
+    // followed without translating a chainId.
+    expect(notice.body).toContain('Local (dev)');
+    expect(notice.body).toContain('Sapphire (sapphire-1)');
+    expect(notice.body).toContain('Switch networks');
+  });
+
+  it('falls back to the bare chainId for a network Adena does not bundle', () => {
+    const notice = describeLoopbackRejection('ACTIVE_NETWORK_MISMATCH', {
+      requiredChainId: REQUIRED,
+      metaChainId: 'dev',
+      activeChainId: 'my-private-chain',
+    });
+
+    expect(notice.body).toContain('my-private-chain');
+  });
+
+  it('tells a locked wallet to unlock rather than to switch networks', () => {
+    const notice = describeLoopbackRejection('WALLET_UNAVAILABLE', {
+      requiredChainId: REQUIRED,
+      metaChainId: 'dev',
+    });
+
+    expect(notice.body).toContain('locked');
+    expect(notice.body).not.toContain('Switch networks');
+  });
+
+  it('quotes what the page declared for the origin mismatch', () => {
+    const notice = describeLoopbackRejection('ORIGIN_CHAIN_MISMATCH', {
+      requiredChainId: REQUIRED,
+      metaChainId: 'gnoland1',
+      activeChainId: 'dev',
+    });
+
+    expect(notice.body).toContain('gnoland1');
+    expect(notice.body).toContain('Local (dev)');
+  });
+
+  it('clips a page-controlled chainId so it cannot crowd out the message', () => {
+    const notice = describeLoopbackRejection('ORIGIN_CHAIN_MISMATCH', {
+      requiredChainId: REQUIRED,
+      metaChainId: 'x'.repeat(500),
+      activeChainId: 'dev',
+    });
+
+    expect(notice.body).toContain('…');
+    expect(notice.body.length).toBeLessThan(200);
+  });
+});
+
+describe('showGnoConnectNotice', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.useRealTimers();
+  });
+
+  it('renders the notice into the page', () => {
+    showGnoConnectNotice({ title: 'Title', body: 'Body' });
+
+    expect(document.getElementById('adena-gnoconnect-notice')).not.toBeNull();
+  });
+
+  it('replaces the previous notice instead of stacking copies', () => {
+    showGnoConnectNotice({ title: 'Title', body: 'First' });
+    showGnoConnectNotice({ title: 'Title', body: 'Second' });
+
+    expect(document.querySelectorAll('#adena-gnoconnect-notice')).toHaveLength(1);
+  });
+
+  it('removes itself after the timeout', () => {
+    jest.useFakeTimers();
+    showGnoConnectNotice({ title: 'Title', body: 'Body' });
+
+    jest.advanceTimersByTime(15_000);
+
+    expect(document.getElementById('adena-gnoconnect-notice')).toBeNull();
+  });
+
+  it('renders page-controlled text as text, never as markup', () => {
+    // The body can quote a chainId the page declared, so this pins that the
+    // notice cannot become an injection point back into the page.
+    const payload = '<img src=x onerror="globalThis.__adenaXss = true">';
+    showGnoConnectNotice({ title: 'Title', body: payload });
+
+    const shadow = document.getElementById('adena-gnoconnect-notice')?.shadowRoot;
+
+    // Falsifiable both ways: the payload must survive as visible text, and must
+    // not have become an element. Rendering it with innerHTML fails the second.
+    expect(shadow?.textContent).toContain(payload);
+    expect(shadow?.querySelector('img')).toBeNull();
+  });
+});

--- a/packages/adena-extension/src/inject/message/methods/gno-connect-notice.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect-notice.ts
@@ -1,0 +1,190 @@
+import { getChainNetworkName } from '@common/constants/gno-connect-allowlist.constant';
+import { LoopbackTrustRejection } from './gno-connect';
+
+/**
+ * Diagnostics for a loopback TxLink the wallet declined to open.
+ *
+ * The trust gate is deliberately silent toward the page: it returns without
+ * calling anything, so a local process cannot tell a rejection apart from a
+ * wallet that is not installed. That silence is correct for the page and wrong
+ * for the person, who sees a link that does nothing and cannot tell whether
+ * their wallet is locked, on another network, or simply too old to support
+ * loopback TxLinks at all.
+ *
+ * Nothing here participates in the decision — the gate has already refused by
+ * the time any of this runs, and no text produced here can change that.
+ */
+export interface GnoConnectNotice {
+  title: string;
+  body: string;
+}
+
+export interface LoopbackRejectionContext {
+  /** chainId the origin may act as, per chains.json. */
+  requiredChainId: string;
+  /** chainId the page declared via meta tag. Page-controlled. */
+  metaChainId: string;
+  /** The wallet's active network, absent when it reported none. */
+  activeChainId?: string;
+  activeNetworkName?: string;
+}
+
+const NOTICE_TITLE = 'Adena did not open this transaction';
+
+// Page-controlled text is quoted back so the developer can see what their page
+// actually declared, so it is clipped to a length that cannot push the rest of
+// the message off screen. It is rendered with textContent, never as markup.
+const MAX_QUOTED_LENGTH = 40;
+
+function clip(value: string): string {
+  return value.length <= MAX_QUOTED_LENGTH ? value : `${value.slice(0, MAX_QUOTED_LENGTH)}…`;
+}
+
+// Names a network the way the picker does, so the instruction matches what the
+// user is looking for: `Local (dev)`. Falls back to the bare chainId for a
+// network Adena does not bundle.
+function describeNetwork(chainId: string, knownName?: string): string {
+  const name = knownName ?? getChainNetworkName(chainId) ?? null;
+  return name === null || name === chainId ? chainId : `${name} (${chainId})`;
+}
+
+export function describeLoopbackRejection(
+  rejection: LoopbackTrustRejection,
+  context: LoopbackRejectionContext,
+): GnoConnectNotice {
+  const required = describeNetwork(context.requiredChainId);
+
+  if (rejection === 'ORIGIN_CHAIN_MISMATCH') {
+    return {
+      title: NOTICE_TITLE,
+      body:
+        `This page declared the network "${clip(context.metaChainId)}", but a page served ` +
+        `from this address may only act as ${required}.`,
+    };
+  }
+
+  if (rejection === 'WALLET_UNAVAILABLE') {
+    return {
+      title: NOTICE_TITLE,
+      body:
+        'Adena is locked, or has no account selected. Unlock it, make sure you are on ' +
+        `${required}, then use the link again.`,
+    };
+  }
+
+  const active =
+    context.activeChainId === undefined
+      ? 'another network'
+      : describeNetwork(context.activeChainId, context.activeNetworkName);
+
+  return {
+    title: NOTICE_TITLE,
+    body:
+      `This link is for ${required}, but Adena is on ${active}. Switch networks in ` +
+      'Adena, then use the link again.',
+  };
+}
+
+const NOTICE_HOST_ID = 'adena-gnoconnect-notice';
+const NOTICE_TIMEOUT_MS = 15_000;
+
+/**
+ * Renders the notice into the page, inside a closed shadow root so neither side's
+ * CSS reaches the other.
+ *
+ * This is diagnostics, not a security surface: any page could draw the same box
+ * itself, so the notice must never be read as proof that Adena said something.
+ * It carries no controls beyond dismissing itself and asks for no input.
+ *
+ * The root is open rather than closed. Closing it would protect nothing — there
+ * is no secret in here, and the page can remove the host element either way —
+ * while making the rendered result impossible to assert on or to inspect when
+ * debugging the very silence this exists to break.
+ */
+export function showGnoConnectNotice(notice: GnoConnectNotice): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const container = document.body ?? document.documentElement;
+  if (!container) {
+    return;
+  }
+
+  // Replace rather than stack: clicking a dead link repeatedly should not build
+  // a wall of identical boxes.
+  document.getElementById(NOTICE_HOST_ID)?.remove();
+
+  const host = document.createElement('div');
+  host.id = NOTICE_HOST_ID;
+  const shadow = host.attachShadow({ mode: 'open' });
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .card {
+      position: fixed;
+      top: 16px;
+      right: 16px;
+      z-index: 2147483647;
+      max-width: 340px;
+      box-sizing: border-box;
+      padding: 14px 16px;
+      border: 1px solid #e0a72e;
+      border-radius: 10px;
+      background: #1f1b14;
+      color: #f5efe3;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 13px;
+      line-height: 1.5;
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+    }
+    .title {
+      display: block;
+      margin-bottom: 4px;
+      padding-right: 16px;
+      font-weight: 600;
+      color: #e0a72e;
+    }
+    .close {
+      position: absolute;
+      top: 8px;
+      right: 10px;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      color: inherit;
+      font-size: 15px;
+      line-height: 1;
+      cursor: pointer;
+    }
+    @media (prefers-reduced-motion: no-preference) {
+      .card { animation: fade 160ms ease-out; }
+      @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+    }
+  `;
+
+  const card = document.createElement('div');
+  card.className = 'card';
+  card.setAttribute('role', 'status');
+  card.setAttribute('aria-live', 'polite');
+
+  const title = document.createElement('strong');
+  title.className = 'title';
+  title.textContent = notice.title;
+
+  const body = document.createElement('span');
+  body.textContent = notice.body;
+
+  const close = document.createElement('button');
+  close.className = 'close';
+  close.type = 'button';
+  close.setAttribute('aria-label', 'Dismiss');
+  close.textContent = '×';
+  close.addEventListener('click', () => host.remove());
+
+  card.append(close, title, body);
+  shadow.append(style, card);
+  container.appendChild(host);
+
+  setTimeout(() => host.remove(), NOTICE_TIMEOUT_MS);
+}

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.spec.ts
@@ -2,6 +2,7 @@ import {
   getLoopbackGnoConnectChainId,
   GnoMessageInfo,
   isAllowedGnoConnectOrigin,
+  getLoopbackGnoConnectRejection,
   isLoopbackGnoConnectTrusted,
   normalizeGnoConnectRpc,
   parseGnoMessageInfo,
@@ -303,6 +304,64 @@ describe('isLoopbackGnoConnectTrusted', () => {
 
   it('rejects when neither the meta chainId nor the active network match', () => {
     expect(isLoopbackGnoConnectTrusted(LOOPBACK_CHAIN_ID, 'gnoland1', 'gnoland1')).toBe(false);
+  });
+});
+
+describe('getLoopbackGnoConnectRejection', () => {
+  const LOOPBACK_CHAIN_ID = 'dev';
+
+  it('reports no rejection exactly when the origin is trusted', () => {
+    expect(getLoopbackGnoConnectRejection(LOOPBACK_CHAIN_ID, 'dev', 'dev')).toBeNull();
+  });
+
+  it('names a foreign meta chainId as the origin mismatch', () => {
+    expect(getLoopbackGnoConnectRejection(LOOPBACK_CHAIN_ID, 'gnoland1', 'dev')).toBe(
+      'ORIGIN_CHAIN_MISMATCH',
+    );
+  });
+
+  it('names an absent active network as the wallet being unavailable', () => {
+    // What a locked wallet looks like from the gate: getNetwork answers
+    // WALLET_LOCKED, so the caller has no chainId to hand over.
+    expect(getLoopbackGnoConnectRejection(LOOPBACK_CHAIN_ID, 'dev', undefined)).toBe(
+      'WALLET_UNAVAILABLE',
+    );
+  });
+
+  it('names a different active network as the network mismatch', () => {
+    expect(getLoopbackGnoConnectRejection(LOOPBACK_CHAIN_ID, 'dev', 'gnoland1')).toBe(
+      'ACTIVE_NETWORK_MISMATCH',
+    );
+  });
+
+  it('prefers the origin mismatch, which holds regardless of wallet state', () => {
+    expect(getLoopbackGnoConnectRejection(LOOPBACK_CHAIN_ID, 'gnoland1', undefined)).toBe(
+      'ORIGIN_CHAIN_MISMATCH',
+    );
+  });
+
+  it('agrees with the trust decision over every combination', () => {
+    // The reason exists to be reported, never to be acted on. Pinning the two
+    // together means a future edit cannot let the message and the decision drift
+    // — the case that would tell a user their wallet is fine while it refuses.
+    const chainIds: (string | undefined)[] = [undefined, 'dev', 'gnoland1', ''];
+
+    for (const metaChainId of chainIds) {
+      for (const activeChainId of chainIds) {
+        if (metaChainId === undefined) {
+          continue;
+        }
+
+        const trusted = isLoopbackGnoConnectTrusted(LOOPBACK_CHAIN_ID, metaChainId, activeChainId);
+        const rejection = getLoopbackGnoConnectRejection(
+          LOOPBACK_CHAIN_ID,
+          metaChainId,
+          activeChainId,
+        );
+
+        expect(rejection === null).toBe(trusted);
+      }
+    }
   });
 });
 

--- a/packages/adena-extension/src/inject/message/methods/gno-connect.ts
+++ b/packages/adena-extension/src/inject/message/methods/gno-connect.ts
@@ -404,7 +404,47 @@ export function isLoopbackGnoConnectTrusted(
   metaChainId: string,
   activeChainId: string | undefined,
 ): boolean {
-  return metaChainId === loopbackChainId && activeChainId === loopbackChainId;
+  return getLoopbackGnoConnectRejection(loopbackChainId, metaChainId, activeChainId) === null;
+}
+
+/**
+ * Why the gate above refused, or null when it did not refuse.
+ *
+ * This is the primitive and isLoopbackGnoConnectTrusted is derived from it, so a
+ * caller can never report a reason the decision did not actually take. The three
+ * outcomes partition exactly the cases the boolean rejects:
+ *
+ * - ORIGIN_CHAIN_MISMATCH: the page declared a chainId the origin may not act
+ *   as. The only reason driven by page-controlled input.
+ * - WALLET_UNAVAILABLE: the wallet reported no active network at all, which is
+ *   what a locked wallet looks like from here (getNetwork answers WALLET_LOCKED,
+ *   so the caller has no chainId to pass). Split out of the mismatch case below
+ *   only so the user can be told to unlock rather than to switch networks.
+ * - ACTIVE_NETWORK_MISMATCH: the wallet is on some other network.
+ */
+export type LoopbackTrustRejection =
+  | 'ORIGIN_CHAIN_MISMATCH'
+  | 'WALLET_UNAVAILABLE'
+  | 'ACTIVE_NETWORK_MISMATCH';
+
+export function getLoopbackGnoConnectRejection(
+  loopbackChainId: string,
+  metaChainId: string,
+  activeChainId: string | undefined,
+): LoopbackTrustRejection | null {
+  if (metaChainId !== loopbackChainId) {
+    return 'ORIGIN_CHAIN_MISMATCH';
+  }
+
+  if (activeChainId === undefined) {
+    return 'WALLET_UNAVAILABLE';
+  }
+
+  if (activeChainId !== loopbackChainId) {
+    return 'ACTIVE_NETWORK_MISMATCH';
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
The runtime trust gate for loopback origins (#868) fails closed, which is right, but it failed closed in silence: a bare console.info and a return. Four different situations produced the identical no-op — wallet on another network, wallet locked, page declaring a chainId its origin may not act as, and an Adena too old to support loopback TxLinks at all. A user clicking Execute on a local gnodev saw the unlock prompt, then nothing, with no way to tell which of those had happened or what to do about it.

The gate itself is unchanged. getLoopbackGnoConnectRejection now names the reason and isLoopbackGnoConnectTrusted is derived from it, so the message and the decision cannot drift; a test pins that equivalence over every combination. The reason becomes a console.warn and a dismissing notice in the page, naming networks the way the network picker does ("Local (dev)") so the instruction can be followed without translating a chainId.

The notice is diagnostics, not a security surface: any page could draw the same box, so it must never be read as proof that Adena said something. It asks for no input, carries no controls but its own dismiss, and renders page-controlled text with textContent — pinned by an injection test. It tells the page nothing new either, since window.adena.GetNetwork() already reports both the active network and WALLET_LOCKED on request.
