### PR TITLE
fix(grc20): follow grc20reg's non-crossing Transfer spec

### DIFF
--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@adena-wallet/sdk": "0.0.14",
     "@bufbuild/protobuf": "2.12.0",
-    "@gnolang/gno-js-client": "2.0.3",
+    "@gnolang/gno-js-client": "2.0.4",
     "@gnolang/tm2-js-client": "2.0.4",
     "@gnolang/tm2-rpc": "1.0.0",
     "@tanstack/react-query": "4.36.1",

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/code-message-static-gas.spec.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/code-message-static-gas.spec.ts
@@ -1,0 +1,84 @@
+import { Document } from 'adena-module';
+
+import {
+  resolveCodeMessageGasType,
+  resolveStaticCodeMessageGasUsed,
+  STATIC_CODE_MESSAGE_GAS_USED,
+} from './code-message-static-gas';
+
+function makeDocument(msgs: Document['msgs']): Document {
+  return {
+    msgs,
+    fee: { gas: '200000', amount: [{ denom: 'ugnot', amount: '1000' }] },
+    memo: '',
+    chain_id: 'pearl-1',
+    account_number: '0',
+    sequence: '0',
+  };
+}
+
+const grc20TransferRun = {
+  type: '/vm.m_run',
+  value: {
+    caller: 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5',
+    package: {
+      name: 'main',
+      path: '',
+      files: [
+        {
+          name: 'main.gno',
+          body: 'package main\n\nfunc main(cur realm) {\n\tgrc20reg.Transfer(0, cur, "k", address("g1"), 1)\n}\n',
+        },
+      ],
+    },
+  },
+};
+
+const plainRun = {
+  type: '/vm.m_run',
+  value: {
+    caller: 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5',
+    package: {
+      name: 'main',
+      path: '',
+      files: [{ name: 'main.gno', body: 'package main\n\nfunc main(cur realm) {}\n' }],
+    },
+  },
+};
+
+const addPackage = {
+  type: '/vm.m_addpkg',
+  value: { creator: 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' },
+};
+
+const bankSend = {
+  type: '/bank.MsgSend',
+  value: { from_address: 'g1', to_address: 'g2', amount: '1ugnot' },
+};
+
+describe('resolveCodeMessageGasType', () => {
+  it('separates a GRC20 transfer run from a plain run', () => {
+    expect(resolveCodeMessageGasType(grc20TransferRun)).toBe('MSG_RUN_GRC20_TRANSFER');
+    expect(resolveCodeMessageGasType(plainRun)).toBe('MSG_RUN');
+  });
+
+  it('classifies add package and ignores non code-bearing messages', () => {
+    expect(resolveCodeMessageGasType(addPackage)).toBe('ADD_PACKAGE');
+    expect(resolveCodeMessageGasType(bankSend)).toBeNull();
+  });
+});
+
+describe('resolveStaticCodeMessageGasUsed', () => {
+  it('returns null when no message carries code', () => {
+    expect(resolveStaticCodeMessageGasUsed(makeDocument([bankSend]))).toBeNull();
+  });
+
+  it('sums the buckets of every code-bearing message', () => {
+    expect(resolveStaticCodeMessageGasUsed(makeDocument([grc20TransferRun]))).toBe(
+      STATIC_CODE_MESSAGE_GAS_USED.MSG_RUN_GRC20_TRANSFER,
+    );
+    expect(resolveStaticCodeMessageGasUsed(makeDocument([addPackage, plainRun]))).toBe(
+      STATIC_CODE_MESSAGE_GAS_USED.ADD_PACKAGE + STATIC_CODE_MESSAGE_GAS_USED.MSG_RUN,
+    );
+  });
+});

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/code-message-static-gas.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/code-message-static-gas.ts
@@ -17,7 +17,7 @@ export type CodeMessageGasType = 'ADD_PACKAGE' | 'MSG_RUN' | 'MSG_RUN_GRC20_TRAN
 /** Conservative `gasUsed` per message type; the fee is derived from it. */
 export const STATIC_CODE_MESSAGE_GAS_USED: Record<CodeMessageGasType, number> = {
   ADD_PACKAGE: 1_000_000_000,
-  MSG_RUN: 100_000_000,
+  MSG_RUN: 1_000_000_000,
   MSG_RUN_GRC20_TRANSFER: 50_000_000,
 };
 

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/code-message-static-gas.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/code-message-static-gas.ts
@@ -16,9 +16,9 @@ export type CodeMessageGasType = 'ADD_PACKAGE' | 'MSG_RUN' | 'MSG_RUN_GRC20_TRAN
 
 /** Conservative `gasUsed` per message type; the fee is derived from it. */
 export const STATIC_CODE_MESSAGE_GAS_USED: Record<CodeMessageGasType, number> = {
-  ADD_PACKAGE: 12_000_000,
-  MSG_RUN: 6_000_000,
-  MSG_RUN_GRC20_TRANSFER: 3_000_000,
+  ADD_PACKAGE: 1_000_000_000,
+  MSG_RUN: 100_000_000,
+  MSG_RUN_GRC20_TRANSFER: 50_000_000,
 };
 
 const MSG_ADD_PACKAGE_TYPE = '/vm.m_addpkg';

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/code-message-static-gas.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/code-message-static-gas.ts
@@ -1,0 +1,71 @@
+import { Account, Document, isAirgapAccount, isLedgerAccount } from 'adena-module';
+
+/**
+ * Gas fallback for code-bearing messages (`/vm.m_addpkg`, `/vm.m_run`).
+ *
+ * Since gnolang/gno#6088 the chain verifies signatures on the simulate path for
+ * these messages, so gas can only be estimated with a real signature. Accounts
+ * that cannot sign in-process (Ledger, AirGap) have no key available while the
+ * fee is being calculated, so they fall back to the table below.
+ *
+ * To tune a value, simulate the same message with an in-process account, read
+ * `gas_used`, and update the entry here — this table is the only place to edit.
+ */
+
+export type CodeMessageGasType = 'ADD_PACKAGE' | 'MSG_RUN' | 'MSG_RUN_GRC20_TRANSFER';
+
+/** Conservative `gasUsed` per message type; the fee is derived from it. */
+export const STATIC_CODE_MESSAGE_GAS_USED: Record<CodeMessageGasType, number> = {
+  ADD_PACKAGE: 12_000_000,
+  MSG_RUN: 6_000_000,
+  MSG_RUN_GRC20_TRANSFER: 3_000_000,
+};
+
+const MSG_ADD_PACKAGE_TYPE = '/vm.m_addpkg';
+const MSG_RUN_TYPE = '/vm.m_run';
+
+// The GRC20 transfer run body is generated in transfer-summary with the
+// registry imported as `grc20reg`, so this marker identifies it regardless of
+// which chain's registry path was used.
+const GRC20_TRANSFER_MARKER = 'grc20reg.Transfer(';
+
+type DocumentMessage = Document['msgs'][number];
+
+function isGRC20TransferRun(message: DocumentMessage): boolean {
+  const files: { body?: string }[] = message.value?.package?.files ?? [];
+  return files.some((file) => (file?.body ?? '').includes(GRC20_TRANSFER_MARKER));
+}
+
+/** The gas bucket a message falls into, or null when it needs no fallback. */
+export function resolveCodeMessageGasType(message: DocumentMessage): CodeMessageGasType | null {
+  if (message.type === MSG_ADD_PACKAGE_TYPE) {
+    return 'ADD_PACKAGE';
+  }
+  if (message.type === MSG_RUN_TYPE) {
+    return isGRC20TransferRun(message) ? 'MSG_RUN_GRC20_TRANSFER' : 'MSG_RUN';
+  }
+  return null;
+}
+
+/** True when the account has no key available during fee calculation. */
+export function canSignInProcess(account?: Account | null): boolean {
+  if (!account) {
+    return false;
+  }
+  return !isLedgerAccount(account) && !isAirgapAccount(account);
+}
+
+/**
+ * Static `gasUsed` for a document, or null when it carries no code-bearing
+ * message. Sums the buckets so a multi-message document is still covered.
+ */
+export function resolveStaticCodeMessageGasUsed(document?: Document | null): number | null {
+  const types = (document?.msgs ?? [])
+    .map(resolveCodeMessageGasType)
+    .filter((type): type is CodeMessageGasType => type !== null);
+
+  if (types.length === 0) {
+    return null;
+  }
+  return types.reduce((total, type) => total + STATIC_CODE_MESSAGE_GAS_USED[type], 0);
+}

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas.ts
@@ -12,6 +12,7 @@ import { useCurrentAccount } from '@hooks/use-current-account';
 import { TransactionService } from '@services/index';
 
 import { useIsInitializedAccount } from '../use-get-account-info';
+import { canSignInProcess, resolveStaticCodeMessageGasUsed } from './code-message-static-gas';
 import { useGetGasPrice } from './use-get-gas-price';
 
 export const GET_ESTIMATE_GAS_KEY = 'transactionGas/useGetEstimateGas';
@@ -83,16 +84,11 @@ function modifyDocument(document: Document, gasWanted: number, gasFee: number): 
   };
 }
 
-// Messages the chain authorizes from their signer, and therefore verifies the
-// signature of even on the simulate path (gnolang/gno#6088 wires the ante's
-// RequireSigForSimulate to txCarriesCode). A placeholder tx carrying one of
-// these is rejected with `/std.UnauthorizedError: signature verification
-// failed`, so gas estimation has to sign for real. Keep in sync with
-// txCarriesCode in gno.land/pkg/gnoland/app.go.
-const SIGN_REQUIRED_MESSAGE_TYPES = ['/vm.m_run', '/vm.m_addpkg'];
-
+// The chain verifies signatures on the simulate path for code-bearing messages
+// (gnolang/gno#6088 wires the ante's RequireSigForSimulate to txCarriesCode), so
+// a placeholder tx carrying one is rejected with `/std.UnauthorizedError`.
 function requiresRealSignature(document: Document): boolean {
-  return (document.msgs ?? []).some((msg) => SIGN_REQUIRED_MESSAGE_TYPES.includes(msg.type));
+  return resolveStaticCodeMessageGasUsed(document) !== null;
 }
 
 /**
@@ -192,6 +188,19 @@ export const useGetEstimateGas = (
         return null;
       }
 
+      // Ledger/AirGap cannot sign while the fee is calculated, and the chain
+      // refuses an unsigned simulate for code-bearing messages, so use the
+      // static table instead of a request that can only fail.
+      const staticGasUsed = resolveStaticCodeMessageGasUsed(document);
+      if (staticGasUsed !== null && !canSignInProcess(currentAccount)) {
+        return {
+          gasUsed: staticGasUsed,
+          storageDeposits: EMPTY_STORAGE_DEPOSITS,
+          hasError: false,
+          simulateErrorMessage: null,
+        };
+      }
+
       const tx = await makeEstimateGasTransaction(
         wallet,
         currentAccount,
@@ -207,26 +216,22 @@ export const useGetEstimateGas = (
 
       const nextResult = await transactionGasService
         .simulateTx(tx)
-        .then(
-          (simulateResult): EstimateGasResult => {
-            return {
-              gasUsed: Number(simulateResult.gas_used),
-              storageDeposits: parseStorageDeposits(simulateResult.response_base?.events ?? []),
-              hasError: false,
-              simulateErrorMessage: null,
-            };
-          },
-        )
-        .catch(
-          (e: Error): EstimateGasResult => {
-            // eslint-disable-next-line no-console
-            console.error('[estimate-gas] simulate failed:', e);
-            return {
-              ...ERROR_ESTIMATE_GAS_RESULT,
-              simulateErrorMessage: e?.message || '',
-            };
-          },
-        );
+        .then((simulateResult): EstimateGasResult => {
+          return {
+            gasUsed: Number(simulateResult.gas_used),
+            storageDeposits: parseStorageDeposits(simulateResult.response_base?.events ?? []),
+            hasError: false,
+            simulateErrorMessage: null,
+          };
+        })
+        .catch((e: Error): EstimateGasResult => {
+          // eslint-disable-next-line no-console
+          console.error('[estimate-gas] simulate failed:', e);
+          return {
+            ...ERROR_ESTIMATE_GAS_RESULT,
+            simulateErrorMessage: e?.message || '',
+          };
+        });
 
       // Keep the higher gasUsed across refetches for the same transaction.
       // Treats an errored/zero response as the lowest value, so a transient

--- a/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas.ts
+++ b/packages/adena-extension/src/hooks/wallet/transaction-gas/use-get-estimate-gas.ts
@@ -83,10 +83,26 @@ function modifyDocument(document: Document, gasWanted: number, gasFee: number): 
   };
 }
 
+// Messages the chain authorizes from their signer, and therefore verifies the
+// signature of even on the simulate path (gnolang/gno#6088 wires the ante's
+// RequireSigForSimulate to txCarriesCode). A placeholder tx carrying one of
+// these is rejected with `/std.UnauthorizedError: signature verification
+// failed`, so gas estimation has to sign for real. Keep in sync with
+// txCarriesCode in gno.land/pkg/gnoland/app.go.
+const SIGN_REQUIRED_MESSAGE_TYPES = ['/vm.m_run', '/vm.m_addpkg'];
+
+function requiresRealSignature(document: Document): boolean {
+  return (document.msgs ?? []).some((msg) => SIGN_REQUIRED_MESSAGE_TYPES.includes(msg.type));
+}
+
 /**
  * Builds a placeholder/signed Tx used only for simulation. The fee amount does
  * not affect the simulated `gas_used` (gasWanted is always DEFAULT_GAS_WANTED),
  * so callers can pass any `gasUsed`/`gasPrice` that yields a valid document.
+ *
+ * `withSignTransaction` forces signing for accounts the node cannot validate
+ * from a pubkey alone; a document carrying a code-bearing message forces it
+ * too, regardless of that flag.
  */
 export const makeEstimateGasTransaction = async (
   wallet: Wallet | null,
@@ -114,7 +130,7 @@ export const makeEstimateGasTransaction = async (
   // master caller. Without this, simulate would reject the placeholder for
   // pubkey-address mismatch (master caller + session pubkey).
   const sessionAddr = isSessionAccount(account) ? await account.getAddress('g') : undefined;
-  if (!withSignTransaction) {
+  if (!withSignTransaction && !requiresRealSignature(modifiedDocument)) {
     return documentToDefaultTx(modifiedDocument, account.publicKey, sessionAddr);
   }
 

--- a/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
+++ b/packages/adena-extension/src/pages/popup/wallet/transfer-summary/index.tsx
@@ -1,3 +1,4 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   CosmosDocument,
   Document,
@@ -5,7 +6,6 @@ import {
   isLedgerAccount,
   isSessionAccount,
 } from 'adena-module';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -63,8 +63,13 @@ const TransferSummaryContainer: React.FC = () => {
   const { navigate, goBack, params } = useAppNavigate<RoutePath.TransferSummary>();
   const summaryInfo = params;
   const { wallet, gnoProvider } = useWalletContext();
-  const { transactionService, chainRegistry, tokenRegistry, cosmosProvider, sessionRepository } =
-    useAdenaContext();
+  const {
+    transactionService,
+    chainRegistry,
+    tokenRegistry,
+    cosmosProvider,
+    sessionRepository,
+  } = useAdenaContext();
   const queryClient = useQueryClient();
   const { currentAccount, currentAddress, currentFundingAddress } = useCurrentAccount();
   const { currentNetwork } = useNetwork();
@@ -351,9 +356,9 @@ const TransferSummaryContainer: React.FC = () => {
     }
 
     // Fallback (no helper configured yet): run an ephemeral package that
-    // resolves the token through grc20reg and transfers from the caller. The
-    // node requires the package name to be "main" and auto-assigns the reserved
-    // run path when Package.Path is left empty.
+    // transfers the token through the registry's own write wrapper. The node
+    // requires the package name to be "main" and auto-assigns the reserved run
+    // path when Package.Path is left empty.
     const runBody = [
       'package main',
       '',
@@ -362,9 +367,9 @@ const TransferSummaryContainer: React.FC = () => {
       ')',
       '',
       'func main(cur realm) {',
-      `\tgrc20reg.MustGet(${gnoLiteral(
-        registryKey,
-      )}).CallerTeller().Transfer(0, cur, ${gnoLiteral(toAddress)}, ${amount})`,
+      `\tgrc20reg.Transfer(0, cur, ${gnoLiteral(registryKey)}, address(${gnoLiteral(
+        toAddress,
+      )}), ${amount})`,
       '}',
       '',
     ].join('\n');
@@ -563,13 +568,7 @@ const TransferSummaryContainer: React.FC = () => {
         break;
       }
     }
-  }, [
-    currentAccount,
-    currentNetwork,
-    gnoProvider,
-    queryClient,
-    sessionRepository,
-  ]);
+  }, [currentAccount, currentNetwork, gnoProvider, queryClient, sessionRepository]);
 
   const transfer = async (): Promise<boolean> => {
     if (isSent || !currentAccount) {

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.spec.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.spec.ts
@@ -61,6 +61,50 @@ describe('mapTransactionEdgeByAddress: MsgRun GRC20 transfer', () => {
     });
   });
 
+  it('picks the transfer the viewer took part in when several are emitted', () => {
+    const OTHER = 'g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh';
+    const OTHER_TOKEN = 'gno.land/r/demo/defi/foo20.FOO';
+    const multiTx = makeMsgRunTransaction([
+      makeTransferEvent([
+        { key: 'token', value: `${OTHER_TOKEN}.0` },
+        { key: 'from', value: SENDER },
+        { key: 'to', value: OTHER },
+        { key: 'value', value: '7' },
+      ]),
+      makeTransferEvent([
+        { key: 'token', value: `${TOKEN_PATH}.0` },
+        { key: 'from', value: OTHER },
+        { key: 'to', value: RECIPIENT },
+        { key: 'value', value: '1000' },
+      ]),
+    ]);
+
+    expect(mapTransactionEdgeByAddress(multiTx, RECIPIENT)).toMatchObject({
+      title: 'Receive',
+      originFrom: OTHER,
+      originTo: RECIPIENT,
+      amount: { value: '1000', denom: TOKEN_PATH },
+    });
+  });
+
+  // The initiating side wins, as it does for bank.MsgSend and MsgCall.
+  it('renders a self-transfer as a send', () => {
+    const selfTx = makeMsgRunTransaction([
+      makeTransferEvent([
+        { key: 'token', value: `${TOKEN_PATH}.0` },
+        { key: 'from', value: SENDER },
+        { key: 'to', value: SENDER },
+        { key: 'value', value: '1000' },
+      ]),
+    ]);
+
+    expect(mapTransactionEdgeByAddress(selfTx, SENDER)).toMatchObject({
+      title: 'Send',
+      typeName: 'Send',
+      valueType: 'DEFAULT',
+    });
+  });
+
   // GRC721 emits Transfer with `tokenId` instead of `value`.
   it('leaves a GRC721 transfer as a contract interaction', () => {
     const nftTx = makeMsgRunTransaction([

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.spec.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.spec.ts
@@ -8,6 +8,18 @@ function makeTransferEvent(attrs: { key: string; value: string }[]): unknown {
   return { type: 'Transfer', pkg_path: 'gno.land/p/demo/tokens/grc20', attrs };
 }
 
+function makeMsgCallTransferTransaction(events: unknown[]): any {
+  return {
+    ...makeMsgRunTransaction(events),
+    messages: [
+      {
+        typeUrl: 'exec',
+        value: { caller: SENDER, pkg_path: 'gno.land/r/gnoland/wugnot', func: 'Transfer' },
+      },
+    ],
+  };
+}
+
 // A GRC20 transfer routed through grc20reg: MsgRun carries no func/args, so the
 // Transfer event is the only description of what moved.
 function makeMsgRunTransaction(events: unknown[]): any {
@@ -102,6 +114,31 @@ describe('mapTransactionEdgeByAddress: MsgRun GRC20 transfer', () => {
       title: 'Send',
       typeName: 'Send',
       valueType: 'DEFAULT',
+    });
+  });
+
+  it('picks the viewer transfer on the exec receive path too', () => {
+    const OTHER = 'g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh';
+    const execTx = makeMsgCallTransferTransaction([
+      makeTransferEvent([
+        { key: 'token', value: 'gno.land/r/demo/defi/foo20.FOO.0' },
+        { key: 'from', value: SENDER },
+        { key: 'to', value: OTHER },
+        { key: 'value', value: '7' },
+      ]),
+      makeTransferEvent([
+        { key: 'token', value: `${TOKEN_PATH}.0` },
+        { key: 'from', value: SENDER },
+        { key: 'to', value: RECIPIENT },
+        { key: 'value', value: '1000' },
+      ]),
+    ]);
+
+    expect(mapTransactionEdgeByAddress(execTx, RECIPIENT)).toMatchObject({
+      title: 'Receive',
+      originFrom: SENDER,
+      originTo: RECIPIENT,
+      amount: { value: '1000', denom: TOKEN_PATH },
     });
   });
 

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.spec.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.spec.ts
@@ -1,0 +1,80 @@
+import { mapTransactionEdgeByAddress } from './transaction-history-query.mapper';
+
+const SENDER = 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5';
+const RECIPIENT = 'g1kcdd3n0d472g2p5l8svyg9t0wq6h5857nq992f';
+const TOKEN_PATH = 'gno.land/r/gnoland/wugnot.wugnot';
+
+function makeTransferEvent(attrs: { key: string; value: string }[]): unknown {
+  return { type: 'Transfer', pkg_path: 'gno.land/p/demo/tokens/grc20', attrs };
+}
+
+// A GRC20 transfer routed through grc20reg: MsgRun carries no func/args, so the
+// Transfer event is the only description of what moved.
+function makeMsgRunTransaction(events: unknown[]): any {
+  return {
+    hash: 'hash',
+    index: 0,
+    success: true,
+    block_height: 1,
+    gas_wanted: 1,
+    gas_used: 1,
+    gas_fee: { amount: 1000, denom: 'ugnot' },
+    messages: [{ typeUrl: 'run', value: { caller: SENDER } }],
+    response: { events },
+  };
+}
+
+describe('mapTransactionEdgeByAddress: MsgRun GRC20 transfer', () => {
+  const tx = makeMsgRunTransaction([
+    makeTransferEvent([
+      { key: 'token', value: `${TOKEN_PATH}.0` },
+      { key: 'from', value: SENDER },
+      { key: 'to', value: RECIPIENT },
+      { key: 'value', value: '1000' },
+    ]),
+  ]);
+
+  it('renders as a send for the sender', () => {
+    const mapped = mapTransactionEdgeByAddress(tx, SENDER);
+
+    expect(mapped).toMatchObject({
+      type: 'TRANSFER',
+      title: 'Send',
+      typeName: 'Send',
+      valueType: 'DEFAULT',
+      originFrom: SENDER,
+      originTo: RECIPIENT,
+      amount: { value: '1000', denom: TOKEN_PATH },
+    });
+  });
+
+  it('renders as a receive for the recipient', () => {
+    const mapped = mapTransactionEdgeByAddress(tx, RECIPIENT);
+
+    expect(mapped).toMatchObject({
+      type: 'TRANSFER',
+      title: 'Receive',
+      typeName: 'Receive',
+      valueType: 'ACTIVE',
+      originFrom: SENDER,
+      originTo: RECIPIENT,
+    });
+  });
+
+  // GRC721 emits Transfer with `tokenId` instead of `value`.
+  it('leaves a GRC721 transfer as a contract interaction', () => {
+    const nftTx = makeMsgRunTransaction([
+      makeTransferEvent([
+        { key: 'token', value: 'gno.land/r/demo/nft.NFT.0' },
+        { key: 'from', value: SENDER },
+        { key: 'to', value: RECIPIENT },
+        { key: 'tokenId', value: '1' },
+      ]),
+    ]);
+
+    expect(mapTransactionEdgeByAddress(nftTx, RECIPIENT)).toMatchObject({
+      type: 'CONTRACT_CALL',
+      title: 'Message Run',
+    });
+  });
+});

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
@@ -113,7 +113,7 @@ export function mapTransactionEdgeByAddress(
   helperPath?: string,
 ): TransactionInfo {
   if (!transaction?.messages?.length || transaction?.messages?.length > 1) {
-    return mapVMTransaction(transaction, helperPath);
+    return mapVMTransaction(transaction, helperPath, undefined, address);
   }
 
   const message = transaction.messages[0];
@@ -133,9 +133,9 @@ export function mapTransactionEdgeByAddress(
       ) {
         return mapReceivedTransactionByMsgCall(transaction, helperPath);
       }
-      return mapVMTransaction(transaction, helperPath);
+      return mapVMTransaction(transaction, helperPath, undefined, address);
     default:
-      return mapVMTransaction(transaction, helperPath);
+      return mapVMTransaction(transaction, helperPath, undefined, address);
   }
 }
 
@@ -274,6 +274,7 @@ export function mapVMTransaction(
   tx: TransactionResponse<AddPackageValue | MsgRunValue | MsgCallValue>,
   helperPath?: string,
   tokenKey?: string,
+  viewerAddress?: string,
 ): TransactionInfo {
   const firstMessage = getDefaultMessage(tx.messages);
 
@@ -428,6 +429,10 @@ export function mapVMTransaction(
   const runTransfer = getGRC20TransferFromEvent(tx, tokenKey);
   if (runTransfer?.tokenPath) {
     const fromAddress = runTransfer.from || (firstMessage.value as MsgRunValue).caller || '';
+    // The event names both parties, so the direction is only known once the
+    // viewer is: the same transaction is a send for one side and a receive for
+    // the other.
+    const isReceive = !!viewerAddress && runTransfer.to === viewerAddress;
 
     return {
       hash: tx.hash,
@@ -435,14 +440,16 @@ export function mapVMTransaction(
       logo: runTransfer.tokenPath,
       type: 'TRANSFER',
       status: tx.success ? 'SUCCESS' : 'FAIL',
-      typeName: 'Send',
-      title: 'Send',
-      description: `To: ${formatAddress(runTransfer.to)}`,
+      typeName: isReceive ? 'Receive' : 'Send',
+      title: isReceive ? 'Receive' : 'Send',
+      description: isReceive
+        ? `From: ${formatAddress(fromAddress)}`
+        : `To: ${formatAddress(runTransfer.to)}`,
       amount: {
         value: runTransfer.value || '0',
         denom: runTransfer.tokenPath,
       },
-      valueType: mapValueType(tx.success),
+      valueType: mapValueType(tx.success, isReceive),
       date: '',
       from: formatAddress(fromAddress),
       originFrom: fromAddress,

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
@@ -63,19 +63,34 @@ function resolveTransferShape(
 // `Transfer` event carrying `token` (Token.ID() = `{packagePath}.{symbol}.{sequence}`),
 // `from`, `to`, and `value`. Reading the token identity and amount from the
 // event is invocation-independent, so prefer it over parsing message args.
+//
+// GRC721 emits a `Transfer` carrying `token` too, but describes the item with
+// `tokenId` instead of `value`, so `value` is what separates the two. When
+// `tokenKey` is given, pick that token's event: one transaction can emit
+// several (e.g. a swap) and the first is not necessarily the requested one.
 function getGRC20TransferFromEvent(
   tx: TransactionResponse<any>,
+  tokenKey?: string,
 ): { tokenPath: string | null; from: string; to: string; value: string } | null {
   const events: Event[] = tx?.response?.events || [];
-  const transferEvent = events.find(
-    (event) => event?.type === 'Transfer' && (event?.attrs || []).some((a) => a.key === 'token'),
-  );
+  const attrOf = (event: Event, key: string): string =>
+    (event.attrs || []).find((a) => a.key === key)?.value || '';
+
+  const transferEvent = events.find((event) => {
+    if (event?.type !== 'Transfer') {
+      return false;
+    }
+    const token = attrOf(event, 'token');
+    if (!token || !(event.attrs || []).some((a) => a.key === 'value')) {
+      return false;
+    }
+    return !tokenKey || token.startsWith(`${tokenKey}.`);
+  });
   if (!transferEvent) {
     return null;
   }
 
-  const attr = (key: string): string =>
-    (transferEvent.attrs || []).find((a) => a.key === key)?.value || '';
+  const attr = (key: string): string => attrOf(transferEvent, key);
 
   const tokenId = attr('token');
   if (!tokenId) {
@@ -158,6 +173,7 @@ export function mapSendTransactionByBankMsgSend(
 export function mapReceivedTransactionByMsgCall(
   tx: TransactionResponse<MsgCallValue>,
   helperPath?: string,
+  tokenKey?: string,
 ): TransactionInfo {
   const firstMessage = getDefaultMessage(tx.messages);
   if (firstMessage.value.func === 'TransferFrom' && tx.messages.length === 1) {
@@ -190,7 +206,7 @@ export function mapReceivedTransactionByMsgCall(
 
   // Prefer the GRC20 Transfer event (token/from/to/value); fall back to parsing
   // message args (with the helper arg offset) when it is absent.
-  const eventInfo = getGRC20TransferFromEvent(tx);
+  const eventInfo = getGRC20TransferFromEvent(tx, tokenKey);
   const { tokenPath, argOffset } = resolveTransferShape(firstMessage.value, helperPath);
   const senderAddress = eventInfo?.from || firstMessage.value.caller || '';
   const receiveAmount = eventInfo?.value || firstMessage.value.args?.[argOffset + 1] || '0';
@@ -257,6 +273,7 @@ export function mapReceivedTransactionByBankMsgSend(
 export function mapVMTransaction(
   tx: TransactionResponse<AddPackageValue | MsgRunValue | MsgCallValue>,
   helperPath?: string,
+  tokenKey?: string,
 ): TransactionInfo {
   const firstMessage = getDefaultMessage(tx.messages);
 
@@ -320,7 +337,7 @@ export function mapVMTransaction(
     if (isTransfer) {
       // Prefer the GRC20 Transfer event (token/from/to/value); fall back to
       // parsing message args (with the helper arg offset) when it is absent.
-      const eventInfo = getGRC20TransferFromEvent(tx);
+      const eventInfo = getGRC20TransferFromEvent(tx, tokenKey);
       const { tokenPath, argOffset } = resolveTransferShape(messageValue, helperPath);
       const fromAddress = eventInfo?.from || messageValue.caller || '';
       const toAddress = eventInfo?.to || messageValue.args?.[argOffset] || '';
@@ -408,7 +425,7 @@ export function mapVMTransaction(
   // `Transfer(0, cur, tokenKey, to, amount)` wrapper (the path taken when the
   // chain has no GRC20 helper realm) carries no func/args, so the emitted
   // Transfer event is the only description of what moved.
-  const runTransfer = getGRC20TransferFromEvent(tx);
+  const runTransfer = getGRC20TransferFromEvent(tx, tokenKey);
   if (runTransfer?.tokenPath) {
     const fromAddress = runTransfer.from || (firstMessage.value as MsgRunValue).caller || '';
 

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
@@ -65,27 +65,49 @@ function resolveTransferShape(
 // event is invocation-independent, so prefer it over parsing message args.
 //
 // GRC721 emits a `Transfer` carrying `token` too, but describes the item with
-// `tokenId` instead of `value`, so `value` is what separates the two. When
-// `tokenKey` is given, pick that token's event: one transaction can emit
-// several (e.g. a swap) and the first is not necessarily the requested one.
+// `tokenId` instead of `value`, so `value` is what separates the two.
+//
+// One transaction can emit several transfers (e.g. a swap), so the first is not
+// necessarily the interesting one: `tokenKey` picks the token whose history is
+// being read, and `viewerAddress` picks the transfer the account took part in.
+function attrOf(event: Event, key: string): string {
+  return (event.attrs || []).find((a) => a.key === key)?.value || '';
+}
+
+function isGRC20TransferEvent(event: Event): boolean {
+  return (
+    event?.type === 'Transfer' &&
+    !!attrOf(event, 'token') &&
+    (event.attrs || []).some((a) => a.key === 'value')
+  );
+}
+
+/** True when the transaction moves a GRC20 token to `address`. */
+export function hasGRC20TransferTo(tx: TransactionResponse<any>, address: string): boolean {
+  const events: Event[] = tx?.response?.events || [];
+  return events.some((event) => isGRC20TransferEvent(event) && attrOf(event, 'to') === address);
+}
+
 function getGRC20TransferFromEvent(
   tx: TransactionResponse<any>,
-  tokenKey?: string,
+  options?: { tokenKey?: string; viewerAddress?: string },
 ): { tokenPath: string | null; from: string; to: string; value: string } | null {
   const events: Event[] = tx?.response?.events || [];
-  const attrOf = (event: Event, key: string): string =>
-    (event.attrs || []).find((a) => a.key === key)?.value || '';
+  const grc20Events = events.filter(isGRC20TransferEvent);
 
-  const transferEvent = events.find((event) => {
-    if (event?.type !== 'Transfer') {
-      return false;
-    }
-    const token = attrOf(event, 'token');
-    if (!token || !(event.attrs || []).some((a) => a.key === 'value')) {
-      return false;
-    }
-    return !tokenKey || token.startsWith(`${tokenKey}.`);
-  });
+  const tokenKey = options?.tokenKey;
+  const viewerAddress = options?.viewerAddress;
+  const transferEvent =
+    (tokenKey
+      ? grc20Events.find((event) => attrOf(event, 'token').startsWith(`${tokenKey}.`))
+      : undefined) ??
+    (viewerAddress
+      ? grc20Events.find(
+          (event) =>
+            attrOf(event, 'from') === viewerAddress || attrOf(event, 'to') === viewerAddress,
+        )
+      : undefined) ??
+    (!tokenKey ? grc20Events[0] : undefined);
   if (!transferEvent) {
     return null;
   }
@@ -206,7 +228,7 @@ export function mapReceivedTransactionByMsgCall(
 
   // Prefer the GRC20 Transfer event (token/from/to/value); fall back to parsing
   // message args (with the helper arg offset) when it is absent.
-  const eventInfo = getGRC20TransferFromEvent(tx, tokenKey);
+  const eventInfo = getGRC20TransferFromEvent(tx, { tokenKey });
   const { tokenPath, argOffset } = resolveTransferShape(firstMessage.value, helperPath);
   const senderAddress = eventInfo?.from || firstMessage.value.caller || '';
   const receiveAmount = eventInfo?.value || firstMessage.value.args?.[argOffset + 1] || '0';
@@ -338,7 +360,7 @@ export function mapVMTransaction(
     if (isTransfer) {
       // Prefer the GRC20 Transfer event (token/from/to/value); fall back to
       // parsing message args (with the helper arg offset) when it is absent.
-      const eventInfo = getGRC20TransferFromEvent(tx, tokenKey);
+      const eventInfo = getGRC20TransferFromEvent(tx, { tokenKey, viewerAddress });
       const { tokenPath, argOffset } = resolveTransferShape(messageValue, helperPath);
       const fromAddress = eventInfo?.from || messageValue.caller || '';
       const toAddress = eventInfo?.to || messageValue.args?.[argOffset] || '';
@@ -426,13 +448,14 @@ export function mapVMTransaction(
   // `Transfer(0, cur, tokenKey, to, amount)` wrapper (the path taken when the
   // chain has no GRC20 helper realm) carries no func/args, so the emitted
   // Transfer event is the only description of what moved.
-  const runTransfer = getGRC20TransferFromEvent(tx, tokenKey);
+  const runTransfer = getGRC20TransferFromEvent(tx, { tokenKey, viewerAddress });
   if (runTransfer?.tokenPath) {
     const fromAddress = runTransfer.from || (firstMessage.value as MsgRunValue).caller || '';
     // The event names both parties, so the direction is only known once the
     // viewer is: the same transaction is a send for one side and a receive for
     // the other.
-    const isReceive = !!viewerAddress && runTransfer.to === viewerAddress;
+    const isReceive =
+      !!viewerAddress && runTransfer.to === viewerAddress && runTransfer.from !== viewerAddress;
 
     return {
       hash: tx.hash,

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
@@ -153,7 +153,7 @@ export function mapTransactionEdgeByAddress(
         ['Transfer', 'TransferFrom'].includes(message.value.func) &&
         message.value.caller !== address
       ) {
-        return mapReceivedTransactionByMsgCall(transaction, helperPath);
+        return mapReceivedTransactionByMsgCall(transaction, helperPath, undefined, address);
       }
       return mapVMTransaction(transaction, helperPath, undefined, address);
     default:
@@ -196,6 +196,7 @@ export function mapReceivedTransactionByMsgCall(
   tx: TransactionResponse<MsgCallValue>,
   helperPath?: string,
   tokenKey?: string,
+  viewerAddress?: string,
 ): TransactionInfo {
   const firstMessage = getDefaultMessage(tx.messages);
   if (firstMessage.value.func === 'TransferFrom' && tx.messages.length === 1) {
@@ -228,7 +229,7 @@ export function mapReceivedTransactionByMsgCall(
 
   // Prefer the GRC20 Transfer event (token/from/to/value); fall back to parsing
   // message args (with the helper arg offset) when it is absent.
-  const eventInfo = getGRC20TransferFromEvent(tx, { tokenKey });
+  const eventInfo = getGRC20TransferFromEvent(tx, { tokenKey, viewerAddress });
   const { tokenPath, argOffset } = resolveTransferShape(firstMessage.value, helperPath);
   const senderAddress = eventInfo?.from || firstMessage.value.caller || '';
   const receiveAmount = eventInfo?.value || firstMessage.value.args?.[argOffset + 1] || '0';

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
@@ -404,6 +404,40 @@ export function mapVMTransaction(
     };
   }
 
+  // MsgRun: a GRC20 transfer routed through the registry's non-crossing
+  // `Transfer(0, cur, tokenKey, to, amount)` wrapper (the path taken when the
+  // chain has no GRC20 helper realm) carries no func/args, so the emitted
+  // Transfer event is the only description of what moved.
+  const runTransfer = getGRC20TransferFromEvent(tx);
+  if (runTransfer?.tokenPath) {
+    const fromAddress = runTransfer.from || (firstMessage.value as MsgRunValue).caller || '';
+
+    return {
+      hash: tx.hash,
+      height: tx.block_height,
+      logo: runTransfer.tokenPath,
+      type: 'TRANSFER',
+      status: tx.success ? 'SUCCESS' : 'FAIL',
+      typeName: 'Send',
+      title: 'Send',
+      description: `To: ${formatAddress(runTransfer.to)}`,
+      amount: {
+        value: runTransfer.value || '0',
+        denom: runTransfer.tokenPath,
+      },
+      valueType: mapValueType(tx.success),
+      date: '',
+      from: formatAddress(fromAddress),
+      originFrom: fromAddress,
+      to: formatAddress(runTransfer.to),
+      originTo: runTransfer.to,
+      networkFee: {
+        value: `${tx.gas_fee.amount || '0'}`,
+        denom: `${tx.gas_fee.denom}`,
+      },
+    };
+  }
+
   return {
     hash: tx.hash,
     height: tx.block_height,

--- a/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.queries.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.queries.ts
@@ -135,6 +135,36 @@ query getAllTransactionHistory {
 }
 `;
 
+/**
+ * GRC20 transfers received through a MsgRun, which the message-shape filter in
+ * `makeAllTransactionHistoryQuery` cannot see: the run body is not indexed, so
+ * only the sender is matched there (by `MsgRun.caller`). Merged into the
+ * all-transactions result by the repository.
+ */
+export const makeGRC20ReceivedTransactionHistoryQuery = (address: string): string => `
+query getGRC20ReceivedTransactionHistory {
+  getTransactions(
+    where: {
+      success: { eq: true }
+      response: {
+        events: {
+          GnoEvent: {
+            type: { eq: "Transfer" }
+            attrs: {
+              key: { eq: "to" }
+              value: { eq: "${address}" }
+            }
+          }
+        }
+      }
+    }
+    order: { heightAndIndex: DESC }
+  ) {
+    ${TRANSACTION_FIELDS}
+  }
+}
+`;
+
 /** Native (BankMsgSend) sends and receives for an address. */
 export const makeNativeTransactionHistoryQuery = (address: string): string => `
 query getNativeTransactionHistory {

--- a/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.queries.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.queries.ts
@@ -160,72 +160,57 @@ query getNativeTransactionHistory {
 `;
 
 /**
- * GRC20 transfers (sent or received) for an address, scoped to a single
- * token package. `caller eq address` catches sends; `args eq address`
- * catches the recipient slot of `Transfer(to, amount)`.
+ * GRC20 transfers (sent or received) for an address, scoped to a single token.
+ *
+ * Matched on the emitted `Transfer` event rather than on the message shape.
+ * Since `grc20reg`'s write wrappers became non-crossing (`Transfer(_ int, rlm
+ * realm, tokenKey, to, amount)`), MsgCall can no longer reach them, so a chain
+ * without a GRC20 helper realm transfers through a MsgRun whose body the indexer
+ * cannot filter on. The event is the one shape every invocation shares — direct
+ * `Transfer(to, amount)`, helper `Transfer(tokenKey, to, amount)` and MsgRun all
+ * emit it — carrying `token`, `from`, `to` and `value`.
+ *
+ * `tokenKey` is the token key `{packagePath}.{symbol}`, while the event's
+ * `token` attr is `Token.ID()` = `{packagePath}.{symbol}.{sequence}`. The
+ * trailing sequence is not part of the wallet's token identity, so the token is
+ * matched by the `{tokenKey}.` prefix instead of an exact value.
  */
-export const makeGRC20TransactionHistoryQuery = (
-  address: string,
-  packagePath: string,
-  options?: { helperPath?: string; tokenKey?: string },
-): string => {
-  const partyFilter = `_or: [
-              { caller: { eq: "${address}" } }
-              { args: { eq: "${address}" } }
-            ]`;
-
-  // Direct token transfer: pkg_path is the token realm, func Transfer.
-  const directBranch = `{
-          value: {
-            MsgCall: {
-              pkg_path: { eq: "${packagePath}" }
-              func: { eq: "Transfer" }
-              ${partyFilter}
-            }
-          }
-        }`;
-
-  // Helper-routed transfer: helperPath.Transfer(tokenKey, to, amount). Match by
-  // the helper realm and the token key carried in args[0].
-  const helperPath = options?.helperPath;
-  const tokenKey = options?.tokenKey;
-  const helperBranch =
-    helperPath && tokenKey
-      ? `{
-          value: {
-            MsgCall: {
-              pkg_path: { eq: "${helperPath}" }
-              func: { eq: "Transfer" }
-              args: { eq: "${tokenKey}" }
-              ${partyFilter}
-            }
-          }
-        }`
-      : null;
-
-  const messagesFilter = helperBranch
-    ? `messages: {
-        _or: [
-          ${directBranch}
-          ${helperBranch}
-        ]
-      }`
-    : `messages: {
-        value: {
-          MsgCall: {
-            pkg_path: { eq: "${packagePath}" }
-            func: { eq: "Transfer" }
-            ${partyFilter}
-          }
-        }
-      }`;
+export const makeGRC20TransactionHistoryQuery = (address: string, tokenKey: string): string => {
+  // `attrs` is an OR list, so the token and the party constraint each need to be
+  // their own `_and` entry rather than sibling attrs of one filter.
+  const partyBranch = (partyKey: 'from' | 'to'): string => `{
+              GnoEvent: {
+                type: { eq: "Transfer" }
+                _and: [
+                  {
+                    attrs: {
+                      key: { eq: "token" }
+                      value: { like: "${tokenKey}." }
+                    }
+                  }
+                  {
+                    attrs: {
+                      key: { eq: "${partyKey}" }
+                      value: { eq: "${address}" }
+                    }
+                  }
+                ]
+              }
+            }`;
 
   return `
 query getGRC20TransactionHistory {
   getTransactions(
     where: {
       success: { eq: true }
-      ${messagesFilter}
+      response: {
+        events: {
+          _or: [
+            ${partyBranch('from')}
+            ${partyBranch('to')}
+          ]
+        }
+      }
     }
     order: { heightAndIndex: DESC }
   ) {

--- a/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.ts
@@ -67,9 +67,12 @@ export class TransactionHistoryIndexerRepository implements ITransactionHistoryI
       return EMPTY_PAGE;
     }
 
-    const result = await TransactionHistoryIndexerRepository.postGraphQuery<
-      TransactionsQueryResult
-    >(this.axiosInstance, this.queryUrl, makeAllTransactionHistoryQuery(address));
+    const result =
+      await TransactionHistoryIndexerRepository.postGraphQuery<TransactionsQueryResult>(
+        this.axiosInstance,
+        this.queryUrl,
+        makeAllTransactionHistoryQuery(address),
+      );
 
     const transactions = (result?.data?.getTransactions ?? []).map((tx) =>
       mapTransactionEdgeByAddress(tx, address, this.grc20HelperPath),
@@ -86,9 +89,12 @@ export class TransactionHistoryIndexerRepository implements ITransactionHistoryI
       return EMPTY_PAGE;
     }
 
-    const result = await TransactionHistoryIndexerRepository.postGraphQuery<
-      TransactionsQueryResult
-    >(this.axiosInstance, this.queryUrl, makeNativeTransactionHistoryQuery(address));
+    const result =
+      await TransactionHistoryIndexerRepository.postGraphQuery<TransactionsQueryResult>(
+        this.axiosInstance,
+        this.queryUrl,
+        makeNativeTransactionHistoryQuery(address),
+      );
 
     const transactions = (result?.data?.getTransactions ?? []).map((tx) => {
       const bankTx = tx as TransactionResponse<BankSendValue>;
@@ -113,20 +119,17 @@ export class TransactionHistoryIndexerRepository implements ITransactionHistoryI
       return EMPTY_PAGE;
     }
 
-    // `tokenPath` is the token key `{packagePath}.{symbol}`. Derive the realm
-    // path for direct transfers and the registry key (== token key) for
-    // helper-routed transfers (matched against the helper's Transfer args[0]).
+    // `tokenPath` is the token key `{packagePath}.{symbol}`, which is what the
+    // Transfer event identifies the token by (minus its trailing sequence).
     const packagePath = packagePathOfTokenPath(tokenPath);
-    const tokenKey = toRegistryKey(tokenPath) ?? undefined;
-    const helperPath = this.grc20HelperPath;
+    const tokenKey = toRegistryKey(tokenPath) ?? tokenPath;
 
-    const result = await TransactionHistoryIndexerRepository.postGraphQuery<
-      TransactionsQueryResult
-    >(
-      this.axiosInstance,
-      this.queryUrl,
-      makeGRC20TransactionHistoryQuery(address, packagePath, { helperPath, tokenKey }),
-    );
+    const result =
+      await TransactionHistoryIndexerRepository.postGraphQuery<TransactionsQueryResult>(
+        this.axiosInstance,
+        this.queryUrl,
+        makeGRC20TransactionHistoryQuery(address, tokenKey),
+      );
 
     const mapped = (result?.data?.getTransactions ?? []).map((tx) => {
       const callTx = tx as TransactionResponse<MsgCallValue>;
@@ -137,11 +140,11 @@ export class TransactionHistoryIndexerRepository implements ITransactionHistoryI
         : mapReceivedTransactionByMsgCall(callTx, this.grc20HelperPath);
     });
 
-    // The direct branch fetches every Transfer on the realm (pkg_path ==
-    // packagePath), so a realm with multiple symbols leaks sibling tokens (e.g.
-    // BAR transfers into FOO's history). Scope to the selected token: keep rows
-    // whose mapped denom is the token path (event-decoded) or, when no event was
-    // available, the realm path (fallback can't disambiguate symbols).
+    // A transaction can carry several Transfer events (e.g. a swap); the mapper
+    // decodes the first one, which is not necessarily this token's. Keep only
+    // the rows that ended up describing the selected token — or, when no event
+    // could be decoded, the realm path (the fallback can't disambiguate
+    // sibling symbols).
     const transactions = mapped.filter(
       (tx) => tx.amount?.denom === tokenPath || tx.amount?.denom === packagePath,
     );

--- a/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.ts
@@ -3,6 +3,7 @@ import { getGrc20RegConfig } from '@common/utils/grc20reg-config';
 import { NetworkMetainfo, TransactionWithPageInfo } from '@types';
 import { AxiosInstance } from 'axios';
 import {
+  hasGRC20TransferTo,
   mapReceivedTransactionByBankMsgSend,
   mapReceivedTransactionByMsgCall,
   mapSendTransactionByBankMsgSend,
@@ -97,10 +98,16 @@ export class TransactionHistoryIndexerRepository implements ITransactionHistoryI
       ),
     ]);
 
-    const transactions = mergeTransactionsByHash(
-      result?.data?.getTransactions ?? [],
-      receivedResult?.data?.getTransactions ?? [],
-    ).map((tx) => mapTransactionEdgeByAddress(tx, address, this.grc20HelperPath));
+    // The received query matches any `Transfer` event, and GRC721 emits one too
+    // (with `tokenId` in place of `value`), so keep only the GRC20 receives it
+    // was meant to add.
+    const received = (receivedResult?.data?.getTransactions ?? []).filter((tx) =>
+      hasGRC20TransferTo(tx, address),
+    );
+
+    const transactions = mergeTransactionsByHash(result?.data?.getTransactions ?? [], received).map(
+      (tx) => mapTransactionEdgeByAddress(tx, address, this.grc20HelperPath),
+    );
 
     return {
       page: { hasNext: false, cursor: null },

--- a/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history-indexer.ts
@@ -18,6 +18,7 @@ import {
   makeAllTransactionHistoryQuery,
   makeBlockTimeLegacyQuery,
   makeBlockTimeQuery,
+  makeGRC20ReceivedTransactionHistoryQuery,
   makeGRC20TransactionHistoryQuery,
   makeNativeTransactionHistoryQuery,
 } from './transaction-history-indexer.queries';
@@ -33,6 +34,20 @@ const EMPTY_PAGE: TransactionWithPageInfo = {
   page: { hasNext: false, cursor: null },
   transactions: [],
 };
+
+// Two queries can return the same transaction; keep one row per hash and
+// restore the indexer's newest-first order.
+function mergeTransactionsByHash(...groups: TransactionResponse[][]): TransactionResponse[] {
+  const byHash = new Map<string, TransactionResponse>();
+  for (const group of groups) {
+    for (const tx of group) {
+      if (!byHash.has(tx.hash)) {
+        byHash.set(tx.hash, tx);
+      }
+    }
+  }
+  return [...byHash.values()].sort((a, b) => b.block_height - a.block_height || b.index - a.index);
+}
 
 export class TransactionHistoryIndexerRepository implements ITransactionHistoryIndexerRepository {
   private axiosInstance: AxiosInstance;
@@ -67,16 +82,25 @@ export class TransactionHistoryIndexerRepository implements ITransactionHistoryI
       return EMPTY_PAGE;
     }
 
-    const result =
-      await TransactionHistoryIndexerRepository.postGraphQuery<TransactionsQueryResult>(
+    // Second query: a MsgRun-routed transfer only names its sender in the
+    // message, so the recipient is reachable through the Transfer event alone.
+    const [result, receivedResult] = await Promise.all([
+      TransactionHistoryIndexerRepository.postGraphQuery<TransactionsQueryResult>(
         this.axiosInstance,
         this.queryUrl,
         makeAllTransactionHistoryQuery(address),
-      );
+      ),
+      TransactionHistoryIndexerRepository.postGraphQuery<TransactionsQueryResult>(
+        this.axiosInstance,
+        this.queryUrl,
+        makeGRC20ReceivedTransactionHistoryQuery(address),
+      ),
+    ]);
 
-    const transactions = (result?.data?.getTransactions ?? []).map((tx) =>
-      mapTransactionEdgeByAddress(tx, address, this.grc20HelperPath),
-    );
+    const transactions = mergeTransactionsByHash(
+      result?.data?.getTransactions ?? [],
+      receivedResult?.data?.getTransactions ?? [],
+    ).map((tx) => mapTransactionEdgeByAddress(tx, address, this.grc20HelperPath));
 
     return {
       page: { hasNext: false, cursor: null },
@@ -136,8 +160,8 @@ export class TransactionHistoryIndexerRepository implements ITransactionHistoryI
       const firstMessage = callTx.messages?.[0];
       const isCallerSelf = firstMessage?.value?.caller === address;
       return isCallerSelf
-        ? mapVMTransaction(callTx, this.grc20HelperPath)
-        : mapReceivedTransactionByMsgCall(callTx, this.grc20HelperPath);
+        ? mapVMTransaction(callTx, this.grc20HelperPath, tokenKey)
+        : mapReceivedTransactionByMsgCall(callTx, this.grc20HelperPath, tokenKey);
     });
 
     // A transaction can carry several Transfer events (e.g. a swap); the mapper

--- a/packages/adena-extension/src/resources/chains/grc20reg.json
+++ b/packages/adena-extension/src/resources/chains/grc20reg.json
@@ -1,7 +1,7 @@
 {
   "pearl-1": {
     "registryPath": "gno.land/r/demo/defi/grc20reg",
-    "helperPath": "gno.land/r/demo/defi/grc20reg"
+    "helperPath": ""
   },
   "gnoland1": {
     "registryPath": "gno.land/r/demo/defi/grc20reg",

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -42,7 +42,7 @@
     "@cosmjs/amino": "0.38.1",
     "@cosmjs/ledger-amino": "0.38.1",
     "@cosmjs/proto-signing": "0.38.1",
-    "@gnolang/gno-js-client": "2.0.3",
+    "@gnolang/gno-js-client": "2.0.4",
     "@gnolang/tm2-js-client": "2.0.4",
     "@ledgerhq/hw-transport": "6.31.4",
     "@ledgerhq/hw-transport-mocker": "6.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,6 +1821,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bufbuild/protobuf@npm:^2.13.0":
+  version: 2.14.0
+  resolution: "@bufbuild/protobuf@npm:2.14.0"
+  checksum: 904533ce3054c76aa43520c35e12d3cafa5594f9a652ccd8d34c547156fc73c5a62bb8d77fb6f416adf8e357bd8e26f311e478a5df3ccb19e6310c827c518c9a
+  languageName: node
+  linkType: hard
+
 "@cosmjs/amino@npm:0.38.1, @cosmjs/amino@npm:^0.38.1":
   version: 0.38.1
   resolution: "@cosmjs/amino@npm:0.38.1"
@@ -2279,19 +2286,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gnolang/gno-js-client@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@gnolang/gno-js-client@npm:2.0.3"
+"@gnolang/gno-js-client@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@gnolang/gno-js-client@npm:2.0.4"
   dependencies:
-    "@bufbuild/protobuf": ^2.11.0
-    "@cosmjs/ledger-amino": ^0.38.1
+    "@bufbuild/protobuf": ^2.13.0
+    "@cosmjs/ledger-amino": 0.38.1
     "@gnolang/tm2-js-client": ^2.0.4
     "@gnolang/tm2-rpc": ^1.0.0
-    protobufjs: ^8.0.0
-    yargs: ^18.0.0
+    protobufjs: ^8.7.1
+    yargs: ^18.1.0
   bin:
-    gno-gen-module: dist/generate-module.cjs
-  checksum: 532d9d4bda45975403ebc2f58146c675c62e6eeb3485f698ccb00b878aa27a446aa008b8a706bf72ca0e276060168b46cfb57bda99b86f172a16fcb8bef3b663
+    gno-gen-module: ./dist/generate-module.cjs
+  checksum: 7b1e752d5e6fe6c8cb736dc08ba9f5994d438e60ba92bedacd82f26db963bf0d9e97126936dad6fef52fae6802257a660b7e3c91eb2eedba567a1beba8ce5da8
   languageName: node
   linkType: hard
 
@@ -6304,7 +6311,7 @@ __metadata:
     "@babel/preset-react": 7.23.3
     "@babel/preset-typescript": 7.23.3
     "@bufbuild/protobuf": 2.12.0
-    "@gnolang/gno-js-client": 2.0.3
+    "@gnolang/gno-js-client": 2.0.4
     "@gnolang/tm2-js-client": 2.0.4
     "@gnolang/tm2-rpc": 1.0.0
     "@jest/globals": 29.7.0
@@ -6394,7 +6401,7 @@ __metadata:
     "@cosmjs/amino": 0.38.1
     "@cosmjs/ledger-amino": 0.38.1
     "@cosmjs/proto-signing": 0.38.1
-    "@gnolang/gno-js-client": 2.0.3
+    "@gnolang/gno-js-client": 2.0.4
     "@gnolang/tm2-js-client": 2.0.4
     "@ledgerhq/hw-transport": 6.31.4
     "@ledgerhq/hw-transport-mocker": 6.29.4
@@ -6605,6 +6612,13 @@ __metadata:
   version: 6.1.0
   resolution: "ansi-regex@npm:6.1.0"
   checksum: 495834a53b0856c02acd40446f7130cb0f8284f4a39afdab20d5dc42b2e198b1196119fe887beed8f9055c4ff2055e3b2f6d4641d0be018cdfb64fedf6fc1aac
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^6.2.2":
+  version: 6.3.0
+  resolution: "ansi-regex@npm:6.3.0"
+  checksum: 85e15deee80d6e52e75864897b6f7b8a8cfc5befe1868f03e3b6bf8925b9b667cf67d4aeafc6d038398f2f11c3813e7b40ad79affdd29a9c491b3585bfa125d5
   languageName: node
   linkType: hard
 
@@ -10719,6 +10733,13 @@ __metadata:
   version: 1.3.0
   resolution: "get-east-asian-width@npm:1.3.0"
   checksum: 757a34c7a46ff385e2775f96f9d3e553f6b6666a8898fb89040d36a1010fba692332772945606a7d4b0f0c6afb84cd394e75d5477c56e1f00f1eb79603b0aecc
+  languageName: node
+  linkType: hard
+
+"get-east-asian-width@npm:^1.5.0":
+  version: 1.6.0
+  resolution: "get-east-asian-width@npm:1.6.0"
+  checksum: 88faf98aaade2b24ad260be369b026d979ff4d0e6201bfd991654da17f2aa720bbddb812ce5612110eef6b469d8370c863f69a2f9818d61733f1eb2a83d779b8
   languageName: node
   linkType: hard
 
@@ -15059,6 +15080,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protobufjs@npm:^8.7.1":
+  version: 8.8.0
+  resolution: "protobufjs@npm:8.8.0"
+  dependencies:
+    long: ^5.3.2
+  checksum: d8700a777fe38b2c9f5c6f7f698f35954d7ba79a3bd465e273ab0da49aff51463f131d38db0d5d15bf7d3e680495fe8bb02ca02ebc13ec8e838b6a5c1d2d739e
+  languageName: node
+  linkType: hard
+
 "proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
@@ -16755,6 +16785,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^8.2.1":
+  version: 8.2.2
+  resolution: "string-width@npm:8.2.2"
+  dependencies:
+    get-east-asian-width: ^1.5.0
+    strip-ansi: ^7.1.2
+  checksum: 37fc1e2bdb488404118b1a07747cf9bb1f5fddfe6f850ba4b1451d118d09fb03ca5948cc69740fec5c54bce384232bcc74e181e8bedf39b5d385e9565df1270e
+  languageName: node
+  linkType: hard
+
 "string.prototype.includes@npm:^2.0.1":
   version: 2.0.1
   resolution: "string.prototype.includes@npm:2.0.1"
@@ -16889,6 +16929,15 @@ __metadata:
   dependencies:
     ansi-regex: ^6.0.1
   checksum: 859c73fcf27869c22a4e4d8c6acfe690064659e84bef9458aa6d13719d09ca88dcfd40cbf31fd0be63518ea1a643fe070b4827d353e09533a5b0b9fd4553d64d
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.2":
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
+  dependencies:
+    ansi-regex: ^6.2.2
+  checksum: 96da3bc6d73cfba1218625a3d66cf7d37a69bf0920d8735b28f9eeaafcdb6c1fe8440e1ae9eb1ba0ca355dbe8702da872e105e2e939fa93e7851b3cb5dd7d316
   languageName: node
   linkType: hard
 
@@ -18528,17 +18577,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^18.0.0":
-  version: 18.0.0
-  resolution: "yargs@npm:18.0.0"
+"yargs@npm:^18.1.0":
+  version: 18.1.0
+  resolution: "yargs@npm:18.1.0"
   dependencies:
     cliui: ^9.0.1
     escalade: ^3.1.1
     get-caller-file: ^2.0.5
-    string-width: ^7.2.0
+    string-width: ^8.2.1
     y18n: ^5.0.5
     yargs-parser: ^22.0.0
-  checksum: a7cf1b97cb4e81c059f78fd32a4160505d421ecdce5409f5e3840fdcc4c982885fc645b44af961eab94d673cb46f81207d831aa87862246907ffacf45884976a
+  checksum: bd56c39d72f5490d4605d75b482b4edc6c67bd673cd687871ba0b4343fb8a85a5675078f28824dbc7eebf31427b643b98151854cacea714431c82aaa6a6ca8e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

`grc20reg`'s write wrappers changed from crossing to **non-crossing** functions on master:

```gno
// Call it non-crossing, forwarding your own `cur`:
//	grc20reg.Transfer(0, cur, "gno.land/r/demo/defi/foo20.FOO", to, 100)
func Transfer(_ int, rlm realm, tokenKey string, to address, amount int64) {
	checkErr(MustGet(tokenKey).RealmTeller(0, rlm).Transfer(0, rlm, to, amount))
}
```

`_ int, rlm realm` is the only shape that yields a non-crossing realm parameter, and `CallerTeller()` moved from `*Token` to `*PrivateLedger`. Both of the wallet's GRC20 transfer paths broke as a result. Fixing the MsgRun fallback then surfaced a second, unrelated regression: since [gnolang/gno#6088](https://github.com/gnolang/gno/pull/6088) the auth ante wires `RequireSigForSimulate` to `txCarriesCode`, so MsgRun signatures are verified on the simulate path as well.

## Changes

### 1. MsgRun fallback follows the registry's documented entry point

`grc20reg.MustGet(key).CallerTeller().Transfer(...)` no longer compiles — that accessor now hangs off the private ledger. The generated run body calls the registry wrapper instead:

```gno
func main(cur realm) {
	grc20reg.Transfer(0, cur, "<tokenKey>", address("<to>"), <amount>)
}
```

Forwarding our own `cur` non-crossing keeps the ephemeral `/e/<caller>/run` realm as the live frame, so `RealmTeller` debits the signing account. A crossing call would mint a fresh `cur` for the registry and spend the registry's own balance. The wrapper also panics through `checkErr`, so a failed transfer reverts rather than reporting success.

### 2. `pearl-1` helper path cleared

`helperPath` pointed at `grc20reg` itself, which worked while `Transfer` was crossing. MsgCall cannot construct a `realm` argument (`convertArgToGno` rejects non-primitive parameter types), so the registry is no longer reachable that way and the chain falls back to MsgRun. Chains with a real helper realm (`gnoland1`, `dev.gnoswap`) are unchanged.

### 3. Gas estimation signs code-bearing transactions

`makeEstimateGasTransaction` sent a pubkey-only placeholder for already-initialized accounts. The node now rejects that for MsgRun with `/std.UnauthorizedError: signature verification failed`. gno's own note:

> The cost: keyless gas estimation no longer works for either message. gnokey signs a second transaction for simulation and is unaffected; other clients that estimate before signing must supply a real signature.

Documents carrying `/vm.m_run` or `/vm.m_addpkg` are now signed for simulation regardless of the `withSignTransaction` flag.

### 4. `@gnolang/gno-js-client` 2.0.3 → 2.0.4

Picks up the current MsgRun proto. `send` and `max_deposit` lost `omitempty` on the chain side, so they must stay present in the sign payload even when empty.

### 5. Token history matches the Transfer event

The per-token history query matched on message shape (`pkg_path` + `func` + `args`), which cannot see a MsgRun — its body is not indexed. It now matches transactions carrying a `Transfer` event for the selected token id:

```graphql
GnoEvent: {
  type: { eq: "Transfer" }
  _and: [
    { attrs: { key: { eq: "token" }, value: { like: "<tokenKey>." } } }
    { attrs: { key: { eq: "from" }, value: { eq: "<address>" } } }
  ]
}
```

Direct, helper-routed and MsgRun transfers all emit the same event, so one branch covers every invocation shape. The event's `token` attr is `Token.ID()` = `{packagePath}.{symbol}.{sequence}` while the wallet's identity is `{packagePath}.{symbol}`, hence the prefix match. MsgRun transactions carrying that event are now mapped as transfers instead of a generic "Message Run" contract interaction.
