### PR TITLE
fix: unify @bufbuild/protobuf so MsgCreateSession can be encoded

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "resolutions": {
     "@storybook/react-docgen-typescript-plugin": "npm:react-docgen-typescript-plugin@1.0.5",
-    "ws": "8.20.0"
+    "ws": "8.20.0",
+    "@bufbuild/protobuf": "2.14.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.9",

--- a/packages/adena-extension/package.json
+++ b/packages/adena-extension/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "@adena-wallet/sdk": "0.0.14",
-    "@bufbuild/protobuf": "2.12.0",
+    "@bufbuild/protobuf": "2.14.0",
     "@gnolang/gno-js-client": "2.0.4",
     "@gnolang/tm2-js-client": "2.0.4",
     "@gnolang/tm2-rpc": "1.0.0",

--- a/packages/adena-module/package.json
+++ b/packages/adena-module/package.json
@@ -38,7 +38,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "2.12.0",
+    "@bufbuild/protobuf": "2.14.0",
     "@cosmjs/amino": "0.38.1",
     "@cosmjs/ledger-amino": "0.38.1",
     "@cosmjs/proto-signing": "0.38.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1814,14 +1814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bufbuild/protobuf@npm:2.12.0, @bufbuild/protobuf@npm:^2.11.0":
-  version: 2.12.0
-  resolution: "@bufbuild/protobuf@npm:2.12.0"
-  checksum: f905c34ffbf0a05ee3fd6281a13f5daa5b43c215682d4900b23629691c1ee7fe0d96fefbbad84055ba0547ef089fb2d488a68c4e8383abf5b7dc56a9207c44ea
-  languageName: node
-  linkType: hard
-
-"@bufbuild/protobuf@npm:^2.13.0":
+"@bufbuild/protobuf@npm:2.14.0":
   version: 2.14.0
   resolution: "@bufbuild/protobuf@npm:2.14.0"
   checksum: 904533ce3054c76aa43520c35e12d3cafa5594f9a652ccd8d34c547156fc73c5a62bb8d77fb6f416adf8e357bd8e26f311e478a5df3ccb19e6310c827c518c9a
@@ -6310,7 +6303,7 @@ __metadata:
     "@babel/preset-env": 7.23.9
     "@babel/preset-react": 7.23.3
     "@babel/preset-typescript": 7.23.3
-    "@bufbuild/protobuf": 2.12.0
+    "@bufbuild/protobuf": 2.14.0
     "@gnolang/gno-js-client": 2.0.4
     "@gnolang/tm2-js-client": 2.0.4
     "@gnolang/tm2-rpc": 1.0.0
@@ -6397,7 +6390,7 @@ __metadata:
     "@babel/preset-env": 7.23.9
     "@babel/preset-flow": 7.23.3
     "@babel/preset-typescript": 7.23.3
-    "@bufbuild/protobuf": 2.12.0
+    "@bufbuild/protobuf": 2.14.0
     "@cosmjs/amino": 0.38.1
     "@cosmjs/ledger-amino": 0.38.1
     "@cosmjs/proto-signing": 0.38.1


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does:

Fixes Create Session Account failing in the approve-transaction popup with
`this.encodeUtf8Into is not a function`, which the popup reported to the user as a
bare `Unknown error`.

#### Root cause

The dependency tree carried **two copies of `@bufbuild/protobuf`**:

| Consumer | Range | Resolved |
| --- | --- | --- |
| `adena-module`, `adena-extension` | `2.12.0` (pinned) | 2.12.0 |
| `@gnolang/tm2-js-client@2.0.4` | `^2.11.0` | 2.12.0 |
| `@gnolang/gno-js-client@2.0.4` | `^2.13.0` | **2.14.0** |

Every copy shares **one** config object stored on the global registry symbol
`Symbol.for("@bufbuild/protobuf/text-encoding")`, and the first copy to call
`getTextEncoding()` initializes it for all of them. Copies **before 2.13** populate
that config with only `{ encodeUtf8, decodeUtf8, checkUtf8 }` — no `encodeUtf8Into`.
The **2.13+** `BinaryWriter` reads `getTextEncoding().encodeUtf8Into` in its
constructor and calls it from `string()` for every string that is longer than
`ASCII_MAX_LENGTH` (32) or contains non-ASCII characters.

So once `tm2-js-client` (2.12.0) touched the global first — which it does on
essentially every RPC decode — any `gno-js-client` (2.14.0) encode of a long string
threw. `MsgCreateSession` writes a **40-character** bech32 `creator`, so it hit the
slow path every single time and never encoded.

Reproduced against the real packages:

```
global keys primed by 2.12: [ 'encodeUtf8', 'decodeUtf8', 'checkUtf8' ]
MsgCreateSession.encode(creator='g1jg8mtutu9khhfwc4nxmuhcpftf0pqmgrzjxw0v')
  -> FAILED: this.encodeUtf8Into is not a function
```

#### The fix

Pin `@bufbuild/protobuf` to `2.14.0` in both workspaces and add a root `resolutions`
entry, so the whole tree dedupes to a single copy. 2.14.0 satisfies both `^2.11.0`
(tm2-js-client) and `^2.13.0` (gno-js-client). `yarn.lock` now has exactly one
`@bufbuild/protobuf` entry.

The `BinaryWriter` / `BinaryReader` surface `adena-module` uses
(`fork`/`join`/`finish`, `string`/`bytes`/`sint64`/`uint32`, `skip`) is unchanged
between 2.12 and 2.14 — `skip()` only gained an optional third parameter.

#### Secondary: the popup was hiding the error

The reason this surfaced as `Unknown error` rather than the actual exception is that
`sendTransaction` in the approve-transaction popup reported failures with an empty
payload, and `TransactionResult` falls back to `'Unknown error'` when there is no
message. This PR also:

- passes the thrown message through on the signing/encoding catch-all (this is the
  only place those errors can be surfaced — they never reach the broadcast branch),
- gives the "transaction data not ready" and session-guard rejection branches a
  message instead of `{}`,
- renders the chain's diagnostic `Log` next to the static `TM2Error` category string
  (`unknown error: <type>`, `unknown request error`, …), matching what the web
  Add Session Account screen already does,
- lets the error box wrap and scroll long multi-line logs.
