### PR TITLE
fix: load balances after unlocking from an auto-lock

### DIFF
--- a/packages/adena-extension/src/App/use-app.ts
+++ b/packages/adena-extension/src/App/use-app.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useIdleTimer } from 'react-idle-timer';
 import { useLocation } from 'react-router-dom';
 
@@ -15,7 +15,7 @@ import { useTokenMetainfo } from '@hooks/use-token-metainfo';
 import { useWallet } from '@hooks/use-wallet';
 
 const useApp = (): void => {
-  const { wallet } = useWalletContext();
+  const { wallet, clearWallet, initWallet } = useWalletContext();
   const { initAccountNames } = useAccountName();
   const { currentAccount } = useCurrentAccount();
   const { currentNetwork, checkNetworkState } = useNetwork();
@@ -25,22 +25,42 @@ const useApp = (): void => {
   const { lockedWallet } = useWallet();
   const queryClient = useQueryClient();
 
-  // Listen for the AUTO_LOCK_TRIGGERED broadcast from background. Without
-  // this, the popup keeps rendering the unlocked screen until the next user
-  // interaction nudges react-query to refetch — invalidating the cached
-  // `wallet/locked` query forces an immediate re-evaluation, which the
-  // existing routing logic in use-init-wallet picks up.
+  // Auto-lock only clears the background's session storage. Everything the
+  // popup holds — the deserialized wallet, the selected account, the cached
+  // `wallet/locked` query — survives untouched, so tear it down here the same
+  // way the manual Lock action does. `initWallet` then re-reads the (now
+  // locked) state, which routes to Login via use-init-wallet and refreshes the
+  // cached lock query.
+  const handleAutoLock = useCallback(async (): Promise<void> => {
+    try {
+      await clearWallet();
+      await initWallet();
+    } finally {
+      // Runs even if initWallet threw, so the lock screen still appears.
+      await queryClient.invalidateQueries({ queryKey: [WALLET_LOCKED_QUERY_KEY] });
+    }
+  }, [clearWallet, initWallet, queryClient]);
+
+  // Held in a ref so the chrome listener is registered exactly once: the
+  // provider hands back fresh `clearWallet` / `initWallet` identities on every
+  // render, which would otherwise re-subscribe on each one.
+  const handleAutoLockRef = useRef(handleAutoLock);
+
+  useEffect(() => {
+    handleAutoLockRef.current = handleAutoLock;
+  }, [handleAutoLock]);
+
   useEffect(() => {
     const handler = (message: unknown): void => {
       if (isAutoLockTriggeredMessage(message)) {
-        queryClient.invalidateQueries({ queryKey: [WALLET_LOCKED_QUERY_KEY] });
+        handleAutoLockRef.current().catch((error) => console.warn(error));
       }
     };
     chrome.runtime.onMessage.addListener(handler);
     return (): void => {
       chrome.runtime.onMessage.removeListener(handler);
     };
-  }, [queryClient]);
+  }, []);
 
   const sendActivityPing = useCallback(() => {
     chrome.runtime

--- a/packages/adena-extension/src/App/use-app.ts
+++ b/packages/adena-extension/src/App/use-app.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect } from 'react';
 import { useIdleTimer } from 'react-idle-timer';
 import { useLocation } from 'react-router-dom';
 
+import { WALLET_LOCKED_QUERY_KEY } from '@common/constants/query-key.constant';
 import { isAutoLockTriggeredMessage } from '@common/utils/auto-lock-timer';
 import { CommandMessage } from '@inject/message/command-message';
 import { useAccountName } from '@hooks/use-account-name';
@@ -32,7 +33,7 @@ const useApp = (): void => {
   useEffect(() => {
     const handler = (message: unknown): void => {
       if (isAutoLockTriggeredMessage(message)) {
-        queryClient.invalidateQueries({ queryKey: ['wallet/locked'] });
+        queryClient.invalidateQueries({ queryKey: [WALLET_LOCKED_QUERY_KEY] });
       }
     };
     chrome.runtime.onMessage.addListener(handler);

--- a/packages/adena-extension/src/common/constants/query-key.constant.ts
+++ b/packages/adena-extension/src/common/constants/query-key.constant.ts
@@ -1,0 +1,25 @@
+/**
+ * Query keys for the wallet's lock state.
+ *
+ * `wallet/existWallet` and `wallet/locked` read local/session storage rather
+ * than the chain, but they still inherit the app-wide query defaults (10s
+ * staleTime, no refetch on window focus). That makes them behave like a cached
+ * snapshot: once a value lands in the cache nothing re-reads it on its own, so
+ * every place that changes the underlying storage has to write the new value
+ * back. `WalletProvider.initWallet` is that place.
+ *
+ * Kept out of `@hooks/use-wallet` so the provider can import the keys without
+ * pulling the hook (and the provider barrel it re-imports) into a cycle.
+ */
+export const WALLET_EXISTS_QUERY_KEY = 'wallet/existWallet';
+export const WALLET_LOCKED_QUERY_KEY = 'wallet/locked';
+
+export const makeWalletExistsQueryKey = (walletServiceId: string): [string, string] => [
+  WALLET_EXISTS_QUERY_KEY,
+  walletServiceId,
+];
+
+export const makeWalletLockedQueryKey = (walletServiceId: string): [string, string] => [
+  WALLET_LOCKED_QUERY_KEY,
+  walletServiceId,
+];

--- a/packages/adena-extension/src/common/provider/wallet/wallet-provider.spec.tsx
+++ b/packages/adena-extension/src/common/provider/wallet/wallet-provider.spec.tsx
@@ -1,0 +1,135 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, waitFor } from '@testing-library/react';
+import React, { PropsWithChildren } from 'react';
+import { RecoilRoot } from 'recoil';
+
+import { makeWalletLockedQueryKey } from '@common/constants/query-key.constant';
+import { useAdenaContext, useWalletContext } from '@hooks/use-context';
+import { useWallet } from '@hooks/use-wallet';
+
+import { WalletProvider } from './wallet-provider';
+
+// Mocked wholesale rather than with `requireActual`: the real module reaches
+// the provider barrel, which pulls @adena-wallet/sdk's social-wallet stack into
+// jsdom and blows up on import.
+jest.mock('@hooks/use-context', () => ({
+  useAdenaContext: jest.fn(),
+  // Resolved lazily: requiring the provider from the factory body would run
+  // into the mock while it is still being constructed.
+  useWalletContext: (): unknown => {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const react = require('react');
+    const { WalletContext } = require('./wallet-provider');
+    /* eslint-enable @typescript-eslint/no-var-requires */
+    return react.useContext(WalletContext);
+  },
+}));
+
+jest.mock('../gno/gno-provider', () => ({
+  GnoProvider: jest.fn().mockImplementation(() => ({})),
+}));
+
+const WALLET_SERVICE_ID = 'wallet-service-id';
+
+const makeAdenaContext = (walletService: Record<string, unknown>): Record<string, unknown> => ({
+  walletService: { id: WALLET_SERVICE_ID, ...walletService },
+  accountService: {
+    getCurrentAccountId: jest.fn().mockResolvedValue(null),
+    changeCurrentAccount: jest.fn().mockResolvedValue(true),
+  },
+  // An empty network list makes `initNetworkMetainfos` bail out early, so the
+  // test only exercises the wallet half of the provider's bootstrap.
+  chainService: { getNetworks: jest.fn().mockResolvedValue([]) },
+  chainRegistry: { register: jest.fn() },
+  tokenRegistry: { register: jest.fn() },
+});
+
+let initWallet: () => Promise<boolean>;
+let lockedWallet: boolean | undefined;
+
+const Probe = (): JSX.Element => {
+  initWallet = useWalletContext().initWallet;
+  lockedWallet = useWallet().lockedWallet;
+  return <div />;
+};
+
+// Mirrors the app-wide defaults in App/app-provider: the lock-state query is
+// cached for 10s and never refetches on window focus, so the provider has to
+// write the fresh value back itself.
+const makeWrapper = (queryClient: QueryClient): React.FC<PropsWithChildren> => {
+  const Wrapper = ({ children }: PropsWithChildren): JSX.Element => (
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <WalletProvider>{children}</WalletProvider>
+      </QueryClientProvider>
+    </RecoilRoot>
+  );
+  Wrapper.displayName = 'WalletProviderWrapper';
+  return Wrapper;
+};
+
+describe('WalletProvider lock-state cache', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    initWallet = jest.fn();
+    lockedWallet = undefined;
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { staleTime: 10_000, refetchOnWindowFocus: false, retry: false },
+      },
+    });
+  });
+
+  it('reports the wallet as unlocked right after an unlock, without waiting for a refetch', async () => {
+    const isLocked = jest.fn().mockResolvedValue(true);
+    const walletService = {
+      existsWallet: jest.fn().mockResolvedValue(true),
+      isLocked,
+      loadWallet: jest
+        .fn()
+        .mockResolvedValue({ accounts: [], currentAccountId: null, hasHDWallet: () => false }),
+    };
+    (useAdenaContext as jest.Mock).mockReturnValue(makeAdenaContext(walletService));
+
+    const Wrapper = makeWrapper(queryClient);
+    render(
+      <Wrapper>
+        <Probe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(lockedWallet).toBe(true));
+
+    // Auto-lock invalidates the query, so the cache holds `true` when the user
+    // reaches the Login screen. Unlocking runs `initWallet` again.
+    isLocked.mockResolvedValue(false);
+    await act(async () => {
+      await initWallet();
+    });
+
+    await waitFor(() => expect(lockedWallet).toBe(false));
+  });
+
+  it('keeps the cached lock state authoritative while the wallet is locked', async () => {
+    const walletService = {
+      existsWallet: jest.fn().mockResolvedValue(true),
+      isLocked: jest.fn().mockResolvedValue(true),
+      loadWallet: jest.fn(),
+    };
+    (useAdenaContext as jest.Mock).mockReturnValue(makeAdenaContext(walletService));
+
+    // Pre-seed a stale `false`, as if the wallet had been unlocked earlier.
+    queryClient.setQueryData(makeWalletLockedQueryKey(WALLET_SERVICE_ID), false);
+
+    const Wrapper = makeWrapper(queryClient);
+    render(
+      <Wrapper>
+        <Probe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(lockedWallet).toBe(true));
+  });
+});

--- a/packages/adena-extension/src/common/provider/wallet/wallet-provider.spec.tsx
+++ b/packages/adena-extension/src/common/provider/wallet/wallet-provider.spec.tsx
@@ -1,11 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, waitFor } from '@testing-library/react';
 import React, { PropsWithChildren } from 'react';
-import { RecoilRoot } from 'recoil';
+import { RecoilRoot, useRecoilValue } from 'recoil';
 
 import { makeWalletLockedQueryKey } from '@common/constants/query-key.constant';
 import { useAdenaContext, useWalletContext } from '@hooks/use-context';
 import { useWallet } from '@hooks/use-wallet';
+import { WalletState } from '@states';
 
 import { WalletProvider } from './wallet-provider';
 
@@ -31,10 +32,13 @@ jest.mock('../gno/gno-provider', () => ({
 
 const WALLET_SERVICE_ID = 'wallet-service-id';
 
-const makeAdenaContext = (walletService: Record<string, unknown>): Record<string, unknown> => ({
+const makeAdenaContext = (
+  walletService: Record<string, unknown>,
+  currentAccountId: string | null = null,
+): Record<string, unknown> => ({
   walletService: { id: WALLET_SERVICE_ID, ...walletService },
   accountService: {
-    getCurrentAccountId: jest.fn().mockResolvedValue(null),
+    getCurrentAccountId: jest.fn().mockResolvedValue(currentAccountId),
     changeCurrentAccount: jest.fn().mockResolvedValue(true),
   },
   // An empty network list makes `initNetworkMetainfos` bail out early, so the
@@ -45,10 +49,17 @@ const makeAdenaContext = (walletService: Record<string, unknown>): Record<string
 });
 
 let initWallet: () => Promise<boolean>;
+let clearWallet: () => Promise<void>;
 let lockedWallet: boolean | undefined;
+let wallet: unknown;
+let currentAccount: unknown;
 
 const Probe = (): JSX.Element => {
-  initWallet = useWalletContext().initWallet;
+  const context = useWalletContext();
+  initWallet = context.initWallet;
+  clearWallet = context.clearWallet;
+  wallet = context.wallet;
+  currentAccount = useRecoilValue(WalletState.currentAccount);
   lockedWallet = useWallet().lockedWallet;
   return <div />;
 };
@@ -74,7 +85,10 @@ describe('WalletProvider lock-state cache', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     initWallet = jest.fn();
+    clearWallet = jest.fn();
     lockedWallet = undefined;
+    wallet = undefined;
+    currentAccount = undefined;
     queryClient = new QueryClient({
       defaultOptions: {
         queries: { staleTime: 10_000, refetchOnWindowFocus: false, retry: false },
@@ -131,5 +145,36 @@ describe('WalletProvider lock-state cache', () => {
     );
 
     await waitFor(() => expect(lockedWallet).toBe(true));
+  });
+
+  it('drops the in-memory wallet and current account when the wallet is cleared', async () => {
+    const account = { id: 'account-1' };
+    const walletService = {
+      existsWallet: jest.fn().mockResolvedValue(true),
+      isLocked: jest.fn().mockResolvedValue(false),
+      loadWallet: jest.fn().mockResolvedValue({
+        accounts: [account],
+        currentAccountId: null,
+        hasHDWallet: () => false,
+      }),
+    };
+    (useAdenaContext as jest.Mock).mockReturnValue(makeAdenaContext(walletService, account.id));
+
+    const Wrapper = makeWrapper(queryClient);
+    render(
+      <Wrapper>
+        <Probe />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(currentAccount).toEqual(account));
+    expect(wallet).not.toBeNull();
+
+    await act(async () => {
+      await clearWallet();
+    });
+
+    expect(wallet).toBeNull();
+    expect(currentAccount).toBeNull();
   });
 });

--- a/packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx
+++ b/packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx
@@ -1,7 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { AdenaWallet, Wallet } from 'adena-module';
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useEffect, useState } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
+import {
+  makeWalletExistsQueryKey,
+  makeWalletLockedQueryKey,
+} from '@common/constants/query-key.constant';
 import { toGnoNetworkProfile } from '@common/mapper/network-profile-mapper';
 import {
   normalizeStoredId,
@@ -43,6 +48,8 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
     chainRegistry,
     tokenRegistry,
   } = useAdenaContext();
+
+  const queryClient = useQueryClient();
 
   const [gnoProvider, setGnoProvider] = useState<GnoProvider>();
 
@@ -123,15 +130,36 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
     }
   }, [wallet, networkMetainfos, tokenMetainfos]);
 
+  // `useWallet` serves `existWallet` / `lockedWallet` from react-query, which
+  // caches with the app-wide 10s staleTime and never refetches on window focus.
+  // `initWallet` runs on every lock and unlock and has just read the
+  // authoritative values from storage, so write them straight into the cache.
+  //
+  // Without this, unlocking after an auto-lock leaves `lockedWallet` stuck at
+  // `true`: the auto-lock broadcast invalidated it to `true` and the unlock
+  // path never re-reads it. Everything gated on `!lockedWallet` — the balance
+  // pollers in use-token-balance / use-account-native-balance-map, and the
+  // auto-lock activity ping in use-app — then stays disabled, so the main
+  // screen keeps rendering balance skeletons forever.
+  const syncWalletLockQueries = useCallback(
+    (existWallet: boolean, isLocked: boolean): void => {
+      queryClient.setQueryData(makeWalletExistsQueryKey(walletService.id), existWallet);
+      queryClient.setQueryData(makeWalletLockedQueryKey(walletService.id), isLocked);
+    },
+    [queryClient, walletService],
+  );
+
   async function initWallet(): Promise<boolean> {
     const existWallet = await walletService.existsWallet();
     if (!existWallet) {
+      syncWalletLockQueries(false, true);
       setWallet(null);
       setWalletStatus('CREATE');
       return true;
     }
 
     const isLocked = await walletService.isLocked();
+    syncWalletLockQueries(true, isLocked);
     if (isLocked) {
       setWallet(null);
       setWalletStatus('LOGIN');

--- a/packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx
+++ b/packages/adena-extension/src/common/provider/wallet/wallet-provider.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { AdenaWallet, Wallet } from 'adena-module';
+import { Wallet } from 'adena-module';
 import React, { createContext, useCallback, useEffect, useState } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
@@ -188,13 +188,13 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({ chi
     return true;
   }
 
+  // Drops the popup's references to the deserialized wallet and the selected
+  // account. The previous implementation passed *functions* to `Promise.all`
+  // instead of promises, so neither setter ever ran and a locked wallet kept
+  // both in memory.
   async function clearWallet(): Promise<void> {
-    await setWallet(new AdenaWallet());
-
-    await Promise.all([
-      async (): Promise<void> => await setWallet(null),
-      async (): Promise<void> => await setCurrentAccount(null),
-    ]);
+    setWallet(null);
+    setCurrentAccount(null);
   }
 
   async function initCurrentAccount(wallet: Wallet): Promise<boolean> {

--- a/packages/adena-extension/src/hooks/use-wallet.ts
+++ b/packages/adena-extension/src/hooks/use-wallet.ts
@@ -1,5 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
+
+import {
+  makeWalletExistsQueryKey,
+  makeWalletLockedQueryKey,
+} from '@common/constants/query-key.constant';
 import { useAdenaContext, useWalletContext } from './use-context';
 
 export interface UseWalletReturn {
@@ -23,7 +28,7 @@ export const useWallet = (): UseWalletReturn => {
   }, [wallet]);
 
   const { data: existWallet, isLoading: isLoadingExistWallet } = useQuery(
-    ['wallet/existWallet', walletService.id],
+    makeWalletExistsQueryKey(walletService.id),
     async () => {
       const existWallet = await walletService.existsWallet().catch(() => false);
       return existWallet;
@@ -32,7 +37,7 @@ export const useWallet = (): UseWalletReturn => {
   );
 
   const { data: lockedWallet, isLoading: isLoadingLockedWallet } = useQuery(
-    ['wallet/locked', walletService.id],
+    makeWalletLockedQueryKey(walletService.id),
     async () => {
       const lockedWallet = await walletService.isLocked();
       return lockedWallet;


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does:

Fixes the wallet main screen hanging on balance skeletons forever after the wallet is unlocked following an auto-lock, and cleans up two related defects in the lock path.

---

#### 1. Stale `wallet/locked` leaves every balance query disabled

`useWallet` serves `existWallet` / `lockedWallet` from React Query. Both read local/session storage rather than the chain, but they still inherit the app-wide defaults introduced in #882 — `staleTime: 10_000` and `refetchOnWindowFocus: false` — which turns them into a cached snapshot that nothing re-reads on its own.

The failing sequence:

1. The auto-lock alarm fires, and `use-app` invalidates `wallet/locked` → `lockedWallet === true` → `use-init-wallet` routes to Login.
2. The user unlocks. **No code path re-reads `wallet/locked`**: `Login.login()` doesn't invalidate it, there is no refetch interval, and window-focus refetching is off. A newly mounted observer only refetches once the 10s stale window has passed, which typing a password usually beats.
3. `useTokenBalance`'s `availableBalanceFetching` is hard-gated on `!lockedWallet`, so the Gno and Cosmos balance queries stay `enabled: false` — the main balance and every token row keep rendering skeletons. `useAccountNativeBalanceMap` is gated the same way.
4. `use-app`'s idle timer is gated on `lockedWallet !== false` too, so the activity ping never fires again and the next auto-lock alarm is never armed.

This is specific to auto-lock because manual Lock never flips the cached value to `true` in the first place, so unlocking from a manual lock still reads `false`. Before #882 (`staleTime: 0` + focus refetching) the auto-lock path self-healed.

**Fix:** `WalletProvider.initWallet` runs on every lock and unlock and has just read the authoritative values from storage, so it now writes them straight into the query cache. That single point covers the popup Login (`loadAccounts()`), the dApp ApproveLogin screen, LaunchAdena and both manual lock handlers. Query keys moved to `@common/constants/query-key.constant` so the provider can import them without pulling the hook — and the provider barrel it re-imports — into a cycle.

#### 2. `clearWallet` never cleared anything

```ts
await Promise.all([
  async (): Promise<void> => await setWallet(null),
  async (): Promise<void> => await setCurrentAccount(null),
]);
```

The array holds *functions*, not promises, so `Promise.all` resolved immediately and neither setter ran. The wallet atom was left holding a throwaway `new AdenaWallet()` — briefly truthy, so it could flip `walletStatus` to `FINISH` — and the previously selected account stayed in memory for the whole locked session.

#### 3. Auto-lock did not tear down the popup's in-memory state

Auto-lock only clears the background's session storage. The popup kept the deserialized wallet, the selected account and the cached lock query. The `AUTO_LOCK_TRIGGERED` handler now runs the same teardown as the manual Lock action — clear the in-memory state, then let `initWallet` re-read the locked state, which routes to Login and refreshes the cached lock query.

### Notes for reviewers

- The auto-lock handler is held in a ref so the `chrome.runtime.onMessage` listener subscribes once. `clearWallet` / `initWallet` come from a context value rebuilt on every provider render, so a plain dependency array would re-subscribe on each one.
- `clearWallet` drops references rather than calling `Wallet.destroy()`. Recoil freezes atom values in development builds, so mutating the stored wallet in place would throw. This matches what manual Lock already did — `walletService.lockWallet()` destroys a freshly loaded copy, not the one held in Recoil.
- With 2 and 3 in place, `currentAccount` now goes `null` on every lock. On unlock `initCurrentAccount` restores it, which re-runs `initTokenMetainfos` in `use-app` — the same path a cold start already takes.
- New `wallet-provider.spec.tsx` covers all three: unlock-after-auto-lock reporting unlocked without a refetch, a locked wallet overriding a stale cached `false`, and `clearWallet` dropping both the wallet and the current account. Each test was confirmed to fail against the pre-fix code.
- `tsc --noEmit` clean, ESLint clean, full suite green (697 tests).

### How to verify manually

1. Set a short auto-lock duration in Settings → Security & Privacy.
2. Leave the wallet idle until it locks, then unlock it.
3. The main screen should render balances instead of skeletons, and the auto-lock timer should re-arm for the next cycle.
