### PR TITLE
chore(grc20): support account asset tokenKey

### DIFF
--- a/packages/adena-extension/src/common/utils/grc20-token-path.ts
+++ b/packages/adena-extension/src/common/utils/grc20-token-path.ts
@@ -2,11 +2,11 @@
  * GRC20 token-key helpers.
  *
  * The wallet identifies a GRC20 token by a single canonical **token key**
- * `` `${packagePath}.${symbol}` `` (dot separator). This is the same value the
+ * `` `${packagePath}.${symbol}` `` (dot separator) — the same value the
  * on-chain `grc20reg` registry uses (the fqname `fqname.Construct(rlmPath,
- * symbol)`) and the same identity the API returns (`tokenId`/`tokenKey`), so the
- * wallet, the registry, and the API all speak one form — no colon/dot
- * conversion. One token per realm+symbol.
+ * symbol)`) and the same identity the API returns in `tokenKey`. The API's
+ * `tokenId` is a different, opaque value and must never be parsed as one.
+ * One token per realm+symbol.
  *
  * A gno package path uses slashes and never contains a `.` in its trailing
  * segment; only the appended `.symbol` carries a dot after the last slash. So

--- a/packages/adena-extension/src/repositories/common/response/token-asset-response.ts
+++ b/packages/adena-extension/src/repositories/common/response/token-asset-response.ts
@@ -54,8 +54,10 @@ export interface AccountAsset {
   packagePath: string;
   symbol: string;
   tokenType: string;
-  // Token key `{packagePath}.{symbol}` — maps directly to the wallet tokenId.
+  // Opaque on-chain value (`{packagePath}.{symbol}.{sequence}`) — not the wallet's tokenId.
   tokenId: string;
+  // Canonical `{packagePath}.{symbol}` key, maps to the wallet tokenId. Absent on older API versions.
+  tokenKey?: string;
 }
 
 export interface AccountAssetsResponse {

--- a/packages/adena-extension/src/repositories/common/token.ts
+++ b/packages/adena-extension/src/repositories/common/token.ts
@@ -16,7 +16,6 @@ import { GNOT_TOKEN } from '@common/constants/token.constant';
 import { GnoProvider } from '@common/provider/gno/gno-provider';
 import { decodeGnoString, gnoLiteral, parseQEvalResult } from '@common/provider/gno/qeval';
 import {
-  isTokenPath,
   parseRegistryKey,
   registryKeyToTokenPath,
   toTokenPath,
@@ -530,11 +529,11 @@ export class TokenRepository implements ITokenRepository {
     return assets
       .filter((asset) => (asset.tokenType ?? '').toUpperCase() === 'GRC20' && !!asset.packagePath)
       .map((asset) => {
-        // The API returns the identity in `tokenId` as the token key
-        // `{packagePath}.{symbol}` — the wallet's canonical form. Fall back to
-        // rebuilding it from packagePath + symbol when the field is missing.
+        // tokenKey is the wallet's canonical identity; tokenId is opaque and
+        // must never be used, even as a fallback. Rebuild from packagePath +
+        // symbol when tokenKey is absent (older API versions).
         const tokenId =
-          (isTokenPath(asset.tokenId) ? asset.tokenId : registryKeyToTokenPath(asset.tokenId)) ??
+          (asset.tokenKey ? tokenIdentifierToRegistryKey(asset.tokenKey) : null) ??
           toTokenPath(asset.packagePath, asset.symbol);
 
         return {

--- a/packages/adena-extension/src/repositories/transaction/transaction-history-api.ts
+++ b/packages/adena-extension/src/repositories/transaction/transaction-history-api.ts
@@ -57,9 +57,8 @@ export class TransactionHistoryApiRepository implements ITransactionHistoryRepos
     tokenPath: string,
     cursor?: string | null,
   ): Promise<TransactionWithPageInfo> {
-    // The endpoint is keyed by the full token key `{packagePath}.{symbol}`
-    // (the same identity the API returns as tokenId/tokenKey); fall back to the
-    // raw input for a legacy bare packagePath.
+    // Keyed by the token key `{packagePath}.{symbol}` (same as the API's
+    // `tokenKey`); fall back to the raw input for a legacy bare packagePath.
     const tokenKey = toRegistryKey(tokenPath) ?? tokenPath;
     const encodedTokenKey = encodeURIComponent(tokenKey);
     const path = `${this.apiUrl}/v1/accounts/${address}/grc20-token/${encodedTokenKey}/transactions`;


### PR DESCRIPTION
### What type of PR is this?

- chore

### What this PR does:

- Supports the account asset API split between tokenId and tokenKey.
- Uses tokenKey as Adena's GRC20 token identity.
- Keeps compatibility before tokenKey is deployed to production.

Closes #890