### PR TITLE
feat: use hex encoding for block and transaction hashes

### DIFF
--- a/packages/adena-extension/src/common/event-store/transaction-event-store.ts
+++ b/packages/adena-extension/src/common/event-store/transaction-event-store.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { EventStore } from './event-store';
 import { Event, EventStatus } from './types';
-import { makeHexByBase64, parseABCIValue } from './utility';
+import { makeRpcHashParam, parseABCIValue } from './utility';
 
 type ResponseDataType = string[];
 
@@ -348,7 +348,7 @@ export class TransactionEventStore implements EventStore<ResponseDataType> {
 
     try {
       const networkClient = axios.create({ baseURL: event.rpcUrl });
-      const result = await networkClient.get('/tx?hash=' + makeHexByBase64(id));
+      const result = await networkClient.get('/tx?hash=' + makeRpcHashParam(id));
 
       const height = Number(result.data?.result?.height || 0);
       if (!height) {

--- a/packages/adena-extension/src/common/event-store/utility.ts
+++ b/packages/adena-extension/src/common/event-store/utility.ts
@@ -1,10 +1,11 @@
+import { toHexHash } from '@common/utils/hash-utils';
+
 /**
- * Converts a base64-encoded hash to hex.
- * Use when calling the tx endpoint of an RPC.
+ * Builds the `hash` query value for an RPC `/tx` lookup, which expects a
+ * `0x`-prefixed hex hash.
  */
-export function makeHexByBase64(base64Hash: string): string {
-  const buffer = Buffer.from(base64Hash, 'base64');
-  return '0x' + buffer.toString('hex');
+export function makeRpcHashParam(hash: string): string {
+  return '0x' + toHexHash(hash);
 }
 
 export function parseABCIValue(str: string): string[] {

--- a/packages/adena-extension/src/common/provider/gno/gno-provider.spec.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.spec.ts
@@ -20,11 +20,10 @@ describe('GnoProvider', () => {
   });
 
   describe('sendTransactionSync', () => {
-    it('returns the broadcast tx hash as canonical base64, not uppercase hex', async () => {
-      // Regression guard: sendTransactionSync must hand dApps the same base64 hash
-      // the tm2-js-client path produced. A direct broadcast previously ran the hash
-      // through base64->hex, which changed the value returned to callers.
+    it('returns the broadcast tx hash as lowercase hex', async () => {
+      // The node answers with a base64 hash; the wallet uses hex.
       const base64Hash = '2dD/aBpjSdCTwYdaF64b+bekuBdenwWbYezWfn3JHWE=';
+      const hexHash = 'd9d0ff681a6349d093c1875a17ae1bf9b7a4b8175e9f059b61ecd67e7dc91d61';
       axiosPostMock.mockResolvedValue({
         data: { result: { error: null, data: null, log: '', hash: base64Hash } },
       });
@@ -32,8 +31,7 @@ describe('GnoProvider', () => {
       const provider = new GnoProvider('https://rpc.example', 'test-13');
       const result = await provider.sendTransactionSync('encoded-tx');
 
-      expect(result.hash).toBe(base64Hash);
-      expect(result.hash).not.toMatch(/^[0-9A-Fa-f]{64}$/);
+      expect(result.hash).toBe(hexHash);
     });
   });
 

--- a/packages/adena-extension/src/common/provider/gno/gno-provider.ts
+++ b/packages/adena-extension/src/common/provider/gno/gno-provider.ts
@@ -5,6 +5,7 @@ import {
   UNKNOWN_ADDRESS_ERROR_TYPE,
 } from '@common/constants/tx-error.constant';
 import { parseTokenAmount } from '@common/utils/amount-utils';
+import { toHexHash } from '@common/utils/hash-utils';
 import type { SessionAccountInfo } from '@gnolang/gno-js-client';
 import { GnoJSONRPCProvider } from '@gnolang/gno-js-client';
 import {
@@ -349,7 +350,17 @@ export class GnoProvider extends GnoJSONRPCProvider {
       const result = await this.sendTransactionSync(tx);
       return result as BroadcastTransactionMap[K]['result'];
     }
-    return super.sendTransaction(tx, endpoint);
+
+    const result = await super.sendTransaction(tx, endpoint);
+    if (!result?.hash) {
+      return result;
+    }
+
+    // The node returns the tx hash base64-encoded; the wallet uses hex.
+    return {
+      ...result,
+      hash: toHexHash(result.hash),
+    };
   }
 
   public async sendTransactionSync(tx: string): Promise<BroadcastTxSyncResult> {
@@ -392,7 +403,7 @@ export class GnoProvider extends GnoJSONRPCProvider {
       error: null,
       data: result.data ?? null,
       Log: log,
-      hash: result.hash,
+      hash: toHexHash(result.hash),
     };
   }
 

--- a/packages/adena-extension/src/common/utils/gnoscan-url.spec.ts
+++ b/packages/adena-extension/src/common/utils/gnoscan-url.spec.ts
@@ -2,7 +2,6 @@ import {
   getGnoscanChainId,
   getGnoscanChainParameters,
   isGnoscanChainIdSupported,
-  normalizeGnoscanTxHash,
 } from './gnoscan-url';
 
 describe('gnoscan url helpers', () => {
@@ -19,24 +18,5 @@ describe('gnoscan url helpers', () => {
   it('does not treat custom networks as supported Gnoscan chain ids', () => {
     expect(isGnoscanChainIdSupported('dev.gnoswap')).toBe(false);
     expect(getGnoscanChainParameters('dev.gnoswap')).toBeNull();
-  });
-
-  describe('normalizeGnoscanTxHash', () => {
-    it('converts an uppercase hex tx hash from a broadcast response to base64', () => {
-      expect(
-        normalizeGnoscanTxHash('98C592D248A40F047012B075BD560F439CE3ED9295CDBEA62C873E20BBD0BD0B'),
-      ).toBe('mMWS0kikDwRwErB1vVYPQ5zj7ZKVzb6mLIc+ILvQvQs=');
-    });
-
-    it('handles lowercase hex tx hashes', () => {
-      expect(
-        normalizeGnoscanTxHash('c58d41a26e4a0bf47e88dccba8abc29e821ae3a8db245bb9bcbc0796edb87a47'),
-      ).toBe('xY1Bom5KC/R+iNzLqKvCnoIa46jbJFu5vLwHlu24ekc=');
-    });
-
-    it('passes an already-base64 tx hash through unchanged', () => {
-      const base64Hash = 'mMWS0kikDwRwErB1vVYPQ5zj7ZKVzb6mLIc+ILvQvQs=';
-      expect(normalizeGnoscanTxHash(base64Hash)).toBe(base64Hash);
-    });
   });
 });

--- a/packages/adena-extension/src/common/utils/gnoscan-url.ts
+++ b/packages/adena-extension/src/common/utils/gnoscan-url.ts
@@ -1,18 +1,4 @@
 import CHAIN_DATA from '@resources/chains/chains.json';
-import { fromHex, toBase64 } from 'adena-module';
-
-// A broadcast RPC response returns the tx hash as a 64-char hex string, whereas
-// Gnoscan (and the indexer) key transactions by the base64-encoded hash. Convert
-// a hex hash to base64 and pass any already-base64 value through unchanged.
-const HEX_TX_HASH_PATTERN = /^[0-9a-fA-F]{64}$/;
-
-export const normalizeGnoscanTxHash = (txHash: string): string => {
-  if (!HEX_TX_HASH_PATTERN.test(txHash)) {
-    return txHash;
-  }
-
-  return toBase64(fromHex(txHash));
-};
 
 const GNOSCAN_CHAIN_IDS = new Set(
   CHAIN_DATA.filter((chain) => !!chain.default && chain.chainId !== 'dev').map(

--- a/packages/adena-extension/src/common/utils/hash-utils.spec.ts
+++ b/packages/adena-extension/src/common/utils/hash-utils.spec.ts
@@ -1,0 +1,41 @@
+import { isBase64Hash, isHexHash, toHexHash } from './hash-utils';
+
+const BASE64_HASH = 'mMWS0kikDwRwErB1vVYPQ5zj7ZKVzb6mLIc+ILvQvQs=';
+const HEX_HASH = '98c592d248a40f047012b075bd560f439ce3ed9295cdbea62c873e20bbd0bd0b';
+
+describe('hash-utils', () => {
+  describe('toHexHash', () => {
+    it('converts a base64 tx hash to lowercase hex', () => {
+      expect(toHexHash(BASE64_HASH)).toBe(HEX_HASH);
+    });
+
+    it('keeps an already hex-encoded hash unchanged', () => {
+      expect(toHexHash(HEX_HASH)).toBe(HEX_HASH);
+    });
+
+    it('lowercases an uppercase hex hash', () => {
+      expect(toHexHash(HEX_HASH.toUpperCase())).toBe(HEX_HASH);
+    });
+
+    it('strips a 0x prefix', () => {
+      expect(toHexHash(`0x${HEX_HASH}`)).toBe(HEX_HASH);
+    });
+
+    it('passes through values that are not 32-byte hashes', () => {
+      expect(toHexHash('')).toBe('');
+      expect(toHexHash('not-a-hash')).toBe('not-a-hash');
+      expect(toHexHash('deadbeef')).toBe('deadbeef');
+    });
+  });
+
+  describe('isHexHash / isBase64Hash', () => {
+    it('recognizes both encodings', () => {
+      expect(isHexHash(HEX_HASH)).toBe(true);
+      expect(isHexHash(`0x${HEX_HASH}`)).toBe(true);
+      expect(isHexHash(BASE64_HASH)).toBe(false);
+
+      expect(isBase64Hash(BASE64_HASH)).toBe(true);
+      expect(isBase64Hash(HEX_HASH)).toBe(false);
+    });
+  });
+});

--- a/packages/adena-extension/src/common/utils/hash-utils.ts
+++ b/packages/adena-extension/src/common/utils/hash-utils.ts
@@ -1,0 +1,39 @@
+import { fromBase64, toHex } from 'adena-module';
+
+const HASH_BYTE_LENGTH = 32;
+const HEX_HASH_PATTERN = /^(?:0x)?[0-9a-fA-F]{64}$/;
+const BASE64_HASH_PATTERN = /^[A-Za-z0-9+/]{43}=$/;
+
+export const isHexHash = (hash: string): boolean => HEX_HASH_PATTERN.test(hash);
+
+export const isBase64Hash = (hash: string): boolean => BASE64_HASH_PATTERN.test(hash);
+
+/**
+ * Normalize a block or transaction hash to lowercase hex without a `0x` prefix.
+ * Values that are neither a 32-byte hex nor a 32-byte base64 hash (Cosmos
+ * hashes, empty values) are returned unchanged.
+ */
+export const toHexHash = (hash: string): string => {
+  if (!hash) {
+    return hash;
+  }
+
+  if (isHexHash(hash)) {
+    return hash.replace(/^0x/, '').toLowerCase();
+  }
+
+  if (!isBase64Hash(hash)) {
+    return hash;
+  }
+
+  try {
+    const bytes = fromBase64(hash);
+    if (bytes.length !== HASH_BYTE_LENGTH) {
+      return hash;
+    }
+
+    return toHex(bytes);
+  } catch {
+    return hash;
+  }
+};

--- a/packages/adena-extension/src/hooks/use-link.ts
+++ b/packages/adena-extension/src/hooks/use-link.ts
@@ -1,5 +1,5 @@
 import { SCANNER_URL } from '@common/constants/resource.constant';
-import { normalizeGnoscanTxHash } from '@common/utils/gnoscan-url';
+import { toHexHash } from '@common/utils/hash-utils';
 import { createRegisterUrl } from '@common/utils/register-url';
 import { makeScannerUrl } from '@common/utils/scanner-utils';
 import { RoutePath, SECURITY_PATH } from '@types';
@@ -23,9 +23,9 @@ const useLink = (): UseLinkReturn => {
 
   const openScannerLink = (path: string, parameters: { [key in string]: string } = {}): void => {
     const scannerUrl = profile?.linkUrl || SCANNER_URL;
-    // Broadcast results pass a hex tx hash; the scanner expects the base64 hash.
+    // Gnoscan keys transactions by their hex hash.
     const normalizedParameters = parameters.txhash
-      ? { ...parameters, txhash: normalizeGnoscanTxHash(parameters.txhash) }
+      ? { ...parameters, txhash: toHexHash(parameters.txhash) }
       : parameters;
     const mergedParameters = scannerParameters
       ? { ...scannerParameters, ...normalizedParameters }

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-mapper.ts
@@ -1,4 +1,5 @@
 import { dateToLocal, formatAddress, getDateText } from '@common/utils/client-utils';
+import { toHexHash } from '@common/utils/hash-utils';
 import { TransactionInfo, TransactionWithPageInfo } from '@types';
 import {
   TransactionHistoryItem,
@@ -168,7 +169,7 @@ export class TransactionHistoryMapper {
     const message = historyItem.func?.[0];
 
     return {
-      hash: historyItem.txHash,
+      hash: toHexHash(historyItem.txHash),
       logo: '',
       type: 'MULTI_CONTRACT_CALL',
       status: historyItem.successYn ? 'SUCCESS' : 'FAIL',
@@ -222,7 +223,7 @@ export class TransactionHistoryMapper {
     const amount = isReceived ? historyItem.amountIn : historyItem.amountOut;
 
     return {
-      hash: historyItem.txHash,
+      hash: toHexHash(historyItem.txHash),
       logo: '',
       type: 'TRANSFER',
       typeName: functionName,
@@ -280,7 +281,7 @@ export class TransactionHistoryMapper {
     const amount = isTransfer && isReceived ? historyItem.amountIn : historyItem.amountOut;
 
     return {
-      hash: historyItem.txHash,
+      hash: toHexHash(historyItem.txHash),
       logo: '',
       type: transactionType,
       typeName: 'Contract Interaction',
@@ -316,7 +317,7 @@ export class TransactionHistoryMapper {
       valueType = 'DEFAULT';
     }
     return {
-      hash: historyItem.txHash,
+      hash: toHexHash(historyItem.txHash),
       logo: '',
       type: 'ADD_PACKAGE',
       status: historyItem.successYn ? 'SUCCESS' : 'FAIL',
@@ -348,7 +349,7 @@ export class TransactionHistoryMapper {
     const title = sessionTitleMap[messageType] ?? historyItem.func[0].funcType;
 
     return {
-      hash: historyItem.txHash,
+      hash: toHexHash(historyItem.txHash),
       logo: '',
       type: 'CONTRACT_CALL',
       status: historyItem.successYn ? 'SUCCESS' : 'FAIL',
@@ -371,7 +372,7 @@ export class TransactionHistoryMapper {
   private static mappedHistoryItemDefault(historyItem: TransactionHistoryItem): TransactionInfo {
     const valueType = historyItem.successYn ? 'DEFAULT' : 'BLUR';
     return {
-      hash: historyItem.txHash,
+      hash: toHexHash(historyItem.txHash),
       logo: '',
       type: 'CONTRACT_CALL',
       typeName: 'Contract Interaction',

--- a/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
+++ b/packages/adena-extension/src/repositories/transaction/mapper/transaction-history-query.mapper.ts
@@ -2,6 +2,7 @@ import { GNOT_TOKEN } from '@common/constants/token.constant';
 import { parseTokenAmount } from '@common/utils/amount-utils';
 import { formatAddress } from '@common/utils/client-utils';
 import { registryKeyToTokenPath } from '@common/utils/grc20-token-path';
+import { toHexHash } from '@common/utils/hash-utils';
 import { TransactionInfo } from '@types';
 import {
   AddPackageValue,
@@ -166,7 +167,7 @@ export function mapSendTransactionByBankMsgSend(
 ): TransactionInfo {
   const firstMessage = getDefaultMessage(tx.messages);
   return {
-    hash: tx.hash,
+    hash: toHexHash(tx.hash),
     height: tx.block_height,
     logo: GNOT_TOKEN.denom,
     type: tx.messages.length === 1 ? 'TRANSFER' : 'MULTI_CONTRACT_CALL',
@@ -201,7 +202,7 @@ export function mapReceivedTransactionByMsgCall(
   const firstMessage = getDefaultMessage(tx.messages);
   if (firstMessage.value.func === 'TransferFrom' && tx.messages.length === 1) {
     return {
-      hash: tx.hash,
+      hash: toHexHash(tx.hash),
       height: tx.block_height,
       logo: firstMessage.value.pkg_path || '',
       type: 'TRANSFER_GRC721',
@@ -236,7 +237,7 @@ export function mapReceivedTransactionByMsgCall(
   const denom = eventInfo?.tokenPath ?? tokenPath ?? (firstMessage.value.pkg_path || '');
 
   return {
-    hash: tx.hash,
+    hash: toHexHash(tx.hash),
     height: tx.block_height,
     logo: denom,
     type: tx.messages.length === 1 ? 'TRANSFER' : 'MULTI_CONTRACT_CALL',
@@ -267,7 +268,7 @@ export function mapReceivedTransactionByBankMsgSend(
 ): TransactionInfo {
   const firstMessage = getDefaultMessage(tx.messages);
   return {
-    hash: tx.hash,
+    hash: toHexHash(tx.hash),
     height: tx.block_height,
     logo: GNOT_TOKEN.denom,
     type: tx.messages.length === 1 ? 'TRANSFER' : 'MULTI_CONTRACT_CALL',
@@ -305,7 +306,7 @@ export function mapVMTransaction(
     const isAddPackage = isAddPackageValue(firstMessage.value);
     const messageValue: any = firstMessage.value;
     return {
-      hash: tx.hash,
+      hash: toHexHash(tx.hash),
       height: tx.block_height,
       logo: '',
       type: 'MULTI_CONTRACT_CALL',
@@ -332,7 +333,7 @@ export function mapVMTransaction(
 
   if (firstMessage.value === 'MsgAddPackage') {
     return {
-      hash: tx.hash,
+      hash: toHexHash(tx.hash),
       height: tx.block_height,
       logo: '',
       type: 'ADD_PACKAGE',
@@ -369,7 +370,7 @@ export function mapVMTransaction(
       const denom = eventInfo?.tokenPath ?? tokenPath ?? (messageValue.pkg_path || '');
 
       return {
-        hash: tx.hash,
+        hash: toHexHash(tx.hash),
         height: tx.block_height,
         logo: denom,
         type: 'TRANSFER',
@@ -399,7 +400,7 @@ export function mapVMTransaction(
       const toAddress = messageValue.args?.[1] || '';
 
       return {
-        hash: tx.hash,
+        hash: toHexHash(tx.hash),
         height: tx.block_height,
         logo: firstMessage.value.pkg_path || '',
         type: 'TRANSFER_GRC721',
@@ -425,7 +426,7 @@ export function mapVMTransaction(
     }
 
     return {
-      hash: tx.hash,
+      hash: toHexHash(tx.hash),
       height: tx.block_height,
       logo: '',
       type: 'CONTRACT_CALL',
@@ -459,7 +460,7 @@ export function mapVMTransaction(
       !!viewerAddress && runTransfer.to === viewerAddress && runTransfer.from !== viewerAddress;
 
     return {
-      hash: tx.hash,
+      hash: toHexHash(tx.hash),
       height: tx.block_height,
       logo: runTransfer.tokenPath,
       type: 'TRANSFER',
@@ -487,7 +488,7 @@ export function mapVMTransaction(
   }
 
   return {
-    hash: tx.hash,
+    hash: toHexHash(tx.hash),
     height: tx.block_height,
     logo: '',
     type: 'CONTRACT_CALL',

--- a/packages/adena-extension/src/repositories/transaction/response/transaction-history-query-response.ts
+++ b/packages/adena-extension/src/repositories/transaction/response/transaction-history-query-response.ts
@@ -1,6 +1,7 @@
 export interface TransactionResponse<
   T = MsgCallValue | MsgRunValue | AddPackageValue | BankSendValue,
 > {
+  // The tm2 GraphQL indexer returns the tx hash base64-encoded.
   hash: string;
   index: number;
   success: boolean;

--- a/packages/adena-extension/src/repositories/transaction/response/transaction-history-response.ts
+++ b/packages/adena-extension/src/repositories/transaction/response/transaction-history-response.ts
@@ -43,5 +43,6 @@ export interface TransactionHistoryItem {
   callerAddress?: string;
   // Session account that signed the tx, or "" for a master-key signature.
   sessionAddress?: string;
+  // Hex-encoded since onbloc-api-v3#213; older deployments still answer base64.
   txHash: string;
 }

--- a/packages/adena-extension/src/services/transaction/transaction.ts
+++ b/packages/adena-extension/src/services/transaction/transaction.ts
@@ -557,14 +557,14 @@ export class TransactionService {
   };
 
   /**
-   * create a transaction hash
+   * create a hex-encoded transaction hash
    *
    * @param transaction
    * @returns
    */
   public createHash(transaction: Tx): string {
     const hash = sha256(encodeGnoTx(transaction));
-    return Buffer.from(hash).toString('base64');
+    return Buffer.from(hash).toString('hex');
   }
 
   /**


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does:

Which makes hex the canonical encoding for block and transaction hashes:

- list responses return hex only
- detail responses carry hex plus a `*Base64` companion field
- `txHash` path params and `/v1/search?param=` accept hex **or** base64

The wallet previously mixed encodings: history came in as base64, `createHash` produced base64, and Gnoscan links converted hex *back* to base64. This normalizes everything to hex.

#### Normalize at the boundaries

Hashes are converted to hex where they enter the wallet, via a new `toHexHash()` helper (`common/utils/hash-utils.ts`). It accepts 32-byte hex or base64 and returns lowercase hex without a `0x` prefix; anything else (Cosmos hashes, empty values) passes through unchanged.

| Boundary | Before | After |
| --- | --- | --- |
| `GnoProvider.sendTransaction` / `sendTransactionSync` — RPC broadcast result | base64 | hex |
| `TransactionService.createHash` | base64 | hex |
| `transaction-history-mapper` (onbloc API v3) | as-is | normalized |
| `transaction-history-query.mapper` (tm2 GraphQL indexer) | base64 | hex |

The API mapper normalizes even though the API already returns hex, so a deployment still on the previous response shape keeps working during rollout.

#### Consumers

- `useLink.openScannerLink` no longer converts hex to base64; it passes hex straight through. `normalizeGnoscanTxHash()` is removed.
- `TransactionEventStore` keys its RPC `/tx?hash=` lookup off the same hash, so `makeHexByBase64` became `makeRpcHashParam` (still emits `0x`-prefixed hex, now accepting either input encoding).

Display, copy, Gnoscan links, notifications, dapp responses, and history dedup keys now all agree on hex. As a side effect, dedup across the API and indexer sources no longer misses duplicates caused by differing encodings.

#### Reviewer note — dapp-facing change

The `hash` in the `DoContract` response returned to dapps is now hex instead of base64. This is intentional (Adena's own responses should use the canonical encoding), but it is a behavior change for `@adena-wallet/sdk` consumers. The API accepts both encodings, so lookups keep working; dapps that string-compare or link with the raw value would see the difference. Worth a note in the SDK release notes.

### Testing

- `tsc --noEmit` clean
- `jest --ci`: 208 suites / 927 tests passing, including a new `hash-utils.spec.ts`
- `eslint` on changed files: no new errors